### PR TITLE
feat: トレンド映画機能 Step 3 — カスタムフック・API取得関数

### DIFF
--- a/.claude/documents/roadmap.md
+++ b/.claude/documents/roadmap.md
@@ -987,10 +987,10 @@
 - [x] 単体テスト
 
 ### Step 3: カスタムフック（`feature/trending-movies-hook`）
-- [ ] `useTrendingMovies`フック作成
+- [x] `useTrendingMovies`フック作成
   - React QueryでDBからトレンド映画データ取得
   - ローディング・エラー状態管理
-- [ ] 単体テスト
+- [x] 単体テスト
 
 ### Step 4: UIコンポーネント（`feature/trending-movies-ui`）
 - [ ] `TrendingMovieCard`コンポーネント作成

--- a/src/features/trending/hooks/useTrendingMovies.test.ts
+++ b/src/features/trending/hooks/useTrendingMovies.test.ts
@@ -1,0 +1,113 @@
+/**
+ * useTrendingMoviesフック テスト
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type ReactNode, createElement } from 'react';
+
+import { useTrendingMovies } from './useTrendingMovies';
+
+// --- Mocks ---
+
+const mockGetTrendingMovies = jest.fn();
+
+jest.mock('@/lib/api/trending/trending', () => ({
+  getTrendingMovies: () => mockGetTrendingMovies(),
+}));
+
+// --- Helpers ---
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+const mockTrendingMovies = [
+  {
+    id: 'uuid-1',
+    tmdb_movie_id: 123,
+    title: 'Trending Movie 1',
+    poster_path: '/poster1.jpg',
+    release_date: '2026-03-01',
+    vote_average: 7.5,
+    popularity: 100,
+    display_order: 1,
+    fetched_at: '2026-03-14T00:00:00Z',
+  },
+  {
+    id: 'uuid-2',
+    tmdb_movie_id: 456,
+    title: 'Trending Movie 2',
+    poster_path: '/poster2.jpg',
+    release_date: '2026-02-15',
+    vote_average: 8.0,
+    popularity: 200,
+    display_order: 2,
+    fetched_at: '2026-03-14T00:00:00Z',
+  },
+];
+
+// --- Tests ---
+
+describe('useTrendingMovies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('トレンド映画一覧を取得する', async () => {
+    mockGetTrendingMovies.mockResolvedValue(mockTrendingMovies);
+
+    const { result } = renderHook(() => useTrendingMovies(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.trendingMovies).toHaveLength(2);
+    expect(result.current.trendingMovies[0].title).toBe('Trending Movie 1');
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('データ未取得時は空配列を返す', async () => {
+    mockGetTrendingMovies.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useTrendingMovies(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.trendingMovies).toEqual([]);
+  });
+
+  it('エラー時はisErrorがtrueになる', async () => {
+    mockGetTrendingMovies.mockRejectedValue(new Error('DB error'));
+
+    const { result } = renderHook(() => useTrendingMovies(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.trendingMovies).toEqual([]);
+  });
+});

--- a/src/features/trending/hooks/useTrendingMovies.ts
+++ b/src/features/trending/hooks/useTrendingMovies.ts
@@ -1,0 +1,42 @@
+/**
+ * トレンド映画 カスタムフック
+ */
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { trendingKeys, TRENDING_STALE_TIME } from '@/constants';
+import { getTrendingMovies } from '@/lib/api/trending/trending';
+import type { TrendingMovie } from '@/lib/types';
+
+/**
+ * useTrendingMoviesフックの返り値
+ */
+export interface UseTrendingMoviesReturn {
+  /** トレンド映画一覧 */
+  trendingMovies: TrendingMovie[];
+  /** 読み込み中 */
+  isLoading: boolean;
+  /** エラー */
+  isError: boolean;
+}
+
+/**
+ * トレンド映画一覧を取得するカスタムフック
+ */
+export function useTrendingMovies(): UseTrendingMoviesReturn {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: trendingKeys.all,
+    queryFn: getTrendingMovies,
+    staleTime: TRENDING_STALE_TIME,
+  });
+
+  return useMemo(
+    () => ({
+      trendingMovies: data ?? [],
+      isLoading,
+      isError,
+    }),
+    [data, isLoading, isError],
+  );
+}

--- a/src/lib/api/trending/trending.test.ts
+++ b/src/lib/api/trending/trending.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * トレンド映画APIクライアント テスト
+ */
+
+import { getTrendingMovies } from './trending';
+
+// --- Mocks ---
+
+const mockSelect = jest.fn();
+const mockOrder = jest.fn();
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: (columns: string) => {
+        mockSelect(columns);
+        return {
+          order: (col: string, opts: { ascending: boolean }) => {
+            mockOrder(col, opts);
+            return Promise.resolve({
+              data: [
+                {
+                  id: 'uuid-1',
+                  tmdb_movie_id: 123,
+                  title: 'Test Movie',
+                  poster_path: '/poster.jpg',
+                  release_date: '2026-03-01',
+                  vote_average: 7.5,
+                  popularity: 100,
+                  display_order: 1,
+                  fetched_at: '2026-03-14T00:00:00Z',
+                },
+              ],
+              error: null,
+            });
+          },
+        };
+      },
+    }),
+  }),
+}));
+
+// --- Tests ---
+
+describe('getTrendingMovies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('display_order昇順でトレンド映画を取得する', async () => {
+    const result = await getTrendingMovies();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Test Movie');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockOrder).toHaveBeenCalledWith('display_order', {
+      ascending: true,
+    });
+  });
+});

--- a/src/lib/api/trending/trending.ts
+++ b/src/lib/api/trending/trending.ts
@@ -1,0 +1,26 @@
+/**
+ * トレンド映画API クライアント
+ */
+
+import { createClient } from '@/lib/supabase/client';
+import type { TrendingMovie } from '@/lib/types';
+
+/**
+ * トレンド映画一覧をDBから取得する
+ *
+ * @returns トレンド映画一覧（display_order順）
+ */
+export async function getTrendingMovies(): Promise<TrendingMovie[]> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from('trending_movies')
+    .select('*')
+    .order('display_order', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}


### PR DESCRIPTION
## 概要
トレンド映画機能 Phase 8 Step 3 として、クライアント側のデータ取得レイヤーを実装しました。

- Supabase クライアントで `trending_movies` テーブルから `display_order` 昇順で取得する API 関数
- TanStack React Query を利用した `useTrendingMovies` カスタムフック（staleTime: 24時間）
- 各関数・フックの単体テスト（API関数1件 + フック3件）

## ロードマップ
- [x] Phase 8 Step 3: カスタムフック（useTrendingMovies）

## レビューポイント
- `useTrendingMovies` の staleTime（24時間）は Cron 週次更新に対して適切か
- `useMemo` によるメモ化の適用範囲

## テスト
- `src/lib/api/trending/trending.test.ts` — Supabase クエリのモックテスト（1件）
- `src/features/trending/hooks/useTrendingMovies.test.ts` — フックテスト（3件: ローディング/データ取得/エラー）
- 全テスト通過確認済み（150 suites / 1,609 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)