### PR TITLE
feat: セッション絶対有効期限（7日間）を追加

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -79,7 +79,7 @@ export const TOAST_MESSAGES = {
  */
 export const SESSION_CONFIG = {
   /** 非アクティブ時のセッション有効期限（秒） — 24時間 */
-  IDLE_MAX_AGE: 24 * 60 * 60,
+  IDLE_MAX_AGE_S: 24 * 60 * 60,
   /** 絶対有効期限（ミリ秒） — 7日間（アクティブでも強制ログアウト） */
   ABSOLUTE_MAX_AGE_MS: 7 * 24 * 60 * 60 * 1000,
 } as const;

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -11,6 +11,7 @@ import bcrypt from 'bcryptjs';
 
 import { AUTH_ERROR_MESSAGES, SESSION_CONFIG } from '@/constants';
 import { OTP_CONFIG } from '@/constants/otp';
+import { isSessionExpired } from '@/lib/auth/sessionExpiry';
 import { checkRateLimit, resetRateLimit } from '@/lib/rateLimit/rateLimit';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -162,7 +163,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
   session: {
     strategy: 'jwt',
-    maxAge: SESSION_CONFIG.IDLE_MAX_AGE,
+    maxAge: SESSION_CONFIG.IDLE_MAX_AGE_S,
   },
 
   pages: {
@@ -303,12 +304,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
 
       // 絶対有効期限チェック（ログインから7日間）
-      if (token.issuedAt && !token.invalidated) {
-        const elapsed = Date.now() - token.issuedAt;
-        if (elapsed > SESSION_CONFIG.ABSOLUTE_MAX_AGE_MS) {
-          token.invalidated = true;
-          return token;
-        }
+      if (!token.invalidated && isSessionExpired(token.issuedAt)) {
+        token.invalidated = true;
+        return token;
       }
 
       // パスワード変更によるセッション無効化チェック（5分間隔）

--- a/src/lib/auth/sessionExpiry.test.ts
+++ b/src/lib/auth/sessionExpiry.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * セッション絶対有効期限チェック テスト
+ */
+
+import { isSessionExpired } from './sessionExpiry';
+import { SESSION_CONFIG } from '@/constants';
+
+describe('isSessionExpired', () => {
+  const now = Date.now();
+
+  it('issuedAtから7日未満の場合はfalseを返す', () => {
+    const sixDaysAgo = now - 6 * 24 * 60 * 60 * 1000;
+    expect(isSessionExpired(sixDaysAgo, now)).toBe(false);
+  });
+
+  it('issuedAtから7日超過の場合はtrueを返す', () => {
+    const eightDaysAgo = now - 8 * 24 * 60 * 60 * 1000;
+    expect(isSessionExpired(eightDaysAgo, now)).toBe(true);
+  });
+
+  it('issuedAtがちょうど7日の場合はfalseを返す（境界値）', () => {
+    const exactlySevenDays = now - SESSION_CONFIG.ABSOLUTE_MAX_AGE_MS;
+    expect(isSessionExpired(exactlySevenDays, now)).toBe(false);
+  });
+
+  it('issuedAtが7日+1msの場合はtrueを返す（境界値）', () => {
+    const justOverSevenDays = now - SESSION_CONFIG.ABSOLUTE_MAX_AGE_MS - 1;
+    expect(isSessionExpired(justOverSevenDays, now)).toBe(true);
+  });
+
+  it('issuedAtがundefinedの場合はfalseを返す（既存セッション互換）', () => {
+    expect(isSessionExpired(undefined, now)).toBe(false);
+  });
+});

--- a/src/lib/auth/sessionExpiry.ts
+++ b/src/lib/auth/sessionExpiry.ts
@@ -1,0 +1,22 @@
+/**
+ * セッション絶対有効期限チェック
+ */
+
+import { SESSION_CONFIG } from '@/constants';
+
+/**
+ * セッションが絶対有効期限を超過しているかチェックする
+ *
+ * @param issuedAt - トークン発行時刻（Date.now()のタイムスタンプ）
+ * @param now - 現在時刻（テスト用に注入可能、デフォルトはDate.now()）
+ * @returns 期限超過の場合 true
+ */
+export function isSessionExpired(
+  issuedAt: number | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!issuedAt) return false;
+
+  const elapsed = now - issuedAt;
+  return elapsed > SESSION_CONFIG.ABSOLUTE_MAX_AGE_MS;
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -34,7 +34,7 @@ declare module 'next-auth/jwt' {
     role: string;
     passwordChangedAt: string | null;
     lastPasswordCheck: number;
-    issuedAt: number;
+    issuedAt?: number;
     invalidated?: boolean;
   }
 }


### PR DESCRIPTION
## 概要
- ログインから7日経過で強制ログアウトする絶対有効期限を追加
- JWT の `issuedAt` にログイン時刻を記録し、`jwt` コールバックで経過時間をチェック
- AI レコメンド機能追加に備え、嗜好データ保護のためトークン漏洩リスクを軽減

## セッション有効期限の整理

| 種類 | 値 | 動作 |
|---|---|---|
| 非アクティブ期限（`maxAge`） | 24時間 | 最後のリクエストから24時間で失効 |
| 絶対有効期限（新規） | 7日間 | ログインから7日で強制失効 |
| パスワード変更 | 即時 | 5分間隔のチェックで無効化 |

## レビューポイント
- `SESSION_CONFIG` 定数で `IDLE_MAX_AGE`（秒）と `ABSOLUTE_MAX_AGE_MS`（ミリ秒）を管理
- 既存の `maxAge: 24 * 60 * 60` を `SESSION_CONFIG.IDLE_MAX_AGE` に置き換え
- JWT 型定義に `issuedAt: number` を追加

## テスト
- ESLint / Prettier: pass
- TypeScript Check: pass