### PR TITLE
header・footerのmax-widthを削除

### DIFF
--- a/src/components/layout/footer/footer.module.scss
+++ b/src/components/layout/footer/footer.module.scss
@@ -13,8 +13,6 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: $spacing-4;
-    max-width: 1440px;
-    margin: 0 auto;
     padding: $spacing-6;
   }
 

--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -14,8 +14,6 @@
     display: flex;
     align-items: center;
     gap: $spacing-6;
-    max-width: 1440px;
-    margin: 0 auto;
     padding: $spacing-4 $spacing-6;
   }
 


### PR DESCRIPTION
## 概要
- header・footerコンテナの`max-width: 1440px`と`margin: 0 auto`を削除

## テスト
- ブラウザで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)