### PR TITLE
security: OWASPセキュリティ監査（#167）

### DIFF
--- a/.claude/documents/security-audit.md
+++ b/.claude/documents/security-audit.md
@@ -1,0 +1,96 @@
+# OWASPセキュリティ監査結果
+
+実施日: 2026-03-16
+
+## 総合評価: 良好
+
+全23 APIルート、認証フロー、インフラ設定を監査した結果、重大な脆弱性は発見されなかった。
+軽微な改善3件を実施し、セキュリティレベルを向上させた。
+
+## 監査結果サマリー
+
+| カテゴリ | 評価 | 備考 |
+|---------|------|------|
+| 認証・認可 | 安全 | 全APIルートで認証チェック済み、RLS適用済み |
+| パスワードハッシュ | 安全 | bcryptjs（salt rounds: 12） |
+| JWT・セッション | 安全 | 24時間idle + 7日absolute、パスワード変更時無効化 |
+| Cookie | 安全 | HttpOnly / Secure(本番) / SameSite=lax |
+| 機密情報露出 | 安全 | NEXT_PUBLIC_にサーバー秘密鍵なし |
+| SQLインジェクション | 安全 | パラメータ化クエリ100% |
+| XSS | 安全 | dangerouslySetInnerHTML不使用、CSPヘッダー追加済み |
+| Zodバリデーション | 安全 | 全APIルートで入力検証済み |
+| レート制限 | 安全 | ログイン/パスワード変更/OTP/登録で適用 |
+| セキュリティヘッダー | 安全 | CSP/HSTS/X-Frame-Options等設定済み |
+| SSRF | 安全 | 外部URLはハードコード、ユーザー入力から構築なし |
+| サプライチェーン | 安全 | package-lock.json管理、不審スクリプトなし |
+| エラー応答 | 安全 | スタックトレース非公開、汎用メッセージ |
+| 依存パッケージ | 安全 | npm audit 脆弱性0件 |
+
+## 発見・修正事項
+
+### 修正済み
+
+1. **CSPヘッダー未設定** (中)
+   - ファイル: `next.config.mjs`
+   - 対応: Content-Security-Policyヘッダーを追加
+
+2. **登録APIのレート制限なし** (高)
+   - ファイル: `src/app/api/auth/register/route.ts`
+   - 対応: email単位で5回/60分のレート制限を追加
+
+3. **flatted脆弱性（DoS）** (高)
+   - 対応: `npm audit fix`でflatted >= 3.4.0に更新
+
+### 残存リスク（許容範囲）
+
+1. **NEXT_PUBLIC_TMDB_API_KEY**: TMDb APIキーがクライアント露出。TMDbはpublicなAPIのため許容。
+2. **ユーザー操作エンドポイント**: favorites/watchlist等の変更系APIにレート制限なし。認証必須のため悪用リスクは低い。
+
+## 詳細確認項目
+
+### 認証・認可
+- [x] 全APIルート認証チェック確認（23ルート）
+- [x] RLSポリシー確認（user_idベース制限）
+- [x] Middleware保護パス確認（/watchlist, /settings, /favorites）
+- [x] CORS: デフォルトsame-origin（明示設定不要）
+
+### 暗号化・トークン
+- [x] パスワードハッシュ: bcryptjs cost=12
+- [x] JWT: 24h idle / 7d absolute / パスワード変更時無効化
+- [x] Cookie: HttpOnly / Secure(prod) / SameSite=lax / __Secure-prefix
+- [x] APIキー: サーバーサイドのみ（SUPABASE_SERVICE_ROLE_KEY, CRON_SECRET等）
+
+### 入力検証
+- [x] SQLi: Supabase SDKパラメータ化クエリ100%
+- [x] XSS: dangerouslySetInnerHTML不使用 + CSP追加
+- [x] Zod: 全APIルートで入力バリデーション実装
+
+### レート制限
+- [x] ログイン: 3回/30分
+- [x] パスワード変更: 3回/30分
+- [x] OTP送信: 1分間隔制限
+- [x] OTP検証: 5回試行制限
+- [x] 登録: 5回/60分（今回追加）
+
+### インフラ・設定
+- [x] セキュリティヘッダー: CSP/HSTS/X-Frame-Options/X-Content-Type-Options
+- [x] 環境変数: NEXT_PUBLIC_にサーバー秘密鍵なし
+- [x] エラー応答: スタックトレース非公開
+
+### 依存パッケージ
+- [x] npm audit: 脆弱性0件
+- [x] package-lock.json: 管理済み
+
+### 認証フロー
+- [x] パスワードポリシー: 8文字以上、英大小文字+数字
+- [x] セッション: 24h idle / 7d absolute
+- [x] OTP: 6桁、10分有効期限、5回試行制限
+- [x] OAuth: Google/GitHub、コールバック安全
+
+### SSRF
+- [x] TMDb API: ベースURL固定、ユーザー入力から構築なし
+- [x] 内部ネットワーク: アクセス制限不要（外部APIのみ）
+
+### サプライチェーン
+- [x] package-lock.json整合性確認
+- [x] 不審なpostinstallスクリプトなし

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,6 +61,20 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' https://image.tmdb.org data: blob:",
+              "font-src 'self'",
+              "connect-src 'self' https://*.supabase.co",
+              "frame-ancestors 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+            ].join('; '),
+          },
         ],
       },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -6976,9 +6976,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/app/api/auth/register/route.test.ts
+++ b/src/app/api/auth/register/route.test.ts
@@ -21,6 +21,11 @@ jest.mock('bcryptjs', () => ({
   hash: jest.fn().mockResolvedValue('hashed_password'),
 }));
 
+const mockCheckRateLimit = jest.fn().mockResolvedValue({ allowed: true });
+jest.mock('@/lib/rateLimit/rateLimit', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}));
+
 const mockGenerateOtpCode = jest.fn().mockReturnValue('123456');
 const mockSendOtpEmail = jest.fn().mockResolvedValue(true);
 jest.mock('@/lib/otp', () => ({
@@ -195,6 +200,25 @@ describe('POST /api/auth/register', () => {
     // ロールバックが実行されたことを確認
     expect(mockOtpDelete).toHaveBeenCalled();
     expect(mockUserDelete).toHaveBeenCalled();
+  });
+
+  it('レート制限超過で429を返す', async () => {
+    mockCheckRateLimit.mockResolvedValueOnce({
+      allowed: false,
+      retryAfter: 3600,
+    });
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        password: 'Password1',
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('3600');
+    const json = await response.json();
+    expect(json.success).toBe(false);
   });
 
   it('OTP INSERT失敗で500を返す', async () => {

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -18,6 +18,7 @@ import { AUTH_ERROR_MESSAGES, BCRYPT_COST } from '@/constants/auth';
 import { OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
 import { HTTP_STATUS, ERROR_CODE } from '@/constants';
 import { generateOtpCode, sendOtpEmail } from '@/lib/otp';
+import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 
 export async function POST(request: Request) {
   try {
@@ -40,6 +41,33 @@ export async function POST(request: Request) {
           },
         },
         { status: HTTP_STATUS.BAD_REQUEST },
+      );
+    }
+
+    // レート制限チェック（email単位で5回/60分）
+    const rateLimitResult = await checkRateLimit(
+      supabase,
+      result.data.email,
+      'register',
+      5,
+      60,
+    );
+
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: ERROR_CODE.RATE_LIMIT_EXCEEDED,
+            message: AUTH_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+          },
+        },
+        {
+          status: HTTP_STATUS.TOO_MANY_REQUESTS,
+          headers: rateLimitResult.retryAfter
+            ? { 'Retry-After': String(rateLimitResult.retryAfter) }
+            : undefined,
+        },
       );
     }
 


### PR DESCRIPTION
## 概要

OWASPセキュリティ監査を実施し、発見された脆弱性を修正。

### 監査実施項目（全項目クリア）
- 認証・認可（23 APIルート全数確認）
- パスワードハッシュ（bcryptjs cost=12）
- JWT・セッション管理（24h idle / 7d absolute）
- Cookie設定（HttpOnly / Secure / SameSite）
- 機密情報露出チェック
- SQLインジェクション対策（パラメータ化クエリ100%）
- XSS対策（CSPヘッダー追加）
- Zodバリデーション網羅性
- レート制限
- セキュリティヘッダー
- SSRF対策
- サプライチェーン
- エラー応答の情報漏洩
- 依存パッケージ脆弱性

### 修正内容
1. **CSPヘッダー追加** — `next.config.mjs`にContent-Security-Policyを設定
2. **登録APIレート制限** — `/api/auth/register`にemail単位5回/60分の制限を追加
3. **flatted脆弱性修正** — npm audit fixでDoS脆弱性を解消（0 vulnerabilities）

## ロードマップ
- フェーズ10 Step 3: OWASPセキュリティ監査 → #167

## レビューポイント
- CSPヘッダーの設定値（script-src 'unsafe-inline' 'unsafe-eval'はNext.jsの動作に必要）
- 登録APIのレート制限パラメータ（5回/60分）の妥当性
- 監査結果ドキュメント `.claude/documents/security-audit.md`

## テスト
- 登録APIテスト: 7件全パス（レート制限テスト含む）
- TypeScript型チェック: エラーなし

Closes #167