### PR TITLE
fix: award_movies.display_order に CHECK 制約を追加

### DIFF
--- a/supabase/migrations/20260322000001_add_display_order_check.sql
+++ b/supabase/migrations/20260322000001_add_display_order_check.sql
@@ -1,0 +1,6 @@
+-- ============================================
+-- award_movies.display_order に CHECK 制約を追加
+-- ============================================
+
+ALTER TABLE award_movies
+  ADD CONSTRAINT chk_award_movies_display_order CHECK (display_order >= 0);


### PR DESCRIPTION
## 概要
`award_movies.display_order` に `CHECK (display_order >= 0)` 制約を追加。
PR #282 のレビュー指摘（#4）への対応。

## レビューポイント
- 既存のマイグレーションは変更せず、新規マイグレーションで `ALTER TABLE ADD CONSTRAINT` を実行

## テスト
- マイグレーション適用で制約が追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)