### PR TITLE
fix: 受賞作品の人名表示から省略を削除

### DIFF
--- a/src/features/awards/awardCategorySection/awardCategorySection.module.scss
+++ b/src/features/awards/awardCategorySection/awardCategorySection.module.scss
@@ -84,6 +84,5 @@
     font-size: $font-size-xs;
     line-height: $line-height-normal;
     color: $text-secondary;
-    @include text-truncate-multiline(1);
   }
 }


### PR DESCRIPTION
## 概要
- 受賞作品ページのカテゴリセクションで、人名（personName）が `text-truncate-multiline(1)` により1行で省略されていた問題を修正
- mixinを削除し、人名が全文表示されるようにした

## ロードマップ
- 受賞作品ページUI改善（人名省略修正）

## レビューポイント
- `awardCategorySection.module.scss` の `__person_name` から `@include text-truncate-multiline(1)` を削除しただけのシンプルな変更

## テスト
- [x] 既存テスト全10件パス確認

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)