### PR TITLE
fix: モーダルオーバーレイのz-indexクリック干渉修正

### DIFF
--- a/src/components/ui/modal/modal.module.scss
+++ b/src/components/ui/modal/modal.module.scss
@@ -23,7 +23,7 @@
     background-color: $background-paper;
     border-radius: $border-radius-lg;
     box-shadow: $shadow-xl;
-    z-index: $z-index-modal + 1;
+    z-index: calc($z-index-modal + 1);
     overflow: hidden;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## 概要
- CSS変数移行後、`$z-index-modal + 1` がCSS `var()` 値に対して正しく算術計算されず、モーダルコンテンツとオーバーレイが同じz-indexになっていた
- `calc($z-index-modal + 1)` に修正し、コンテンツがオーバーレイより上に配置されるようにした

## ロードマップ
- N/A（バグ修正）

## レビューポイント
- `modal.module.scss` L26: `calc()` でラップすることで `var(--z-index-modal)` に対する算術が正しく動作する

## テスト
- ビルド成功確認済み
- E2Eで再現していたモーダル閉じるボタンのクリック干渉が解消される想定