### PR TITLE
fix: ジャンル名上書きマップを共通化し検索フィルターにも適用

### DIFF
--- a/src/app/api/movies/genres/route.ts
+++ b/src/app/api/movies/genres/route.ts
@@ -6,11 +6,20 @@
 import { NextResponse } from 'next/server';
 
 import { getGenres } from '@/lib/tmdb/tmdb';
-import { HTTP_STATUS, ERROR_CODE, SEARCH_ERROR_MESSAGES } from '@/constants';
+import {
+  HTTP_STATUS,
+  ERROR_CODE,
+  SEARCH_ERROR_MESSAGES,
+  GENRE_NAME_OVERRIDES,
+} from '@/constants';
 
 export async function GET() {
   try {
-    const genres: { id: number; name: string }[] = await getGenres();
+    const rawGenres: { id: number; name: string }[] = await getGenres();
+    const genres = rawGenres.map((genre) => ({
+      ...genre,
+      name: GENRE_NAME_OVERRIDES[genre.name] ?? genre.name,
+    }));
 
     return NextResponse.json(
       {

--- a/src/app/api/movies/route.ts
+++ b/src/app/api/movies/route.ts
@@ -29,6 +29,7 @@ import {
   ERROR_CODE,
   GENRE_CACHE_DURATION_MS,
   DISCOVER_API_MAX_PAGES,
+  GENRE_NAME_OVERRIDES,
 } from '@/constants';
 import { discoverMovies, getGenres } from '@/lib/tmdb/tmdb';
 import { syncNowPlayingMovies } from '@/lib/sync/syncNowPlayingMovies';
@@ -57,13 +58,6 @@ function formatDateToString(date: Date): string {
  */
 let genreCache: { data: Record<number, string>; cachedAt: number } | null =
   null;
-
-/** TMDb日本語訳の誤訳を自然な日本語に上書きするマップ */
-const GENRE_NAME_OVERRIDES: Record<string, string> = {
-  履歴: '歴史',
-  謎: 'ミステリー',
-  西洋: '西部劇',
-};
 
 /**
  * ジャンルマップを取得（キャッシュ付き）

--- a/src/constants/tmdb.ts
+++ b/src/constants/tmdb.ts
@@ -13,3 +13,10 @@ export const TMDB_RETRY_CONFIG = {
   /** リトライ対象のHTTPステータスコード */
   RETRYABLE_STATUS_CODES: [429, 503, 504] as readonly number[],
 } as const;
+
+/** TMDb日本語訳の誤訳を自然な日本語に上書きするマップ */
+export const GENRE_NAME_OVERRIDES: Record<string, string> = {
+  履歴: '歴史',
+  謎: 'ミステリー',
+  西洋: '西部劇',
+};


### PR DESCRIPTION
## 概要
公開予定ページと検索結果ページでジャンル名の表記が不一致だった問題を修正。

- `GENRE_NAME_OVERRIDES`（履歴→歴史、謎→ミステリー、西洋→西部劇）を `/constants/tmdb.ts` に共通定数として抽出
- `/api/movies/route.ts` のローカル定義を共通定数の参照に置き換え
- `/api/movies/genres/route.ts` にも同じ上書きマップを適用

Closes #198

## ロードマップ
- N/A（バグ修正）

## レビューポイント
- `GENRE_NAME_OVERRIDES` の配置場所が `constants/tmdb.ts` で適切か
- `/api/movies/genres/route.ts` での適用方法（`map` でコピー生成）

## テスト
- `npm run build` 成功確認済み
- 全テスト（1816件）合格確認済み