### PR TITLE
refactor: 内部APIエンドポイント・外部URLを定数化

### DIFF
--- a/src/components/layout/footer/footer.tsx
+++ b/src/components/layout/footer/footer.tsx
@@ -8,6 +8,7 @@ import { type HTMLAttributes, type ReactNode, memo } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { ASSET_PATHS } from '@/constants';
 import { cn } from '@/utils/cn';
 
 import styles from './footer.module.scss';
@@ -75,7 +76,7 @@ export const Footer = memo<FooterProps>(function Footer({
 
         <div className={styles.c_footer__attribution}>
           <Image
-            src='/tmdb-logo.svg'
+            src={ASSET_PATHS.TMDB_LOGO}
             alt='TMDB'
             width={100}
             height={8}

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -21,6 +21,44 @@ export const API = {
 } as const;
 
 /**
+ * 内部APIエンドポイント
+ */
+export const API_ENDPOINTS = {
+  AUTH: {
+    OTP_SEND: '/api/auth/otp/send',
+    OTP_VERIFY: '/api/auth/otp/verify',
+  },
+} as const;
+
+/**
+ * 外部URL
+ */
+export const EXTERNAL_URLS = {
+  /** YouTube埋め込みURL */
+  YOUTUBE_EMBED: 'https://www.youtube.com/embed/',
+  /** プレースホルダー画像サービス */
+  PLACEHOLDER_IMAGE: 'https://placehold.co',
+} as const;
+
+/**
+ * 公開アセットパス
+ */
+export const ASSET_PATHS = {
+  /** TMDbロゴ */
+  TMDB_LOGO: '/tmdb-logo.svg',
+} as const;
+
+/**
+ * URLパラメータキー（検索フィルター用）
+ */
+export const QUERY_PARAMS = {
+  PAGE: 'page',
+  GENRE: 'genre',
+  YEAR: 'year',
+  VOTE_AVERAGE_GTE: 'vote_average_gte',
+} as const;
+
+/**
  * HTTPステータスコード
  */
 export const HTTP_STATUS = {

--- a/src/features/auth/otpLoginForm/hooks/useOtpLogin.ts
+++ b/src/features/auth/otpLoginForm/hooks/useOtpLogin.ts
@@ -10,6 +10,7 @@ import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 
+import { API_ENDPOINTS } from '@/constants';
 import { OTP_ACTION } from '@/constants/otp';
 import {
   AUTH_ERROR_MESSAGES,
@@ -45,7 +46,7 @@ export function useOtpLogin(): UseOtpLoginReturn {
     setApiError(null);
 
     try {
-      const response = await fetch('/api/auth/otp/send', {
+      const response = await fetch(API_ENDPOINTS.AUTH.OTP_SEND, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/features/auth/otpVerification/hooks/useOtpVerification.ts
+++ b/src/features/auth/otpVerification/hooks/useOtpVerification.ts
@@ -6,6 +6,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 
+import { API_ENDPOINTS } from '@/constants';
 import { OTP_CONFIG } from '@/constants/otp';
 import type { OtpAction } from '@/constants/otp';
 
@@ -70,7 +71,7 @@ export function useOtpVerification({
       setApiError(null);
 
       try {
-        const response = await fetch('/api/auth/otp/verify', {
+        const response = await fetch(API_ENDPOINTS.AUTH.OTP_VERIFY, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, code, action }),
@@ -102,7 +103,7 @@ export function useOtpVerification({
     setApiError(null);
 
     try {
-      const response = await fetch('/api/auth/otp/send', {
+      const response = await fetch(API_ENDPOINTS.AUTH.OTP_SEND, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, action }),

--- a/src/features/movies/component/videoDialog/videoDialog.tsx
+++ b/src/features/movies/component/videoDialog/videoDialog.tsx
@@ -9,6 +9,7 @@ import { memo, useMemo } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { IoCloseOutline } from 'react-icons/io5';
 
+import { EXTERNAL_URLS } from '@/constants';
 import type { Video } from '@/lib/types';
 
 import styles from './videoDialog.module.scss';
@@ -79,7 +80,7 @@ export const VideoDialog = memo<VideoDialogProps>(function VideoDialog({
               <div key={video.id} className={styles.c_video_dialog__item}>
                 <div className={styles.c_video_dialog__video_wrapper}>
                   <iframe
-                    src={`https://www.youtube.com/embed/${encodeURIComponent(video.key)}`}
+                    src={`${EXTERNAL_URLS.YOUTUBE_EMBED}${encodeURIComponent(video.key)}`}
                     title={video.name}
                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
                     allowFullScreen

--- a/src/features/search/hooks/useMovieFilter.ts
+++ b/src/features/search/hooks/useMovieFilter.ts
@@ -8,6 +8,8 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 
+import { QUERY_PARAMS } from '@/constants';
+
 /**
  * フィルターオプションの型
  */
@@ -38,9 +40,9 @@ export interface UseMovieFilterReturn {
  * URLパラメータからフィルター状態を読み取る
  */
 function parseFiltersFromParams(searchParams: URLSearchParams): FilterOptions {
-  const genreParam = searchParams.get('genre');
-  const yearParam = searchParams.get('year');
-  const voteParam = searchParams.get('vote_average_gte');
+  const genreParam = searchParams.get(QUERY_PARAMS.GENRE);
+  const yearParam = searchParams.get(QUERY_PARAMS.YEAR);
+  const voteParam = searchParams.get(QUERY_PARAMS.VOTE_AVERAGE_GTE);
 
   return {
     genre: genreParam
@@ -64,27 +66,27 @@ function buildSearchParamsFromFilters(
   const params = new URLSearchParams(currentParams.toString());
 
   // ページをリセット
-  params.delete('page');
+  params.delete(QUERY_PARAMS.PAGE);
 
   // ジャンル
   if (filters.genre && filters.genre.length > 0) {
-    params.set('genre', filters.genre.join(','));
+    params.set(QUERY_PARAMS.GENRE, filters.genre.join(','));
   } else {
-    params.delete('genre');
+    params.delete(QUERY_PARAMS.GENRE);
   }
 
   // 公開年
   if (filters.year !== undefined) {
-    params.set('year', String(filters.year));
+    params.set(QUERY_PARAMS.YEAR, String(filters.year));
   } else {
-    params.delete('year');
+    params.delete(QUERY_PARAMS.YEAR);
   }
 
   // 最低評価
   if (filters.vote_average_gte !== undefined) {
-    params.set('vote_average_gte', String(filters.vote_average_gte));
+    params.set(QUERY_PARAMS.VOTE_AVERAGE_GTE, String(filters.vote_average_gte));
   } else {
-    params.delete('vote_average_gte');
+    params.delete(QUERY_PARAMS.VOTE_AVERAGE_GTE);
   }
 
   return params;
@@ -120,10 +122,10 @@ export function useMovieFilter(): UseMovieFilterReturn {
 
   const handleFilterClear = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
-    params.delete('genre');
-    params.delete('year');
-    params.delete('vote_average_gte');
-    params.delete('page');
+    params.delete(QUERY_PARAMS.GENRE);
+    params.delete(QUERY_PARAMS.YEAR);
+    params.delete(QUERY_PARAMS.VOTE_AVERAGE_GTE);
+    params.delete(QUERY_PARAMS.PAGE);
     router.push(`/search?${params.toString()}`);
   }, [searchParams, router]);
 

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -2,7 +2,7 @@
  * 画像URLユーティリティ
  */
 
-import { API } from '@/constants';
+import { API, EXTERNAL_URLS } from '@/constants';
 
 // 画像サイズ型定義
 export type TMDbImageSize =
@@ -101,5 +101,5 @@ export function getPlaceholderImageUrl(
   text?: string,
 ): string {
   const displayText = text || `${width}x${height}`;
-  return `https://placehold.co/${width}x${height}?text=${encodeURIComponent(displayText)}`;
+  return `${EXTERNAL_URLS.PLACEHOLDER_IMAGE}/${width}x${height}?text=${encodeURIComponent(displayText)}`;
 }


### PR DESCRIPTION
## 概要
ハードコードされた内部APIエンドポイント・外部URL・URLパラメータキーを定数化。

- `API_ENDPOINTS` — OTP送信/検証の内部APIパス
- `EXTERNAL_URLS` — YouTube埋め込み・プレースホルダー画像URL
- `ASSET_PATHS` — TMDbロゴなどの公開アセットパス
- `QUERY_PARAMS` — 検索フィルター用URLパラメータキー（page, genre, year, vote_average_gte）

## レビューポイント
- `src/constants/common.ts` に4つの定数オブジェクトを追加

## テスト
- 全1817テスト通過
- TypeScript型チェック通過

Closes #221