### PR TITLE
feat: 受賞作品ページにカテゴリナビゲーション追加

### DIFF
--- a/src/features/awards/awardCategorySection/awardCategorySection.test.tsx
+++ b/src/features/awards/awardCategorySection/awardCategorySection.test.tsx
@@ -53,6 +53,7 @@ const createMockCategory = (
 });
 
 const defaultProps = {
+  awardName: 'academy_awards',
   onMovieClick: jest.fn(),
   isInWatchlist: jest.fn().mockReturnValue(false),
   onWatchlistToggle: jest.fn(),

--- a/src/features/awards/awardCategorySection/awardCategorySection.tsx
+++ b/src/features/awards/awardCategorySection/awardCategorySection.tsx
@@ -17,6 +17,7 @@ import styles from './awardCategorySection.module.scss';
 
 export interface AwardCategorySectionProps {
   category: AwardCategoryData;
+  awardName: string;
   onMovieClick: (movieId: number) => void;
   isInWatchlist: (tmdbMovieId: number) => boolean;
   onWatchlistToggle: (movie: MovieCacheItem) => void;
@@ -31,6 +32,7 @@ export interface AwardCategorySectionProps {
 export const AwardCategorySection = memo<AwardCategorySectionProps>(
   function AwardCategorySection({
     category,
+    awardName,
     onMovieClick,
     isInWatchlist,
     onWatchlistToggle,
@@ -67,7 +69,10 @@ export const AwardCategorySection = memo<AwardCategorySectionProps>(
     }, [category.nominees]);
 
     return (
-      <div id={`category-${category.category}`} className={styles.c_award_category}>
+      <div
+        id={`category-${awardName}-${category.category}`}
+        className={styles.c_award_category}
+      >
         <h3 className={styles.c_award_category__title}>{category.label}</h3>
 
         {winnerCacheItem && (

--- a/src/features/awards/awardSection/awardSection.module.scss
+++ b/src/features/awards/awardSection/awardSection.module.scss
@@ -25,7 +25,8 @@
     border-radius: $border-radius-full;
     cursor: pointer;
     box-shadow: $shadow-sm;
-    transition: background-color $transition-duration-base,
+    transition:
+      background-color $transition-duration-base,
       box-shadow $transition-duration-base;
 
     &::after {

--- a/src/features/awards/awardSection/awardSection.test.tsx
+++ b/src/features/awards/awardSection/awardSection.test.tsx
@@ -11,10 +11,17 @@ jest.mock(
   () => ({
     AwardCategorySection: ({
       category,
+      awardName,
     }: {
       category: { category: string; label: string };
+      awardName: string;
     }) => (
-      <div data-testid={`category-${category.category}`}>{category.label}</div>
+      <div
+        data-testid={`category-${category.category}`}
+        id={`category-${awardName}-${category.category}`}
+      >
+        {category.label}
+      </div>
     ),
   }),
 );
@@ -106,12 +113,8 @@ describe('AwardSection', () => {
       name: 'アカデミー賞カテゴリナビゲーション',
     });
     expect(nav).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: '作品賞' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: '監督賞' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '作品賞' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '監督賞' })).toBeInTheDocument();
   });
 
   it('ナビゲーションボタンをクリックするとscrollIntoViewが呼ばれる', async () => {
@@ -121,9 +124,11 @@ describe('AwardSection', () => {
 
     render(<AwardSection award={award} {...defaultProps} />);
 
-    const targetElement = screen.getByTestId('category-best_director');
-    targetElement.id = 'category-best_director';
-    targetElement.scrollIntoView = mockScrollIntoView;
+    const targetElement = document.getElementById(
+      'category-academy_awards-best_director',
+    );
+    expect(targetElement).not.toBeNull();
+    targetElement!.scrollIntoView = mockScrollIntoView;
 
     await user.click(screen.getByRole('button', { name: '監督賞' }));
 

--- a/src/features/awards/awardSection/awardSection.tsx
+++ b/src/features/awards/awardSection/awardSection.tsx
@@ -37,15 +37,20 @@ export const AwardSection = memo<AwardSectionProps>(function AwardSection({
   isFavoriteProcessing,
 }) {
   const handleCategoryClick = useCallback(
-    (categoryKey: string) => {
-      const element = document.getElementById(`category-${categoryKey}`);
-      element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      const categoryKey = e.currentTarget.dataset.category;
+      if (categoryKey) {
+        document
+          .getElementById(`category-${award.awardName}-${categoryKey}`)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     },
-    [],
+    [award.awardName],
   );
 
   return (
     <section className={styles.c_award_section} aria-label={award.label}>
+      <h2 className={styles.c_award_section__title}>{award.label}</h2>
       <nav
         className={styles.c_award_section__nav}
         aria-label={`${award.label}カテゴリナビゲーション`}
@@ -55,18 +60,19 @@ export const AwardSection = memo<AwardSectionProps>(function AwardSection({
             key={category.category}
             type='button'
             className={styles.c_award_section__nav_button}
-            onClick={() => handleCategoryClick(category.category)}
+            data-category={category.category}
+            onClick={handleCategoryClick}
           >
             {category.label}
           </button>
         ))}
       </nav>
-      <h2 className={styles.c_award_section__title}>{award.label}</h2>
       <div className={styles.c_award_section__categories}>
         {award.categories.map((category) => (
           <AwardCategorySection
             key={category.category}
             category={category}
+            awardName={award.awardName}
             onMovieClick={onMovieClick}
             isInWatchlist={isInWatchlist}
             onWatchlistToggle={onWatchlistToggle}

--- a/src/features/awards/awardsPage/awardsPage.test.tsx
+++ b/src/features/awards/awardsPage/awardsPage.test.tsx
@@ -233,7 +233,7 @@ describe('AwardsPage', () => {
     render(<AwardsPage />);
 
     expect(screen.getByText('アカデミー賞')).toBeInTheDocument();
-    expect(screen.getByText('作品賞')).toBeInTheDocument();
+    expect(screen.getAllByText('作品賞').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('受賞映画')).toBeInTheDocument();
     expect(screen.getByText('ノミネート映画')).toBeInTheDocument();
   });


### PR DESCRIPTION
## 概要
- 受賞作品ページにカテゴリナビゲーション（アンカーボタン）を追加
- 各カテゴリセクションにid属性を付与し、スムーズスクロールで移動可能に
- ボタンは白背景 + ボーダー + 影 + 下矢印のチップスタイル

Closes #298

## ロードマップ
- なし（UI改善タスク）

## レビューポイント
- ナビゲーションボタンのデザイン・配置
- アクセシビリティ（`nav`要素 + `aria-label`）
- スムーズスクロールの動作

## テスト
- ナビゲーション表示テスト追加
- scrollIntoView呼び出しテスト追加
- カバレッジ100%維持