### PR TITLE
ウォッチリスト機能の設計見直しとロードマップ整理

### DIFF
--- a/.claude/documents/api-specification.md
+++ b/.claude/documents/api-specification.md
@@ -315,9 +315,17 @@
 ## ウォッチリストAPI
 
 ### GET /api/watchlist
-ユーザーのウォッチリスト取得
+ユーザーのウォッチリスト取得（カーソルベースページング）
 
 **認証**: 必須
+
+**ページング方式**: カーソルベース（added_at基準）
+- ウォッチリストは追加・削除が頻繁に発生するため、オフセットベースだとページずれが起きる
+- added_at（降順）をカーソルとして使用し、安定したページングを実現
+
+**Query Parameters:**
+- `cursor` (optional): カーソル値（前回レスポンスのnext_cursor、ISO 8601形式）
+- `limit` (optional): 取得件数（デフォルト: 20、最大: 50）
 
 **Response (200 OK):**
 ```json
@@ -328,18 +336,21 @@
       {
         "id": "watchlist-uuid",
         "tmdb_movie_id": 12345,
-        "added_at": "2025-01-29T10:00:00Z",
-        "movie": {
-          "id": 12345,
-          "title": "映画タイトル",
-          "poster_path": "/path/to/poster.jpg",
-          "release_date": "2025-01-29"
-        }
+        "title": "映画タイトル",
+        "poster_path": "/path/to/poster.jpg",
+        "release_date": "2025-01-29",
+        "added_at": "2025-01-29T10:00:00Z"
       }
-    ]
+    ],
+    "next_cursor": "2025-01-28T15:00:00Z",
+    "has_more": true
   }
 }
 ```
+
+**備考:**
+- `next_cursor` が `null` の場合、次ページなし（`has_more: false`）
+- レスポンスは `added_at` 降順（新しい順）で固定
 
 ---
 
@@ -351,9 +362,18 @@
 **Request Body:**
 ```json
 {
-  "tmdb_movie_id": 12345
+  "tmdb_movie_id": 12345,
+  "title": "映画タイトル",
+  "poster_path": "/path/to/poster.jpg",
+  "release_date": "2025-01-29"
 }
 ```
+
+**Validation (zod):**
+- `tmdb_movie_id`: 正の整数、必須
+- `title`: 文字列、必須
+- `poster_path`: 文字列、任意
+- `release_date`: 文字列（日付形式）、任意
 
 **Response (201 Created):**
 ```json
@@ -363,12 +383,16 @@
   "data": {
     "id": "watchlist-uuid",
     "tmdb_movie_id": 12345,
+    "title": "映画タイトル",
+    "poster_path": "/path/to/poster.jpg",
+    "release_date": "2025-01-29",
     "added_at": "2025-01-29T10:00:00Z"
   }
 }
 ```
 
 **Error Responses:**
+- `400 Bad Request`: バリデーションエラー
 - `401 Unauthorized`: 認証が必要
 - `409 Conflict`: すでにウォッチリストに追加済み
 

--- a/.claude/documents/database-schema.md
+++ b/.claude/documents/database-schema.md
@@ -54,9 +54,9 @@
 | notes | TEXT | NULL | - | メモ（将来的に使用） |
 
 **インデックス:**
-- `user_id, tmdb_movie_id` (UNIQUE) - 重複登録防止
+- `user_id, tmdb_movie_id` (UNIQUE, WHERE deleted_at IS NULL) - 重複登録防止（論理削除済みは対象外、再追加可能）
 - `user_id` - ユーザー検索の高速化
-- `added_at` - 追加日順ソート用
+- `added_at` - 追加日順ソート用（カーソルベースページングのカーソル）
 - `deleted_at` - 論理削除フィルタ用
 
 **外部キー:**

--- a/.claude/documents/roadmap.md
+++ b/.claude/documents/roadmap.md
@@ -398,16 +398,87 @@
   - 通知設定
   - テーマ切り替え
 
-### ウォッチリスト一覧
-- [ ] WatchlistItemコンポーネント実装
-- [ ] ウォッチリスト一覧取得API実装（`/api/watchlist`）
+### ウォッチリスト機能
+
+#### Step 1: DB確認・API・フック基盤（`feature/watchlist-api`）
+- [ ] watchlistテーブルの既存migration確認（RLS・インデックス・UNIQUE制約のWHERE deleted_at IS NULL対応）
+- [ ] ウォッチリスト一覧取得API（GET /api/watchlist）
   - NextAuth.jsで認証チェック
-  - axiosでクライアント側リクエスト
-- [ ] リアルタイム更新実装
+  - カーソルベースページング（無限スクロール用、20件ずつ）
+  - ソート: 追加日順（新しい順）
+- [ ] ウォッチリスト追加API（POST /api/watchlist）
+  - NextAuth.jsで認証チェック
+  - 重複チェック（409 Conflict）
+- [ ] ウォッチリスト削除API（DELETE /api/watchlist/:id）
+  - NextAuth.jsで認証チェック
+  - 論理削除（deleted_at更新）
+- [ ] zodバリデーションスキーマ作成
+- [ ] APIクライアント（src/lib/api/watchlist.ts）作成
+- [ ] useWatchlistフック作成（TanStack Query）
+  - useInfiniteQuery（サイドバー一覧用、20件ずつ）
+  - useMutation（追加・削除、楽観的UI更新）
+  - ウォッチリスト状態チェック（キャッシュから判定）
+- [ ] テストを追加
+  - API Routeテスト（/api/watchlist）
+    - GET: 認証チェック・ページング・ソート・deleted_atフィルタ
+    - POST: 認証チェック・正常追加・重複409・バリデーションエラー
+    - DELETE: 認証チェック・正常削除・404（存在しない/他ユーザー/削除済み）
+  - zodスキーマテスト（watchlistAddSchema等）
+  - APIクライアントテスト（getWatchlist・addWatchlist・removeWatchlist）
+  - useWatchlistフックテスト
+    - 一覧取得（useInfiniteQuery）・次ページ読み込み
+    - 追加mutation・楽観的更新・エラー時ロールバック
+    - 削除mutation・楽観的更新・エラー時ロールバック
+    - ウォッチリスト状態チェック（isInWatchlist）
+
+#### Step 2: サイドバーウォッチリスト表示（`feature/watchlist-sidebar`）
+- [ ] MovieDetailModalを共通UIコンポーネントに移動（features/movies/component/ → components/ui/movie/detailModal/）
+  - 現在movieListContentからのみ使用されているが、WatchlistPanel・お気に入り等からも使うため共通化
+  - 既存のimportパスを更新
+- [ ] WatchlistItemコンポーネント作成（小ポスター + タイトル + 削除ボタン、クリックで映画詳細モーダル表示）
+- [ ] WatchlistPanelコンポーネント作成（サイドバー内、高さ300px、スクロール + 無限読み込み + MovieDetailModal統合）
+- [ ] 既存Sidebarのwatchlist propにWatchlistPanelを渡して統合（スロット・見出しは実装済み）
+- [ ] 空状態の表示（「ウォッチリストに映画を追加しましょう」）
+- [ ] テストを追加
+  - WatchlistItemテスト
+    - レンダリング（ポスター・タイトル・削除ボタン表示）
+    - アイテムクリック時にonClick（映画詳細モーダル表示用）コールバック
+    - 削除ボタンクリック時のコールバック（onClickを発火しない、stopPropagation）
+    - ポスター画像なし時のフォールバック表示
+    - aria属性の確認
+  - WatchlistPanelテスト
+    - 一覧表示（複数件）
+    - 空状態メッセージ表示
+    - ローディング状態表示
+    - スクロール時の追加読み込みトリガー（Intersection Observer）
+
+#### Step 3: MovieTileウォッチリスト統合（`feature/watchlist-tile`）
+- [ ] WatchlistAddButtonコンポーネント作成（プラスアイコン / チェックアイコン切替）
+- [ ] MovieTileにWatchlistAddButton統合（ポスター上にオーバーレイ表示）
+  - event.stopPropagation()で詳細モーダルと干渉しない
+- [ ] 映画詳細モーダル内にもウォッチリスト追加/削除ボタン配置
+- [ ] 楽観的UI更新（追加/削除時に即座にUI反映、失敗時にロールバック）
+- [ ] Toast通知（「ウォッチリストに追加しました」「ウォッチリストから削除しました」）
+- [ ] テストを追加
+  - WatchlistAddButtonテスト
+    - 未追加時: プラスアイコン表示・クリックで追加コールバック
+    - 追加済み時: チェックアイコン表示・クリックで削除コールバック
+    - event.stopPropagation()が呼ばれることの確認
+    - aria-label切替（「ウォッチリストに追加」/「ウォッチリストから削除」）
+  - MovieTile統合テスト
+    - WatchlistAddButtonがポスター上に表示される
+    - ボタンクリックがMovieTileのonClickを発火しない
+  - 映画詳細モーダル統合テスト
+    - ウォッチリスト追加/削除ボタンの表示・動作
+  - E2Eテスト（Playwright）
+    - MovieTileからウォッチリスト追加 → サイドバーに反映
+    - サイドバーから削除 → MovieTileのアイコンが戻る
+    - 詳細モーダルからウォッチリスト追加/削除
+    - Toast通知の表示確認
 
 ### お気に入り機能（設計書: `.claude/documents/favorites-design.md`）
 
-#### Step 1: DB・API基盤（`feature/favorites-api`）
+#### Step 4: DB・API基盤（`feature/favorites-api`）
 - [ ] favoritesテーブル作成（Supabase migration）
   - UUID主キー、論理削除、RLSポリシー設定
   - UNIQUE制約（user_id, tmdb_movie_id WHERE deleted_at IS NULL）
@@ -419,7 +490,7 @@
 - [ ] APIクライアント（src/lib/api/favorites.ts）作成
 - [ ] テストを追加
 
-#### Step 2: お気に入りUI（`feature/favorites-ui`）
+#### Step 5: お気に入りUI（`feature/favorites-ui`）
 - [ ] FavoriteButtonコンポーネント作成（ハートアイコン）
 - [ ] RatingIndicatorコンポーネント作成（1〜10点、数値インジケーター）
 - [ ] FavoriteRatingModalコンポーネント作成（点数入力モーダル）
@@ -427,24 +498,13 @@
 - [ ] useFavoritesフック作成（TanStack Query）
 - [ ] テストを追加
 
-#### Step 3: お気に入り一覧ページ（`feature/favorites-page`）
+#### Step 6: お気に入り一覧ページ（`feature/favorites-page`）
 - [ ] ROUTES定数にFAVORITES追加
 - [ ] SideNavに「お気に入り」項目追加
 - [ ] /favorites ページ作成
 - [ ] FavoriteListコンポーネント作成（グリッド表示 + 評価表示）
 - [ ] ソート機能（登録日順 / 評価順）
 - [ ] テストを追加
-
-### ウォッチリスト追加・削除
-- [ ] ウォッチリスト追加UI実装
-- [ ] ウォッチリスト追加API実装（`POST /api/watchlist`）
-  - NextAuth.jsで認証チェック
-  - axiosでクライアント側リクエスト
-- [ ] ウォッチリスト削除API実装（`DELETE /api/watchlist/:id`）
-  - NextAuth.jsで認証チェック
-  - axiosでクライアント側リクエスト
-- [ ] 楽観的UI更新
-- [ ] エラーハンドリング（axios error handling）
 
 ---
 


### PR DESCRIPTION
## 概要
ウォッチリスト機能のロードマップを見直し、Step分けによる段階的な実装計画に再構成しました。
併せてAPI仕様書・DBスキーマの不整合を修正しています。

## ロードマップ
- ウォッチリスト一覧・追加・削除のタスクをStep 1〜3に再構成
- お気に入り機能のStep番号を4〜6に変更（通し番号）

## レビューポイント
### ロードマップ変更点
- **Step 1（API基盤）**: カーソルベースページング採用（追加・削除によるオフセットずれ対策）、TanStack QueryベースのuseWatchlistフック
- **Step 2（サイドバー表示）**: 専用ページは作らず、サイドバー内300pxスクロール+無限読み込みで表示。MovieDetailModalの共通化（→ `components/ui/movie/detailModal/`）を含む
- **Step 3（MovieTile統合）**: プラスアイコンによるウォッチリスト追加、楽観的UI更新、E2Eテスト
- リアルタイム更新を削除（Supabase Realtime未使用の方針に統一）

### API仕様書変更点
- GET /api/watchlist: カーソルベースページング（cursor/limit/next_cursor/has_more）追加
- POST /api/watchlist: title, poster_path, release_dateをリクエストボディに追加、zodバリデーション記載

### DBスキーマ変更点
- watchlistのUNIQUE制約に `WHERE deleted_at IS NULL` 追加（論理削除済み映画の再追加を可能に）

## テスト
設計ドキュメントの変更のみのため、テスト実行は不要です。