### PR TITLE
usersテーブルにroleカラム追加と管理者Seeder作成

### DIFF
--- a/.claude/documents/database-schema.md
+++ b/.claude/documents/database-schema.md
@@ -20,6 +20,7 @@
 | password_hash | VARCHAR(255) | NOT NULL | - | ハッシュ化されたパスワード |
 | name | VARCHAR(100) | NULL | - | ユーザー名 |
 | avatar_url | TEXT | NULL | - | アバター画像URL |
+| role | VARCHAR(20) | NOT NULL | 'user' | ユーザー権限（user / admin） |
 | is_verified | BOOLEAN | NOT NULL | false | メール認証済みフラグ |
 | created_at | TIMESTAMP | NOT NULL | now() | 作成日時 |
 | updated_at | TIMESTAMP | NOT NULL | now() | 更新日時 |

--- a/.claude/documents/roadmap.md
+++ b/.claude/documents/roadmap.md
@@ -151,6 +151,13 @@
   - 再発行は5分間隔
 - [ ] axiosインスタンスでAPI呼び出し
 
+### 管理者ユーザー
+- [x] usersテーブルにroleカラム追加（デフォルト: 'user'、管理者: 'admin'）
+- [x] 管理者Seeder作成
+  - メール認証不要（OTPスキップ、is_verified = true で挿入）
+  - role = 'admin' で挿入
+  - Supabase SQLまたはスクリプトで管理者ユーザーを追加
+
 ### ログイン・セッション管理（NextAuth.js）
 - [ ] ログインフォームUI実装（react-hook-form + zod）
 - [ ] NextAuth.js signIn()統合

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -80,6 +80,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           email: user.email,
           name: user.name,
           image: user.avatar_url,
+          role: user.role,
         };
       },
     }),
@@ -103,6 +104,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.email = user.email;
         token.name = user.name;
         token.picture = user.image;
+        token.role = user.role;
       }
       return token;
     },
@@ -114,6 +116,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.email = token.email as string;
         session.user.name = token.name as string | null;
         session.user.image = token.picture as string | null;
+        session.user.role = token.role as string;
       }
       return session;
     },

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -132,6 +132,8 @@ export interface User {
   name: string | null;
   /** アバター画像URL */
   image: string | null;
+  /** ユーザー権限 */
+  role: 'user' | 'admin';
   /** 作成日時 */
   created_at: string;
   /** 更新日時 */

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module 'next-auth' {
       email: string;
       name: string | null;
       image: string | null;
+      role: string;
     };
   }
 
@@ -20,6 +21,7 @@ declare module 'next-auth' {
     email: string;
     name: string | null;
     image: string | null;
+    role: string;
   }
 }
 
@@ -29,5 +31,6 @@ declare module 'next-auth/jwt' {
     email: string;
     name: string | null;
     picture: string | null;
+    role: string;
   }
 }

--- a/supabase/migrations/20260208000000_add_user_role.sql
+++ b/supabase/migrations/20260208000000_add_user_role.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- usersテーブルにroleカラムを追加
+-- ============================================
+
+ALTER TABLE users
+  ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'user';
+
+-- roleカラムのバリデーション
+ALTER TABLE users
+  ADD CONSTRAINT chk_user_role CHECK (role IN ('user', 'admin'));
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);

--- a/supabase/seeds/admin_user.sql
+++ b/supabase/seeds/admin_user.sql
@@ -1,0 +1,29 @@
+-- ============================================
+-- 管理者ユーザーSeeder
+-- ============================================
+-- メール認証不要（is_verified = true）
+-- role = 'admin' で挿入
+--
+-- 使い方:
+--   1. 下記のメールアドレスとパスワードハッシュを環境に合わせて変更
+--   2. Supabase SQL Editorで実行
+--
+-- パスワードハッシュの生成方法:
+--   node -e "const bcrypt = require('bcryptjs'); bcrypt.hash('your-password', 12).then(h => console.log(h));"
+-- ============================================
+
+INSERT INTO users (email, password_hash, name, role, is_verified, created_at, updated_at)
+VALUES (
+  'admin@example.com',
+  -- デフォルトパスワード: 'Admin1234'（必ず変更してください）
+  '$2b$12$/U3RRTxAaDW.vYoGK3EMO.rl2cLr.3d314RKTVSPZGQ/f4jgy.y3u',
+  '管理者',
+  'admin',
+  true,
+  now(),
+  now()
+)
+ON CONFLICT (email) DO UPDATE SET
+  role = 'admin',
+  is_verified = true,
+  updated_at = now();


### PR DESCRIPTION
## 概要
usersテーブルにroleカラム（user/admin）を追加し、管理者ユーザーをSeederで投入できるようにした。
NextAuth.jsの型定義・コールバックにもroleを反映し、セッションからroleを参照可能にした。

## ロードマップ
- [x] usersテーブルにroleカラム追加（デフォルト: 'user'、管理者: 'admin'）
- [x] 管理者Seeder作成（メール認証不要、role='admin'）

## レビューポイント
- マイグレーション: `CHECK (role IN ('user', 'admin'))` でバリデーション
- Seeder: `ON CONFLICT (email) DO UPDATE` で冪等性を確保
- Seederのデフォルトパスワード（Admin1234）は本番では必ず変更が必要
- NextAuth.js: authorize → JWT callback → session callbackの3箇所でroleを伝搬

## テスト
- ビルド成功確認済み
- ESLint / Prettier パス