### PR TITLE
fix: Auth.js debug-enabled警告の抑制

### DIFF
--- a/.claude/documents/environment-variables.md
+++ b/.claude/documents/environment-variables.md
@@ -62,8 +62,8 @@ NEXTAUTH_SECRET=your_nextauth_secret_here_minimum_32_chars
 # NextAuth.js URL（本番環境で必須）
 NEXTAUTH_URL=http://localhost:3000  # 本番: https://yourdomain.com
 
-# NextAuth.js Debug Mode（開発時のみ）
-NEXTAUTH_DEBUG=true  # 本番環境ではfalse
+# Auth.js Debug Mode（明示的に有効化する場合のみ）
+AUTH_DEBUG=true  # デフォルトはfalse、デバッグ時のみ有効化
 ```
 
 **Cookie設定（NextAuth.js設定ファイルで実装）:**

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -428,6 +428,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
 
-  // デバッグモード（開発環境のみ）
-  debug: process.env.NODE_ENV === 'development',
+  // デバッグモード（AUTH_DEBUG=true で明示的に有効化）
+  debug: process.env.AUTH_DEBUG === 'true',
 });


### PR DESCRIPTION
## 概要
- Auth.jsの`debug-enabled`警告を環境変数`AUTH_DEBUG`で制御するよう変更
- `AUTH_DEBUG=true`を明示的に設定した場合のみデバッグモードが有効化される方式に変更

Closes #218

## ロードマップ
- 該当なし（バグ修正）

## レビューポイント
- `src/lib/auth/auth.ts`: `debug`の判定を`process.env.AUTH_DEBUG === 'true'`に変更
- `.claude/documents/environment-variables.md`: 環境変数ドキュメントを`AUTH_DEBUG`に更新

## テスト
- `AUTH_DEBUG`未設定 → デバッグ警告が表示されないことを確認
- `AUTH_DEBUG=true`設定 → デバッグモードが有効になることを確認