### PR TITLE
feat: AIレコメンド機能 Step 3 — 取得API・クライアント・フック

### DIFF
--- a/.claude/documents/roadmap.md
+++ b/.claude/documents/roadmap.md
@@ -1068,20 +1068,20 @@
     - お気に入り0件ユーザーのスキップ
 
 ### Step 3: レコメンド取得API + フック + APIクライアント（`feature/ai-recommendations-api`）
-- [ ] APIクライアント作成（`lib/api/recommendations.ts`）
+- [x] APIクライアント作成（`lib/api/recommendations.ts`）
   - getRecommendations()
-- [ ] レコメンド取得API実装（`GET /api/recommendations`）
+- [x] レコメンド取得API実装（`GET /api/recommendations`）
   - NextAuth.js認証チェック
   - 自分のrecommendationsをdisplay_order順で取得
   - generated_atを含めて返却
   - レコメンドなし → 空配列 + generated_at: null
-- [ ] useRecommendationsフック作成（TanStack Query）
+- [x] useRecommendationsフック作成（TanStack Query）
   - useQueryでレコメンド取得
   - staleTime: 1時間（日次更新のため）
   - ローディング・エラー状態管理
-- [ ] 単体テスト
+- [x] 単体テスト
   - APIクライアントテスト（getRecommendations）
-- [ ] 結合テスト
+- [x] 結合テスト
   - API Routeテスト（GET /api/recommendations）
     - 認証チェック（401）
     - 正常取得（レコメンドあり）

--- a/src/app/api/recommendations/route.test.ts
+++ b/src/app/api/recommendations/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * レコメンド取得API Route テスト (GET)
+ */
+
+import { GET } from './route';
+
+// --- Mocks ---
+
+const mockFrom = jest.fn();
+jest.mock('@/helpers/supabase', () => ({
+  createServiceRoleClient: jest.fn(() => ({ from: mockFrom })),
+  dbConnectionErrorResponse: () =>
+    new Response(JSON.stringify({ success: false }), { status: 500 }),
+}));
+
+jest.mock('@/helpers/auth', () => ({
+  getAuthSession: jest.fn().mockResolvedValue({ user: { id: 'user-123' } }),
+  unauthorizedResponse: () =>
+    new Response(JSON.stringify({ success: false }), { status: 401 }),
+}));
+
+import { getAuthSession } from '@/helpers/auth';
+
+// --- Helpers ---
+
+/** レコメンド取得のモック */
+const mockRecommendationsQuery = (
+  recs: Record<string, unknown>[],
+  error: Error | null = null,
+) => {
+  mockFrom.mockReturnValueOnce({
+    select: () => ({
+      eq: () => ({
+        order: () => Promise.resolve({ data: recs, error }),
+      }),
+    }),
+  });
+};
+
+// --- Tests ---
+
+describe('GET /api/recommendations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getAuthSession as jest.Mock).mockResolvedValue({
+      user: { id: 'user-123' },
+    });
+  });
+
+  it('レコメンド一覧を取得できる', async () => {
+    const mockRecs = [
+      {
+        id: 'rec-1',
+        tmdb_movie_id: 100,
+        title: 'メッセージ',
+        poster_path: '/arrival.jpg',
+        release_date: '2016-11-11',
+        vote_average: 7.9,
+        genre_ids: [878],
+        reason: 'SF好きにおすすめ',
+        display_order: 1,
+        generated_at: '2026-03-15T03:00:00Z',
+      },
+      {
+        id: 'rec-2',
+        tmdb_movie_id: 200,
+        title: 'インセプション',
+        poster_path: '/inception.jpg',
+        release_date: '2010-07-16',
+        vote_average: 8.4,
+        genre_ids: [878, 28],
+        reason: 'SF映画好きにおすすめ',
+        display_order: 2,
+        generated_at: '2026-03-15T03:00:00Z',
+      },
+    ];
+
+    mockRecommendationsQuery(mockRecs);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.recommendations).toHaveLength(2);
+    expect(json.data.generated_at).toBe('2026-03-15T03:00:00Z');
+  });
+
+  it('レコメンドなしの場合、空配列とgenerated_at: nullを返す', async () => {
+    mockRecommendationsQuery([]);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.recommendations).toHaveLength(0);
+    expect(json.data.generated_at).toBeNull();
+  });
+
+  it('未認証で401を返す', async () => {
+    (getAuthSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+  });
+
+  it('DBエラー時に500を返す', async () => {
+    mockRecommendationsQuery([], new Error('DB error'));
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('SERVER_ERROR');
+  });
+
+  it('DB接続エラーで500を返す', async () => {
+    const { createServiceRoleClient } = await import('@/helpers/supabase');
+    (createServiceRoleClient as jest.Mock).mockReturnValueOnce(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -1,0 +1,70 @@
+/**
+ * レコメンド取得API
+ * GET /api/recommendations
+ *
+ * 認証済みユーザーの自分のレコメンドをdisplay_order順で取得する。
+ * レコメンドが未生成の場合は空配列 + generated_at: null を返す。
+ */
+
+import { NextResponse } from 'next/server';
+
+import { getAuthSession, unauthorizedResponse } from '@/helpers/auth';
+import {
+  createServiceRoleClient,
+  dbConnectionErrorResponse,
+} from '@/helpers/supabase';
+import { HTTP_STATUS, ERROR_CODE, errorMessage } from '@/constants';
+
+const TARGET = 'レコメンド';
+
+export async function GET() {
+  try {
+    const session = await getAuthSession();
+    if (!session) return unauthorizedResponse();
+
+    const supabase = createServiceRoleClient();
+    if (!supabase) return dbConnectionErrorResponse();
+
+    const { data, error } = await supabase
+      .from('recommendations')
+      .select(
+        'id, tmdb_movie_id, title, poster_path, release_date, vote_average, genre_ids, reason, display_order, generated_at',
+      )
+      .eq('user_id', session.user.id)
+      .order('display_order', { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+
+    const recommendations = data ?? [];
+    const generatedAt =
+      recommendations.length > 0
+        ? (recommendations[0].generated_at as string)
+        : null;
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          recommendations,
+          generated_at: generatedAt,
+        },
+      },
+      { status: HTTP_STATUS.OK },
+    );
+  } catch (error) {
+    console.error('Recommendations fetch error:', error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: ERROR_CODE.SERVER_ERROR,
+          message: errorMessage.fetchFailed(TARGET),
+        },
+      },
+      { status: HTTP_STATUS.INTERNAL_SERVER_ERROR },
+    );
+  }
+}

--- a/src/features/recommendations/hooks/useRecommendations.test.ts
+++ b/src/features/recommendations/hooks/useRecommendations.test.ts
@@ -1,0 +1,118 @@
+/**
+ * useRecommendationsフックのテスト
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useRecommendations } from './useRecommendations';
+
+// --- Mocks ---
+jest.mock('@/lib/api/recommendations/recommendations', () => ({
+  getRecommendationsApi: jest.fn(),
+}));
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+  };
+});
+
+import { useQuery } from '@tanstack/react-query';
+
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+describe('useRecommendations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('レコメンド一覧を返す', () => {
+    const mockRecs = [
+      {
+        id: 'rec-1',
+        tmdb_movie_id: 100,
+        title: 'メッセージ',
+        poster_path: '/arrival.jpg',
+        release_date: '2016-11-11',
+        vote_average: 7.9,
+        genre_ids: [878],
+        reason: 'SF好きにおすすめ',
+        display_order: 1,
+      },
+    ];
+
+    mockUseQuery.mockReturnValue({
+      data: {
+        data: {
+          recommendations: mockRecs,
+          generated_at: '2026-03-15T03:00:00Z',
+        },
+      },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    const { result } = renderHook(() => useRecommendations());
+
+    expect(result.current.recommendations).toEqual(mockRecs);
+    expect(result.current.generatedAt).toBe('2026-03-15T03:00:00Z');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('ローディング中はisLoadingがtrue', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    const { result } = renderHook(() => useRecommendations());
+
+    expect(result.current.recommendations).toEqual([]);
+    expect(result.current.generatedAt).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('エラー時はisErrorがtrue', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    const { result } = renderHook(() => useRecommendations());
+
+    expect(result.current.recommendations).toEqual([]);
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('データがundefinedの場合は空配列とnullを返す', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    const { result } = renderHook(() => useRecommendations());
+
+    expect(result.current.recommendations).toEqual([]);
+    expect(result.current.generatedAt).toBeNull();
+  });
+
+  it('staleTimeとgcTimeが1時間に設定されている', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    renderHook(() => useRecommendations());
+
+    const queryOptions = mockUseQuery.mock.calls[0][0];
+    expect(queryOptions.staleTime).toBe(60 * 60 * 1000);
+    expect(queryOptions.gcTime).toBe(60 * 60 * 1000);
+  });
+});

--- a/src/features/recommendations/hooks/useRecommendations.ts
+++ b/src/features/recommendations/hooks/useRecommendations.ts
@@ -1,0 +1,64 @@
+/**
+ * useRecommendationsフック
+ * レコメンド一覧をTanStack Queryで取得・キャッシュ
+ */
+
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { getRecommendationsApi } from '@/lib/api/recommendations/recommendations';
+import { recommendationKeys, RECOMMENDATIONS_STALE_TIME } from '@/constants';
+import type { Recommendation } from '@/schema/recommendations';
+
+/**
+ * useRecommendationsフックの返り値
+ */
+export interface UseRecommendationsReturn {
+  /** レコメンド一覧 */
+  recommendations: Recommendation[];
+  /** 生成日時（未生成の場合null） */
+  generatedAt: string | null;
+  /** ローディング中 */
+  isLoading: boolean;
+  /** エラー状態 */
+  isError: boolean;
+}
+
+/**
+ * レコメンド一覧取得フック
+ */
+export function useRecommendations(): UseRecommendationsReturn {
+  const recommendationsQuery = useQuery({
+    queryKey: recommendationKeys.all,
+    queryFn: () => getRecommendationsApi(),
+    staleTime: RECOMMENDATIONS_STALE_TIME,
+    gcTime: RECOMMENDATIONS_STALE_TIME,
+  });
+
+  const recommendations = useMemo(
+    () => recommendationsQuery.data?.data.recommendations ?? [],
+    [recommendationsQuery.data],
+  );
+
+  const generatedAt = useMemo(
+    () => recommendationsQuery.data?.data.generated_at ?? null,
+    [recommendationsQuery.data],
+  );
+
+  return useMemo(
+    () => ({
+      recommendations,
+      generatedAt,
+      isLoading: recommendationsQuery.isLoading,
+      isError: recommendationsQuery.isError,
+    }),
+    [
+      recommendations,
+      generatedAt,
+      recommendationsQuery.isLoading,
+      recommendationsQuery.isError,
+    ],
+  );
+}

--- a/src/lib/api/recommendations/recommendations.test.ts
+++ b/src/lib/api/recommendations/recommendations.test.ts
@@ -1,0 +1,79 @@
+/**
+ * レコメンドAPIクライアント テスト
+ */
+
+import { axiosInstance } from '@/lib/axios/axios';
+
+import { getRecommendationsApi } from './recommendations';
+
+jest.mock('@/lib/axios/axios', () => ({
+  axiosInstance: {
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = axiosInstance.get as jest.Mock;
+
+describe('getRecommendationsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('レコメンド一覧を取得できる', async () => {
+    const mockResponse = {
+      data: {
+        success: true,
+        data: {
+          recommendations: [
+            {
+              id: 'rec-1',
+              tmdb_movie_id: 100,
+              title: 'メッセージ',
+              poster_path: '/arrival.jpg',
+              release_date: '2016-11-11',
+              vote_average: 7.9,
+              genre_ids: [878],
+              reason: 'SF好きにおすすめ',
+              display_order: 1,
+            },
+          ],
+          generated_at: '2026-03-15T03:00:00Z',
+        },
+      },
+    };
+
+    mockGet.mockResolvedValue(mockResponse);
+
+    const result = await getRecommendationsApi();
+
+    expect(mockGet).toHaveBeenCalledWith('/api/recommendations');
+    expect(result.success).toBe(true);
+    expect(result.data.recommendations).toHaveLength(1);
+    expect(result.data.generated_at).toBe('2026-03-15T03:00:00Z');
+  });
+
+  it('レコメンドが空の場合、空配列を返す', async () => {
+    const mockResponse = {
+      data: {
+        success: true,
+        data: {
+          recommendations: [],
+          generated_at: null,
+        },
+      },
+    };
+
+    mockGet.mockResolvedValue(mockResponse);
+
+    const result = await getRecommendationsApi();
+
+    expect(result.data.recommendations).toHaveLength(0);
+    expect(result.data.generated_at).toBeNull();
+  });
+
+  it('APIエラー時に例外をスローする', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'));
+
+    await expect(getRecommendationsApi()).rejects.toThrow('Network error');
+  });
+});

--- a/src/lib/api/recommendations/recommendations.ts
+++ b/src/lib/api/recommendations/recommendations.ts
@@ -1,0 +1,24 @@
+/**
+ * レコメンドAPI クライアント
+ */
+
+import { axiosInstance } from '@/lib/axios/axios';
+import type { RecommendationsApiResponse } from '@/schema/recommendations';
+
+/**
+ * レコメンド取得レスポンスの型
+ */
+export interface GetRecommendationsResponse {
+  success: true;
+  data: RecommendationsApiResponse;
+}
+
+/**
+ * レコメンド一覧を取得
+ */
+export async function getRecommendationsApi(): Promise<GetRecommendationsResponse> {
+  const response = await axiosInstance.get<GetRecommendationsResponse>(
+    '/api/recommendations',
+  );
+  return response.data;
+}


### PR DESCRIPTION
## 概要
AIレコメンド機能のStep 3として、レコメンド取得API・APIクライアント・TanStack Queryフックを実装。

- `GET /api/recommendations` — NextAuth.js認証付きレコメンド取得API
- `getRecommendationsApi()` — axiosベースのAPIクライアント
- `useRecommendations()` — TanStack Queryフック（staleTime: 1時間）

## ロードマップ
- [x] APIクライアント作成（`lib/api/recommendations.ts`）
- [x] レコメンド取得API実装（`GET /api/recommendations`）
- [x] useRecommendationsフック作成（TanStack Query）
- [x] 単体テスト（APIクライアント）
- [x] 結合テスト（API Route・フック）

## レビューポイント
- API Routeのレスポンス形式（recommendations配列 + generated_at）
- useRecommendationsのstaleTime/gcTime設定（1時間）
- レコメンド未生成時の空配列 + generated_at: null の挙動

## テスト
- APIクライアントテスト: 3件
- API Routeテスト: 5件（認証・正常取得・空配列・DBエラー・DB接続エラー）
- フックテスト: 5件（データ取得・ローディング・エラー・空配列・staleTime確認）
- 全13件パス、ESLint・TypeScript・Prettierエラーなし