### PR TITLE
refactor: レコメンドセクションのMovieTileの高さを揃える

### DIFF
--- a/src/components/ui/movie/movieTile/movieTile.module.scss
+++ b/src/components/ui/movie/movieTile/movieTile.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  height: 100%;
   border-radius: $border-radius-lg;
   transition: $transition-all;
 

--- a/src/features/recommendations/component/recommendationSection/recommendationSection.module.scss
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.module.scss
@@ -49,6 +49,7 @@
   &__item {
     display: flex;
     flex-direction: column;
+    height: 100%;
 
     > :first-child {
       flex: 1;
@@ -60,6 +61,7 @@
     font-size: $font-size-xs;
     line-height: $line-height-normal;
     color: $text-secondary;
+    min-height: calc($font-size-xs * $line-height-normal * 2);
     @include text-truncate-multiline(2);
   }
 }


### PR DESCRIPTION
## 概要
- レコメンドセクションのグリッドアイテムに`height: 100%`を追加し、タイルの高さを統一
- MovieTile（`.c_movie_tile`）に`height: 100%`を追加し、親コンテナの高さに合わせる
- reason（レコメンド理由）テキストに`min-height`を設定し、行数差によるばらつきを解消

Closes #244

## ロードマップ
- [x] レコメンドセクションのMovieTileの高さを揃える

## レビューポイント
- reasonの`min-height`は2行分を確保（`calc($font-size-xs * $line-height-normal * 2)`）
- MovieTileの`height: 100%`追加が他のグリッド（公開予定、現在上映中など）に副作用がないか確認

## テスト
- [x] TypeScript型チェック通過
- [x] 全175テストスイート・1817テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)