### PR TITLE
fix: 映画一覧の無限スクロールで重複キーエラーを修正

### DIFF
--- a/src/app/api/movies/route.ts
+++ b/src/app/api/movies/route.ts
@@ -286,6 +286,7 @@ export async function GET(request: Request) {
       .select('*')
       .eq('release_type', release_type)
       .order(sortColumn, { ascending, nullsFirst: false })
+      .order('id', { ascending: true })
       .range(offset, offset + PAGINATION.ITEMS_PER_PAGE - 1);
 
     if (isNowPlayingTheatrical) {

--- a/src/features/movies/hooks/useMovieList.ts
+++ b/src/features/movies/hooks/useMovieList.ts
@@ -318,11 +318,17 @@ export function useMovieList(options: UseMovieListOptions): UseMovieListReturn {
     setIsFilterModalOpen(false);
   }, []);
 
-  // 全ページの映画を結合
-  const movies = useMemo(
-    () => moviesQuery.data?.pages.flatMap((page) => page.data.movies) ?? [],
-    [moviesQuery.data],
-  );
+  // 全ページの映画を結合（ページ間の重複を除去）
+  const movies = useMemo(() => {
+    const allMovies =
+      moviesQuery.data?.pages.flatMap((page) => page.data.movies) ?? [];
+    const seen = new Set<number>();
+    return allMovies.filter((movie) => {
+      if (seen.has(movie.id)) return false;
+      seen.add(movie.id);
+      return true;
+    });
+  }, [moviesQuery.data]);
 
   const genres = useMemo(
     () => moviesQuery.data?.pages[0]?.data.genres ?? {},


### PR DESCRIPTION
## 概要
映画一覧の無限スクロール読み込み中に上スクロールすると `Encountered two children with the same key` エラーが発生する問題を修正。

ソートカラム（popularity, release_dateなど）に同じ値を持つ行がある場合、DBのOFFSET/LIMITページネーションで行の順序が不安定になり、ページ間で同じ映画が重複して返されることが原因。

## 修正内容
- **API（route.ts）**: データクエリにセカンダリソート `.order('id')` を追加し、ページネーションの順序を安定化
- **フロント（useMovieList.ts）**: ページ結合時に `movie.id` の重複を除去する防御的対策を追加

## レビューポイント
- セカンダリソートの追加がパフォーマンスに影響しないか（idは主キーなのでインデックス済み）

## テスト
- 無限スクロール時のコンソールエラーが解消されることを確認