### PR TITLE
fix: SP表示で検索アイコンを右寄せに配置

### DIFF
--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -56,8 +56,11 @@
   // 検索バー
   &__search {
     margin-left: auto;
-    width: 100%;
-    max-width: 400px;
+
+    @include lg {
+      width: 100%;
+      max-width: 400px;
+    }
   }
 
   // ユーザーメニュー（lg未満で非表示 → MobileDrawer内に移動）


### PR DESCRIPTION
## 概要
- SP表示でヘッダーの検索アイコンが右寄せになるよう修正
- `__search`の`width: 100%`をlg以上に限定し、SPでは`margin-left: auto`で右端に配置

## ロードマップ
- バグ修正のため該当なし

## レビューポイント
- SP幅で検索アイコンがヘッダー右端に配置されるか
- lg以上で検索バーの幅が従来通り維持されるか

## テスト
- SCSS変更のみのため既存テストに影響なし