### PR TITLE
refactor: useMediaQueryをuseSyncExternalStoreで実装

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -4,7 +4,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 /**
  * メディアクエリの一致状態を管理する
@@ -29,33 +29,30 @@ import { useEffect, useState } from 'react';
  * ```
  */
 export function useMediaQuery(query: string): boolean {
-  // サーバーサイドレンダリング対応
-  const [matches, setMatches] = useState<boolean>(false);
-
-  useEffect(() => {
+  const subscribe = (callback: () => void) => {
     if (typeof window === 'undefined') {
-      return;
+      return () => {};
     }
 
     const mediaQueryList = window.matchMedia(query);
+    mediaQueryList.addEventListener('change', callback);
 
-    // 初期値を設定
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMatches(mediaQueryList.matches);
-
-    // メディアクエリの変化を監視
-    const handleChange = (event: MediaQueryListEvent) => {
-      setMatches(event.matches);
-    };
-
-    // リスナーを追加
-    mediaQueryList.addEventListener('change', handleChange);
-
-    // クリーンアップ
     return () => {
-      mediaQueryList.removeEventListener('change', handleChange);
+      mediaQueryList.removeEventListener('change', callback);
     };
-  }, [query]);
+  };
 
-  return matches;
+  const getSnapshot = () => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.matchMedia(query).matches;
+  };
+
+  const getServerSnapshot = () => {
+    return false;
+  };
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## 概要

`useMediaQuery`を`useSyncExternalStore`を使った実装に変更し、ESLint無効化コメントを削除しました。

## 問題点

以前の実装では：
- `useEffect`内で`setState`を同期的に呼び出していた
- カスケードレンダリングのリスクがあった
- ESLintルール `react-hooks/set-state-in-effect` を無効化していた

## 解決策

React 18の`useSyncExternalStore`を使用：

```typescript
const subscribe = (callback: () => void) => {
  const mediaQueryList = window.matchMedia(query);
  mediaQueryList.addEventListener('change', callback);
  return () => mediaQueryList.removeEventListener('change', callback);
};

const getSnapshot = () => window.matchMedia(query).matches;
const getServerSnapshot = () => false;

return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
```

## 利点

✅ **React推奨パターン**: `useSyncExternalStore`は外部ストアとの同期に最適
✅ **パフォーマンス**: カスケードレンダリングを回避
✅ **SSR対応**: `getServerSnapshot`で明確に制御
✅ **ESLint準拠**: 無効化コメント不要
✅ **コードの簡潔性**: useEffectとuseStateが不要に

## 参考

- [React 18: useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)
- [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)