### PR TITLE
fix: 設定ページのレイアウトシフトをスケルトンで解消

### DIFF
--- a/src/features/settings/notificationSettings/notificationSettings.test.tsx
+++ b/src/features/settings/notificationSettings/notificationSettings.test.tsx
@@ -131,10 +131,19 @@ describe('NotificationSettings', () => {
     ).not.toBeChecked();
   });
 
-  it('ローディング中はnullを返す', () => {
+  it('ローディング中はスケルトンが表示される', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}));
-    const { container } = render(<NotificationSettings />);
+    render(<NotificationSettings />);
 
-    expect(container.firstChild).toBeNull();
+    expect(
+      screen.queryByRole('checkbox', {
+        name: '公開日リマインダーを受け取る',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'ウォッチリストに追加した映画の公開日が近づいたら通知します',
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/settings/notificationSettings/notificationSettings.tsx
+++ b/src/features/settings/notificationSettings/notificationSettings.tsx
@@ -7,6 +7,7 @@
 import { memo, useCallback, useState, useEffect } from 'react';
 
 import { Checkbox } from '@/components/ui/checkbox/checkbox';
+import { Skeleton } from '@/components/ui/skeleton/skeleton';
 import { getSettings, updateSettings } from '@/lib/api/user/user';
 import { useToast } from '@/hooks/useToast';
 import { handleApiError } from '@/utils/error';
@@ -69,7 +70,14 @@ export const NotificationSettings = memo(function NotificationSettings() {
     [toast],
   );
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <div className={styles.c_notification_settings}>
+        <Skeleton variant='rect' width={200} height={20} />
+        <Skeleton variant='text' width={280} height={14} />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.c_notification_settings}>

--- a/src/features/settings/settingsPage/settingsPage.test.tsx
+++ b/src/features/settings/settingsPage/settingsPage.test.tsx
@@ -161,4 +161,21 @@ describe('SettingsPage', () => {
       screen.queryByRole('heading', { name: 'パスワード変更' }),
     ).not.toBeInTheDocument();
   });
+
+  it('セッションloading中はパスワード変更セクションにスケルトンが表示される', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'loading',
+      update: jest.fn(),
+    });
+
+    render(<SettingsPage />);
+
+    expect(
+      screen.getByRole('heading', { name: 'パスワード変更' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('change-password-form'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/features/settings/settingsPage/settingsPage.tsx
+++ b/src/features/settings/settingsPage/settingsPage.tsx
@@ -8,6 +8,7 @@ import { memo } from 'react';
 import { useSession } from 'next-auth/react';
 
 import { Heading } from '@/components/ui/heading/heading';
+import { Skeleton } from '@/components/ui/skeleton/skeleton';
 import { DisplayNameForm } from '@/features/settings/displayNameForm/displayNameForm';
 import { ChangePasswordForm } from '@/features/settings/changePasswordForm/changePasswordForm';
 import { NotificationSettings } from '@/features/settings/notificationSettings/notificationSettings';
@@ -20,8 +21,9 @@ import styles from './settingsPage.module.scss';
  * 設定ページ
  */
 export const SettingsPage = memo(function SettingsPage() {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const email = session?.user?.email ?? '';
+  const isSessionLoading = status === 'loading';
 
   return (
     <div className={styles.c_settings_page}>
@@ -33,11 +35,18 @@ export const SettingsPage = memo(function SettingsPage() {
           <DisplayNameForm />
         </section>
 
-        {email && (
+        {isSessionLoading ? (
           <section className={styles.c_settings_page__section}>
             <Heading level={2}>パスワード変更</Heading>
-            <ChangePasswordForm email={email} />
+            <Skeleton variant='rect' width='100%' height={48} />
           </section>
+        ) : (
+          email && (
+            <section className={styles.c_settings_page__section}>
+              <Heading level={2}>パスワード変更</Heading>
+              <ChangePasswordForm email={email} />
+            </section>
+          )
         )}
 
         <section className={styles.c_settings_page__section}>

--- a/src/features/settings/themeSettings/themeSettings.test.tsx
+++ b/src/features/settings/themeSettings/themeSettings.test.tsx
@@ -153,10 +153,13 @@ describe('ThemeSettings', () => {
     });
   });
 
-  it('ローディング中はnullを返す', () => {
+  it('ローディング中はスケルトンが表示される', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}));
-    const { container } = render(<ThemeSettings />);
+    render(<ThemeSettings />);
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('theme-select')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('アプリの外観を切り替えます'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/settings/themeSettings/themeSettings.tsx
+++ b/src/features/settings/themeSettings/themeSettings.tsx
@@ -7,6 +7,7 @@
 import { memo, useCallback, useState, useEffect } from 'react';
 
 import { Select } from '@/components/ui/select/select';
+import { Skeleton } from '@/components/ui/skeleton/skeleton';
 import { THEME_VALUES } from '@/schema/user';
 import { getSettings, updateSettings } from '@/lib/api/user/user';
 import { useToast } from '@/hooks/useToast';
@@ -91,7 +92,16 @@ export const ThemeSettings = memo(function ThemeSettings() {
     [theme, toast],
   );
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <div className={styles.c_theme_settings}>
+        <div className={styles.c_theme_settings__select}>
+          <Skeleton variant='rect' width={200} height={36} />
+        </div>
+        <Skeleton variant='text' width={160} height={14} />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.c_theme_settings}>


### PR DESCRIPTION
## 概要
設定ページで通知・外観・パスワード変更セクションがAPIレスポンス待ちの間 `return null` していたため、
コンテンツ出現時にレイアウトシフトが発生していた問題をSkeletonコンポーネントで解消。

## レビューポイント
- `NotificationSettings`: チェックボックス + 説明テキスト相当のスケルトン（幅200px/高20px + 幅280px/高14px）
- `ThemeSettings`: セレクト相当のスケルトン（幅200px/高36px + 幅160px/高14px）
- `SettingsPage`: `useSession` の `status === 'loading'` 中にパスワード変更セクションのスケルトン表示

## テスト
- NotificationSettings: 「ローディング中はスケルトンが表示される」に変更（40テスト全パス）
- ThemeSettings: 同上
- SettingsPage: セッションloading中のスケルトン表示テスト追加