### PR TITLE
refactor: 内部APIエンドポイント・外部URLを定数化

### DIFF
--- a/src/components/layout/footer/footer.tsx
+++ b/src/components/layout/footer/footer.tsx
@@ -8,7 +8,7 @@ import { type HTMLAttributes, type ReactNode, memo } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { IMAGE_SIZES } from '@/constants';
+import { IMAGE_SIZES, ASSET_PATHS } from '@/constants';
 import { cn } from '@/utils/cn';
 
 import styles from './footer.module.scss';
@@ -76,7 +76,7 @@ export const Footer = memo<FooterProps>(function Footer({
 
         <div className={styles.c_footer__attribution}>
           <Image
-            src='/tmdb-logo.svg'
+            src={ASSET_PATHS.TMDB_LOGO}
             alt='TMDB'
             width={IMAGE_SIZES.TMDB_LOGO.WIDTH}
             height={IMAGE_SIZES.TMDB_LOGO.HEIGHT}

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -1,0 +1,10 @@
+/**
+ * 内部APIエンドポイント定数
+ */
+
+export const API_ENDPOINTS = {
+  /** OTP検証 */
+  OTP_VERIFY: '/api/auth/otp/verify',
+  /** OTP送信 */
+  OTP_SEND: '/api/auth/otp/send',
+} as const;

--- a/src/constants/external.ts
+++ b/src/constants/external.ts
@@ -1,0 +1,15 @@
+/**
+ * 外部URL・アセットパス定数
+ */
+
+export const EXTERNAL_URLS = {
+  /** YouTube埋め込みベースURL */
+  YOUTUBE_EMBED: 'https://www.youtube.com/embed',
+  /** プレースホルダー画像ベースURL */
+  PLACEHOLDER_IMAGE: 'https://placehold.co',
+} as const;
+
+export const ASSET_PATHS = {
+  /** TMDBロゴ */
+  TMDB_LOGO: '/tmdb-logo.svg',
+} as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,3 +25,6 @@ export * from './cron';
 export * from './navigation';
 export * from './ui';
 export * from './strings';
+export * from './apiEndpoints';
+export * from './external';
+export * from './queryParams';

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -1,0 +1,14 @@
+/**
+ * URLクエリパラメータキー定数
+ */
+
+export const QUERY_PARAMS = {
+  /** ページ番号 */
+  PAGE: 'page',
+  /** ジャンル */
+  GENRE: 'genre',
+  /** 公開年 */
+  YEAR: 'year',
+  /** 最低評価 */
+  VOTE_AVERAGE_GTE: 'vote_average_gte',
+} as const;

--- a/src/features/auth/otpVerification/hooks/useOtpVerification.ts
+++ b/src/features/auth/otpVerification/hooks/useOtpVerification.ts
@@ -8,7 +8,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { OTP_CONFIG } from '@/constants/otp';
 import type { OtpAction } from '@/constants/otp';
-import { UI_ERROR_MESSAGES } from '@/constants';
+import { UI_ERROR_MESSAGES, API_ENDPOINTS } from '@/constants';
 
 interface UseOtpVerificationProps {
   email: string;
@@ -71,7 +71,7 @@ export function useOtpVerification({
       setApiError(null);
 
       try {
-        const response = await fetch('/api/auth/otp/verify', {
+        const response = await fetch(API_ENDPOINTS.OTP_VERIFY, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, code, action }),
@@ -105,7 +105,7 @@ export function useOtpVerification({
     setApiError(null);
 
     try {
-      const response = await fetch('/api/auth/otp/send', {
+      const response = await fetch(API_ENDPOINTS.OTP_SEND, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, action }),

--- a/src/features/movies/component/videoDialog/videoDialog.tsx
+++ b/src/features/movies/component/videoDialog/videoDialog.tsx
@@ -9,7 +9,7 @@ import { memo, useMemo } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { IoCloseOutline } from 'react-icons/io5';
 
-import { ICON_SIZES, ARIA_LABELS } from '@/constants';
+import { ICON_SIZES, ARIA_LABELS, EXTERNAL_URLS } from '@/constants';
 import type { Video } from '@/lib/types';
 
 import styles from './videoDialog.module.scss';
@@ -82,7 +82,7 @@ export const VideoDialog = memo<VideoDialogProps>(function VideoDialog({
               <div key={video.id} className={styles.c_video_dialog__item}>
                 <div className={styles.c_video_dialog__video_wrapper}>
                   <iframe
-                    src={`https://www.youtube.com/embed/${encodeURIComponent(video.key)}`}
+                    src={`${EXTERNAL_URLS.YOUTUBE_EMBED}/${encodeURIComponent(video.key)}`}
                     title={video.name}
                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
                     allowFullScreen

--- a/src/features/search/hooks/useMovieFilter.ts
+++ b/src/features/search/hooks/useMovieFilter.ts
@@ -8,6 +8,8 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 
+import { QUERY_PARAMS } from '@/constants';
+
 /**
  * フィルターオプションの型
  */
@@ -38,9 +40,9 @@ export interface UseMovieFilterReturn {
  * URLパラメータからフィルター状態を読み取る
  */
 function parseFiltersFromParams(searchParams: URLSearchParams): FilterOptions {
-  const genreParam = searchParams.get('genre');
-  const yearParam = searchParams.get('year');
-  const voteParam = searchParams.get('vote_average_gte');
+  const genreParam = searchParams.get(QUERY_PARAMS.GENRE);
+  const yearParam = searchParams.get(QUERY_PARAMS.YEAR);
+  const voteParam = searchParams.get(QUERY_PARAMS.VOTE_AVERAGE_GTE);
 
   return {
     genre: genreParam
@@ -64,27 +66,27 @@ function buildSearchParamsFromFilters(
   const params = new URLSearchParams(currentParams.toString());
 
   // ページをリセット
-  params.delete('page');
+  params.delete(QUERY_PARAMS.PAGE);
 
   // ジャンル
   if (filters.genre && filters.genre.length > 0) {
-    params.set('genre', filters.genre.join(','));
+    params.set(QUERY_PARAMS.GENRE, filters.genre.join(','));
   } else {
-    params.delete('genre');
+    params.delete(QUERY_PARAMS.GENRE);
   }
 
   // 公開年
   if (filters.year !== undefined) {
-    params.set('year', String(filters.year));
+    params.set(QUERY_PARAMS.YEAR, String(filters.year));
   } else {
-    params.delete('year');
+    params.delete(QUERY_PARAMS.YEAR);
   }
 
   // 最低評価
   if (filters.vote_average_gte !== undefined) {
-    params.set('vote_average_gte', String(filters.vote_average_gte));
+    params.set(QUERY_PARAMS.VOTE_AVERAGE_GTE, String(filters.vote_average_gte));
   } else {
-    params.delete('vote_average_gte');
+    params.delete(QUERY_PARAMS.VOTE_AVERAGE_GTE);
   }
 
   return params;
@@ -120,10 +122,10 @@ export function useMovieFilter(): UseMovieFilterReturn {
 
   const handleFilterClear = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
-    params.delete('genre');
-    params.delete('year');
-    params.delete('vote_average_gte');
-    params.delete('page');
+    params.delete(QUERY_PARAMS.GENRE);
+    params.delete(QUERY_PARAMS.YEAR);
+    params.delete(QUERY_PARAMS.VOTE_AVERAGE_GTE);
+    params.delete(QUERY_PARAMS.PAGE);
     router.push(`/search?${params.toString()}`);
   }, [searchParams, router]);
 

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -2,7 +2,7 @@
  * 画像URLユーティリティ
  */
 
-import { API } from '@/constants';
+import { API, EXTERNAL_URLS } from '@/constants';
 
 // 画像サイズ型定義
 export type TMDbImageSize =
@@ -101,5 +101,5 @@ export function getPlaceholderImageUrl(
   text?: string,
 ): string {
   const displayText = text || `${width}x${height}`;
-  return `https://placehold.co/${width}x${height}?text=${encodeURIComponent(displayText)}`;
+  return `${EXTERNAL_URLS.PLACEHOLDER_IMAGE}/${width}x${height}?text=${encodeURIComponent(displayText)}`;
 }


### PR DESCRIPTION
## 概要
- 内部APIエンドポイントを`src/constants/apiEndpoints.ts`に集約（OTP verify/send）
- 外部URL（YouTube埋め込み、プレースホルダー画像）とアセットパスを`src/constants/external.ts`に集約
- URLクエリパラメータキーを`src/constants/queryParams.ts`に集約

Closes #221

## ロードマップ
- [x] 内部APIエンドポイント・外部URLを定数化

## レビューポイント
- 定数ファイルの分割方針（apiEndpoints / external / queryParams）
- `EXTERNAL_URLS`と`ASSET_PATHS`の分離

## テスト
- [x] TypeScript型チェック通過
- [x] 全175テストスイート・1817テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)