### PR TITLE
refactor: ユーティリティ関数のデフォルト値・設定値を定数化

### DIFF
--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -20,12 +20,13 @@ import {
   SETTINGS_ERROR_MESSAGES,
   SETTINGS_SUCCESS_MESSAGES,
   API_ERROR_MESSAGES,
+  DEFAULT_USER_SETTINGS,
 } from '@/constants';
 
 /** デフォルトのユーザー設定 */
 const DEFAULT_SETTINGS: UserSettings = {
-  theme: 'light',
-  notificationEnabled: false,
+  theme: DEFAULT_USER_SETTINGS.THEME,
+  notificationEnabled: DEFAULT_USER_SETTINGS.NOTIFICATION_ENABLED,
 };
 
 export async function GET() {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -165,6 +165,40 @@ export const API_ERROR_MESSAGES = {
 } as const;
 
 /**
+ * 日付フォーマット
+ */
+export const DATE_FORMAT = {
+  /** 日付のみ（例: 2024年01月15日） */
+  DATE: 'yyyy年MM月dd日',
+  /** 日時（例: 2024年01月15日 10:30） */
+  DATETIME: 'yyyy年MM月dd日 HH:mm',
+} as const;
+
+/**
+ * IntersectionObserverデフォルト設定
+ */
+export const INTERSECTION_OBSERVER = {
+  /** デフォルトのrootMargin */
+  ROOT_MARGIN: '200px',
+} as const;
+
+/**
+ * 為替レート（概算用）
+ */
+export const EXCHANGE_RATE = {
+  /** USD→JPY 固定レート */
+  USD_TO_JPY: 150,
+} as const;
+
+/**
+ * デフォルトユーザー設定
+ */
+export const DEFAULT_USER_SETTINGS = {
+  THEME: 'light',
+  NOTIFICATION_ENABLED: false,
+} as const;
+
+/**
  * バリデーション設定
  */
 export const VALIDATION = {

--- a/src/features/movies/component/movieDetailContent/movieDetailContent.tsx
+++ b/src/features/movies/component/movieDetailContent/movieDetailContent.tsx
@@ -22,6 +22,7 @@ import {
   getTMDbProviderLogoUrl,
 } from '@/utils/image';
 import { formatDate } from '@/utils/date';
+import { EXCHANGE_RATE } from '@/constants';
 import { useMovieDetail } from '@/features/movies/hooks/useMovieDetail';
 import type { WatchProvider } from '@/lib/types';
 
@@ -50,8 +51,6 @@ function formatRuntime(minutes: number): string {
 }
 
 const MAX_CAST_DISPLAY = 10;
-/** 概算用の固定為替レート（USD→JPY） */
-const USD_TO_JPY_RATE = 150;
 
 /**
  * 日本円を読みやすい単位でフォーマット
@@ -77,7 +76,7 @@ function formatJpy(yen: number): string {
 function formatCurrency(amount: number): string {
   if (amount === 0) return '-';
   const usd = `$${amount.toLocaleString('en-US')}`;
-  const jpyAmount = Math.round(amount * USD_TO_JPY_RATE);
+  const jpyAmount = Math.round(amount * EXCHANGE_RATE.USD_TO_JPY);
   return `${usd}（約${formatJpy(jpyAmount)}）`;
 }
 

--- a/src/features/search/hooks/useGenres.ts
+++ b/src/features/search/hooks/useGenres.ts
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { getGenresApi } from '@/lib/api/genres/genres';
-import { genreKeys } from '@/constants';
+import { genreKeys, GENRE_CACHE_DURATION_MS } from '@/constants';
 import type { Genre } from '@/lib/types';
 
 /**
@@ -31,8 +31,8 @@ export function useGenres(): UseGenresReturn {
   const genresQuery = useQuery({
     queryKey: genreKeys.all,
     queryFn: () => getGenresApi(),
-    staleTime: 24 * 60 * 60 * 1000,
-    gcTime: 24 * 60 * 60 * 1000,
+    staleTime: GENRE_CACHE_DURATION_MS,
+    gcTime: GENRE_CACHE_DURATION_MS,
   });
 
   const genres = useMemo(

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -5,6 +5,8 @@
 
 import { useEffect, useRef } from 'react';
 
+import { INTERSECTION_OBSERVER } from '@/constants';
+
 interface UseIntersectionObserverOptions {
   /** コールバックを実行するかどうか */
   enabled?: boolean;
@@ -25,7 +27,11 @@ export function useIntersectionObserver(
   onIntersect: () => void,
   options: UseIntersectionObserverOptions = {},
 ) {
-  const { enabled = true, rootMargin = '200px', threshold = 0 } = options;
+  const {
+    enabled = true,
+    rootMargin = INTERSECTION_OBSERVER.ROOT_MARGIN,
+    threshold = 0,
+  } = options;
   const targetRef = useRef<HTMLDivElement>(null);
   const onIntersectRef = useRef(onIntersect);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -5,6 +5,8 @@
 import { format as dateFnsFormat, parseISO } from 'date-fns';
 import { ja } from 'date-fns/locale';
 
+import { DATE_FORMAT } from '@/constants';
+
 /**
  * 日付を指定フォーマットで文字列化
  *
@@ -23,7 +25,7 @@ import { ja } from 'date-fns/locale';
  */
 export function formatDate(
   date: Date | string | number | null | undefined,
-  formatString: string = 'yyyy年MM月dd日',
+  formatString: string = DATE_FORMAT.DATE,
 ): string | null {
   if (!date) return null;
 
@@ -54,7 +56,7 @@ export function formatDate(
  */
 export function formatDateTime(
   date: Date | string | number | null | undefined,
-  formatString: string = 'yyyy年MM月dd日 HH:mm',
+  formatString: string = DATE_FORMAT.DATETIME,
 ): string | null {
   return formatDate(date, formatString);
 }


### PR DESCRIPTION
## 概要
ユーティリティ関数やhooksのハードコードされたデフォルト値を定数化。

- `DATE_FORMAT.DATE` / `DATE_FORMAT.DATETIME` — 日付フォーマット文字列
- `INTERSECTION_OBSERVER.ROOT_MARGIN` — IntersectionObserverのrootMargin
- `useGenres` — `24 * 60 * 60 * 1000` → 既存の `GENRE_CACHE_DURATION_MS` 参照に統一
- `DEFAULT_USER_SETTINGS` — ユーザー設定デフォルト値（theme, notificationEnabled）
- `EXCHANGE_RATE.USD_TO_JPY` — USD→JPY概算為替レート

※ `src/utils/string.ts` と `src/utils/validation.ts` は存在しないためスキップ

## レビューポイント
- `src/constants/common.ts` に追加した4つの定数オブジェクト

## テスト
- 全1817テスト通過
- TypeScript型チェック通過

Closes #222