### PR TITLE
docs: トレンド映画表示フェーズをロードマップに追加

### DIFF
--- a/.claude/documents/roadmap.md
+++ b/.claude/documents/roadmap.md
@@ -965,6 +965,7 @@
   - UNIQUE制約（tmdb_movie_id）
   - RLSポリシー設定（SELECT: 全ユーザー、INSERT/UPDATE/DELETE: service_roleのみ）
   - インデックス（display_order）
+- [ ] Supabase CLIでマイグレーション実行（`supabase migration new` → `supabase db push`）
 - [ ] トレンド映画用の型定義作成（`lib/types/trending.ts`）
   - TMDb Trending APIレスポンス型
   - DBレコード型


### PR DESCRIPTION
## 概要
- ロードマップにフェーズ8「トレンド映画表示」を追加
- TMDb Trending API（`GET /trending/movie/week`）で今週のトレンド映画10件を週次CronでDB保存し、ホームページに横スクロールで表示する機能の計画
- 既存フェーズ8以降を連番繰り下げ（8→9、9→10、10→11、11→12、8.5→9.5）

## ロードマップ
- フェーズ8: トレンド映画表示（Step 1〜5）を新規追加
  - Step 1: DB・型定義・定数（`trending_movies`テーブル作成）
  - Step 2: TMDb API取得ロジック + Cron API（週次 `0 20 * * 0`）
  - Step 3: カスタムフック
  - Step 4: UIコンポーネント（横スクロール10件）
  - Step 5: ホームページ統合

## レビューポイント
- フェーズ8のStep分割の粒度が適切か
- Cron + DB保存方式の設計が妥当か
- 既存フェーズの番号繰り下げに漏れがないか

## テスト
- ドキュメントのみの変更のためテスト不要