### PR TITLE
セッション期限切れ時の自動ログアウト機能を追加

### DIFF
--- a/src/components/providers/sessionExpiryHandler.test.tsx
+++ b/src/components/providers/sessionExpiryHandler.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * SessionExpiryHandlerのテスト
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useSessionExpiry } from './sessionExpiryHandler';
+
+// next-auth/reactのモック
+const mockSignOut = jest.fn();
+let mockStatus = 'loading';
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ status: mockStatus }),
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
+jest.mock('@/constants', () => ({
+  ROUTES: { LOGIN: '/auth/signin' },
+}));
+
+describe('useSessionExpiry', () => {
+  beforeEach(() => {
+    mockSignOut.mockClear();
+    mockStatus = 'loading';
+  });
+
+  it('初回レンダリング時にsignOutを呼ばないこと', () => {
+    mockStatus = 'unauthenticated';
+    renderHook(() => useSessionExpiry());
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('authenticated → unauthenticated に変化した時にsignOutを呼ぶこと', () => {
+    mockStatus = 'authenticated';
+    const { rerender } = renderHook(() => useSessionExpiry());
+
+    mockStatus = 'unauthenticated';
+    rerender();
+
+    expect(mockSignOut).toHaveBeenCalledWith({
+      callbackUrl: '/auth/signin',
+    });
+  });
+
+  it('loading → authenticated に変化した時にsignOutを呼ばないこと', () => {
+    mockStatus = 'loading';
+    const { rerender } = renderHook(() => useSessionExpiry());
+
+    mockStatus = 'authenticated';
+    rerender();
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('loading → unauthenticated に変化した時にsignOutを呼ばないこと', () => {
+    mockStatus = 'loading';
+    const { rerender } = renderHook(() => useSessionExpiry());
+
+    mockStatus = 'unauthenticated';
+    rerender();
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('authenticated のまま変化しない場合にsignOutを呼ばないこと', () => {
+    mockStatus = 'authenticated';
+    const { rerender } = renderHook(() => useSessionExpiry());
+
+    rerender();
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('signOutは1回だけ呼ばれること', () => {
+    mockStatus = 'authenticated';
+    const { rerender } = renderHook(() => useSessionExpiry());
+
+    mockStatus = 'unauthenticated';
+    rerender();
+    rerender();
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/providers/sessionExpiryHandler.tsx
+++ b/src/components/providers/sessionExpiryHandler.tsx
@@ -1,0 +1,37 @@
+/**
+ * セッション期限切れ検知コンポーネント
+ *
+ * authenticated → unauthenticated に変化した場合、自動的にログアウトしてログインページへリダイレクトする。
+ */
+
+'use client';
+
+import { memo, useEffect, useRef } from 'react';
+import { signOut, useSession } from 'next-auth/react';
+
+import { ROUTES } from '@/constants';
+
+/**
+ * セッション期限切れを検知してログアウトするフック
+ */
+export function useSessionExpiry() {
+  const { status } = useSession();
+  const prevStatusRef = useRef(status);
+
+  useEffect(() => {
+    if (
+      prevStatusRef.current === 'authenticated' &&
+      status === 'unauthenticated'
+    ) {
+      signOut({ callbackUrl: ROUTES.LOGIN });
+    }
+    prevStatusRef.current = status;
+  }, [status]);
+}
+
+export const SessionExpiryHandler = memo(function SessionExpiryHandler() {
+  useSessionExpiry();
+  return null;
+});
+
+SessionExpiryHandler.displayName = 'SessionExpiryHandler';

--- a/src/components/providers/sessionProvider.tsx
+++ b/src/components/providers/sessionProvider.tsx
@@ -7,6 +7,8 @@
 import { memo, type ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';
 
+import { SessionExpiryHandler } from './sessionExpiryHandler';
+
 interface AppSessionProviderProps {
   children: ReactNode;
 }
@@ -14,7 +16,12 @@ interface AppSessionProviderProps {
 export const AppSessionProvider = memo(function AppSessionProvider({
   children,
 }: AppSessionProviderProps) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <SessionExpiryHandler />
+      {children}
+    </SessionProvider>
+  );
 });
 
 AppSessionProvider.displayName = 'AppSessionProvider';


### PR DESCRIPTION
## 概要
- セッション（JWT）が期限切れになった際に、自動的にログアウトしてログインページへリダイレクトする機能を追加
- これまではセッション切れ後もUIがログイン状態のまま表示され続け、ユーザーに通知されなかった

## 変更内容
- `useSessionExpiry`フック + `SessionExpiryHandler`コンポーネントを新規作成
- `useSession()`の`status`が`authenticated` → `unauthenticated`に変化した場合のみ`signOut()`を実行
- 初回ロード時の未ログイン状態（`loading` → `unauthenticated`）ではログアウト処理を実行しない
- `AppSessionProvider`内に組み込み、全ページで有効

## テスト
- 6テストケース作成済み（全パス）
- 全290テスト通過
- 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)