### PR TITLE
fix: パスワード変更セクションのレイアウト修正（#188）

### DIFF
--- a/src/features/settings/changePasswordForm/changePasswordForm.module.scss
+++ b/src/features/settings/changePasswordForm/changePasswordForm.module.scss
@@ -3,21 +3,10 @@
 
 .c_change_password_form {
   width: 100%;
-  max-width: 540px;
-  margin: 0 auto;
-  padding: $spacing-4;
-
-  @include md {
-    padding: $spacing-8;
-  }
 }
 
 .c_change_password_form__body {
-  margin-top: $spacing-6;
-
-  @include md {
-    margin-top: $spacing-8;
-  }
+  margin-top: $spacing-4;
 }
 
 .c_change_password_form__fields {


### PR DESCRIPTION
## 概要
設定画面のパスワード変更セクションで、ボタンが中央寄せになっていた問題と見出しとの距離が離れすぎていた問題を修正。

- `max-width: 540px` + `margin: 0 auto` を削除し、親settingsPageの制約に従うように変更
- `margin-top` を `$spacing-4` に縮小

## ロードマップ
- Issue #188

## レビューポイント
- 他のセクション（プロフィール等）と左寄せが統一されているか

## テスト
- CSSのみの変更のため既存テストに影響なし

Closes #188