### PR TITLE
fix: レコメンドセクションのMovieTileの高さを揃える

### DIFF
--- a/src/features/recommendations/component/recommendationSection/recommendationSection.module.scss
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.module.scss
@@ -49,6 +49,10 @@
   &__item {
     display: flex;
     flex-direction: column;
+
+    > :first-child {
+      flex: 1;
+    }
   }
 
   &__reason {


### PR DESCRIPTION
## 概要
レコメンドセクションのグリッドアイテム内でMovieTileの高さがコンテンツ量によってばらついていた問題を修正。

- `__item` の `:first-child`（MovieTile）に `flex: 1` を適用し、行内のタイル高さを統一
- reasonテキストは下部に固定される

## レビューポイント
- SCSS 1行の変更のみ（`> :first-child { flex: 1; }`）

## テスト
- 既存15テスト通過
- TypeScript型チェック通過

Closes #244