### PR TITLE
setup: Playwright E2Eテスト結果をPRコメントに表示

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,6 +89,12 @@ jobs:
           E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
           E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
 
+      - name: playwright-report-summary
+        uses: daun/playwright-report-summary@v3
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        with:
+          report-file: playwright-report/results.json
+
       - name: upload-playwright-report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
   workers: isCI ? 2 : undefined,
-  reporter: isCI ? 'github' : 'html',
+  reporter: isCI
+    ? [['github'], ['json', { outputFile: 'playwright-report/results.json' }]]
+    : 'html',
   timeout: 30000,
   expect: {
     timeout: 10000,


### PR DESCRIPTION
## 概要
Playwright E2Eテストの結果サマリーをPRコメントに自動投稿する機能を追加しました。
Jestカバレッジレポートと同様に、テスト結果がPR上で確認できるようになります。

## 変更内容
- `playwright.config.ts`: CI時にJSONレポーターを追加（`github` + `json`）
- `.github/workflows/e2e.yml`: `daun/playwright-report-summary@v3` ステップ追加（PR時のみ）

## レビューポイント
- JSONレポーターの出力先は `playwright-report/results.json`（既存のアーティファクトアップロードに含まれる）
- PRコメントはPRイベント時のみ投稿（`github.event_name == 'pull_request'`）

## テスト
- このPR自体のCIでコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)