### PR TITLE
fix: CSPのfont-srcにdata:を追加（fciconsフォント対応）

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -68,7 +68,9 @@ const nextConfig = {
               "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' https://image.tmdb.org data: blob:",
-              "font-src 'self'",
+              // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
+              // base64エンコードした data: URI で読み込むために必要
+              "font-src 'self' data:",
               "connect-src 'self' https://*.supabase.co",
               'frame-src https://www.youtube.com',
               "frame-ancestors 'none'",


### PR DESCRIPTION
## 概要
- CSPの`font-src`ディレクティブに`data:`を追加し、`@fullcalendar/core`のアイコンフォント(fcicons)読み込みのCSP違反を解消

## ロードマップ
- N/A（セキュリティバグ修正）

## レビューポイント
- `@fullcalendar/core`はアイコンフォント(fcicons)をbase64エンコードしたdata: URI形式で内部的に読み込んでおり、ライブラリ側の変更は不可能なため`data:`の許可で対応
- `data:`は外部サーバーへの接続を伴わないため、セキュリティリスクは限定的

## テスト
- [ ] アプリ起動後、DevToolsコンソールにCSP違反エラーが表示されないことを確認
- [ ] FullCalendar（公開カレンダー）のアイコン（ナビゲーション矢印等）が正常に表示されることを確認

Closes #258