### PR TITLE
fix: レコメンドのお気に入りボタンが登録後にアクティブにならない問題を修正

### DIFF
--- a/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
@@ -73,6 +73,8 @@ const mockHandleFavoriteModalSubmit = jest.fn();
 const mockHandleFavoriteDelete = jest.fn();
 const mockIsFavoriteProcessing = jest.fn().mockReturnValue(false);
 
+const mockGetFavoriteInfo = jest.fn().mockReturnValue(null);
+
 jest.mock('@/features/favorites/hooks/useFavoriteToggle', () => ({
   useFavoriteToggle: () => ({
     modalState: { isOpen: false, movie: null, currentFavorite: null },
@@ -81,6 +83,7 @@ jest.mock('@/features/favorites/hooks/useFavoriteToggle', () => ({
     handleModalSubmit: mockHandleFavoriteModalSubmit,
     handleDelete: mockHandleFavoriteDelete,
     isFavoriteProcessing: mockIsFavoriteProcessing,
+    getFavoriteInfo: mockGetFavoriteInfo,
   }),
 }));
 

--- a/src/features/recommendations/component/recommendationSection/recommendationSection.tsx
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.tsx
@@ -42,6 +42,7 @@ export const RecommendationSection = memo<RecommendationSectionProps>(
       handleModalSubmit: handleFavoriteModalSubmit,
       handleDelete: handleFavoriteDelete,
       isFavoriteProcessing,
+      getFavoriteInfo,
     } = useFavoriteToggle();
 
     const { isInWatchlist, toggleWatchlist, isMovieToggling } =
@@ -56,8 +57,12 @@ export const RecommendationSection = memo<RecommendationSectionProps>(
     }, []);
 
     const movieCacheItems = useMemo(
-      () => recommendations.map(toMovieCacheItem),
-      [recommendations],
+      () =>
+        recommendations.map((rec) => ({
+          ...toMovieCacheItem(rec),
+          favorite: getFavoriteInfo(rec.tmdb_movie_id),
+        })),
+      [recommendations, getFavoriteInfo],
     );
 
     const reasonMap = useMemo(


### PR DESCRIPTION
## 概要
- レコメンドセクションでお気に入り登録後、ハートボタンがアクティブ状態にならない問題を修正
- `getFavoriteInfo`でお気に入り情報を`MovieCacheItem`の`favorite`フィールドに反映

## レビューポイント
- `useFavoriteToggle`の`getFavoriteInfo`を`useMemo`の依存に追加し、お気に入り状態変更時に再計算される

## テスト
- 既存テスト全12件合格

## 依存PR
- #136 (ウォッチリストボタン追加)