### PR TITLE
fix: カレンダーE2Eテストのflaky対策

### DIFF
--- a/e2e/calendar/calendar.spec.ts
+++ b/e2e/calendar/calendar.spec.ts
@@ -11,7 +11,9 @@ import { test, expect } from '../fixtures/auth';
 test.describe('カレンダー', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page
+      .getByRole('button', { name: '公開カレンダーを開く' })
+      .waitFor({ timeout: 30000 });
   });
 
   test('サイドバーのカレンダーボタンクリックでダイアログが表示される', async ({


### PR DESCRIPTION
## 概要
カレンダーE2Eテストの `waitForLoadState('networkidle')` をイベント駆動待機に切り替え。

Closes #283

## 変更内容
- `beforeEach` の `waitForLoadState('networkidle')` → カレンダーボタンの `waitFor` に変更
- #274 の修正パターンに準拠

## レビューポイント
- カレンダーボタンの待機で十分か（他テストと同パターン）

## テスト
- CI E2Eで確認