### PR TITLE
feat: レコメンドセクションにウォッチリスト追加ボタンを追加

### DIFF
--- a/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
@@ -9,10 +9,12 @@ jest.mock('@/components/ui/movie/movieTile/movieTile', () => ({
     movie,
     onClick,
     onFavoriteToggle,
+    onWatchlistToggle,
   }: {
     movie: { id: number; title: string };
     onClick?: (movieId: number) => void;
     onFavoriteToggle?: () => void;
+    onWatchlistToggle?: () => void;
   }) => (
     <div
       data-testid={`movie-tile-${movie.id}`}
@@ -32,6 +34,17 @@ jest.mock('@/components/ui/movie/movieTile/movieTile', () => ({
           }}
         >
           お気に入り
+        </button>
+      )}
+      {onWatchlistToggle && (
+        <button
+          data-testid={`watchlist-btn-${movie.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onWatchlistToggle();
+          }}
+        >
+          ウォッチリスト
         </button>
       )}
     </div>
@@ -77,6 +90,19 @@ jest.mock(
     FavoriteRatingModal: () => <div data-testid='favorite-rating-modal' />,
   }),
 );
+
+const mockIsInWatchlist = jest.fn().mockReturnValue(false);
+const mockToggleWatchlist = jest.fn();
+const mockIsMovieToggling = jest.fn().mockReturnValue(false);
+
+jest.mock('@/features/watchlist/hooks/useWatchlistToggle', () => ({
+  useWatchlistToggle: () => ({
+    isInWatchlist: mockIsInWatchlist,
+    toggleWatchlist: mockToggleWatchlist,
+    isToggling: false,
+    isMovieToggling: mockIsMovieToggling,
+  }),
+}));
 
 // --- Helpers ---
 
@@ -209,6 +235,20 @@ describe('RecommendationSection', () => {
       expect(
         screen.queryByTestId('movie-detail-modal'),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ウォッチリストボタン', () => {
+    it('各MovieTileにウォッチリストボタンが表示される', () => {
+      render(
+        <RecommendationSection
+          recommendations={createMockRecommendations(2)}
+          hasFavorites={true}
+        />,
+      );
+
+      expect(screen.getByTestId('watchlist-btn-100')).toBeInTheDocument();
+      expect(screen.getByTestId('watchlist-btn-101')).toBeInTheDocument();
     });
   });
 

--- a/src/features/recommendations/component/recommendationSection/recommendationSection.tsx
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.tsx
@@ -11,6 +11,7 @@ import { MovieTile } from '@/components/ui/movie/movieTile/movieTile';
 import { MovieDetailModal } from '@/components/ui/movie/detailModal/movieDetailModal';
 import { FavoriteRatingModal } from '@/features/favorites/component/favoriteRatingModal/favoriteRatingModal';
 import { useFavoriteToggle } from '@/features/favorites/hooks/useFavoriteToggle';
+import { useWatchlistToggle } from '@/features/watchlist/hooks/useWatchlistToggle';
 import { RECOMMENDATIONS_MESSAGES } from '@/constants';
 import type { Recommendation } from '@/schema/recommendations';
 import { toMovieCacheItem } from '@/features/recommendations/utils/toMovieCacheItem';
@@ -42,6 +43,9 @@ export const RecommendationSection = memo<RecommendationSectionProps>(
       handleDelete: handleFavoriteDelete,
       isFavoriteProcessing,
     } = useFavoriteToggle();
+
+    const { isInWatchlist, toggleWatchlist, isMovieToggling } =
+      useWatchlistToggle();
 
     const handleMovieClick = useCallback((movieId: number) => {
       setSelectedMovieId(movieId);
@@ -115,6 +119,9 @@ export const RecommendationSection = memo<RecommendationSectionProps>(
                 <MovieTile
                   movie={movie}
                   onClick={handleMovieClick}
+                  isInWatchlist={isInWatchlist(movie.id)}
+                  onWatchlistToggle={toggleWatchlist}
+                  watchlistDisabled={isMovieToggling(movie.id)}
                   onFavoriteToggle={handleFavoriteToggle}
                   favoriteDisabled={isFavoriteProcessing(movie.id)}
                 />


### PR DESCRIPTION
## 概要
- レコメンドセクションの各MovieTileにウォッチリスト追加/削除ボタンを表示
- 既存の`useWatchlistToggle`フックパターンに準拠
- お気に入りボタンと合わせて、レコメンド映画に対するアクションが一通り揃う

## レビューポイント
- `movieListContent.tsx`と同じパターンで`useWatchlistToggle`を統合
- `isInWatchlist` / `toggleWatchlist` / `isMovieToggling`をMovieTileに渡す

## テスト
- ウォッチリストボタン表示テスト追加（1件）
- 既存テスト含め全12件合格