### PR TITLE
setup: Supabase Data API GRANT付与ルールを追加

### DIFF
--- a/.claude/rules/supabase-db.md
+++ b/.claude/rules/supabase-db.md
@@ -23,3 +23,22 @@ globs:
 
 - スキーマ変更後は `supabase gen types typescript --project-id <project-id> > src/types/database.types.ts` で型定義を再生成する
 - 型定義ファイルは手動で編集しない（常に自動生成で上書き）
+
+## 【必須】Data API公開のためのGRANT付与
+
+> 背景: Supabaseの仕様変更により、2026/05/30以降の新規プロジェクトと2026/10/30以降の既存プロジェクトでは、`public` スキーマで作成したテーブルがData API（supabase-js / PostgREST / GraphQL）にデフォルトで公開されなくなる。明示的な `GRANT` が無い場合、PostgRESTは `42501` エラーを返す。
+
+- 新規テーブル作成マイグレーションでは、`CREATE TABLE` 直後に必ず以下のGRANTを記述する（不要なロールへの付与は省く）
+- `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` と `CREATE POLICY` だけでは公開されない。GRANTが前提
+- 公開読み取り（マスターデータ等）は `anon` にもSELECTを付与する。ユーザー固有データなら `authenticated` のみで十分
+- `service_role` は管理用ロールなので、サーバー側からアクセスするテーブルには付与する
+
+```sql
+-- 例1: ユーザー固有データ（認証必須）
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<table_name> TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<table_name> TO service_role;
+
+-- 例2: 公開マスターデータ（未認証含む全員が閲覧可能）
+GRANT SELECT ON public.<table_name> TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.<table_name> TO service_role;
+```

--- a/.claude/skills/db-schema/SKILL.md
+++ b/.claude/skills/db-schema/SKILL.md
@@ -14,6 +14,7 @@ argument-hint: <tableName>
 ### アーキテクチャ原則
 
 - **Row Level Security (RLS)**: すべてのテーブルで必須
+- **GRANT付与**: Data API（supabase-js / PostgREST / GraphQL）公開のため必須（2026/10/30以降の既存プロジェクトに適用される仕様変更対応）
 - **UUID主キー**: `gen_random_uuid()`を使用
 - **タイムスタンプ**: `created_at`, `updated_at`を必ず含める
 - **論理削除**: ユーザーデータは`deleted_at`で論理削除
@@ -72,6 +73,31 @@ BEGIN
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+```
+
+## Data API公開のためのGRANT付与
+
+> 2026/05/30以降の新規Supabaseプロジェクト、2026/10/30以降の既存プロジェクトでは、`public` スキーマで作成したテーブルはGRANTを明示しないとData API（supabase-js / PostgREST / GraphQL）からアクセスできない。RLSとは別に、必ずGRANTも付与する。
+
+### パターンA: ユーザー固有データ（認証必須）
+
+```sql
+GRANT SELECT, INSERT, UPDATE, DELETE ON <table_name> TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <table_name> TO service_role;
+```
+
+### パターンB: 公開データ（未認証含む全員が閲覧可能）
+
+```sql
+GRANT SELECT ON <table_name> TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <table_name> TO service_role;
+```
+
+### パターンC: マスターデータ（読み取り専用、サーバー側のみ書き込み）
+
+```sql
+GRANT SELECT ON <table_name> TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <table_name> TO service_role;
 ```
 
 ## Row Level Security (RLS) ポリシー
@@ -271,6 +297,10 @@ CREATE TRIGGER set_updated_at
   BEFORE UPDATE ON watchlist
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
+
+-- Data API GRANT（パターンA: ユーザー固有データ）
+GRANT SELECT, INSERT, UPDATE, DELETE ON watchlist TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON watchlist TO service_role;
 
 -- RLS Policies
 ALTER TABLE watchlist ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## 概要

Supabaseの仕様変更（2026/10/30以降、既存プロジェクトの `public` スキーマ新規テーブルが Data API にデフォルト公開されなくなる）に対応するため、新規テーブル作成マイグレーションで `GRANT` を必須化するルールと、`/db-schema` スキルへのGRANTテンプレートを追加。

既存テーブル（39マイグレーション分）は現状の権限を保持するため影響なし。今後の新規テーブル作成時の漏れを防ぐためのルール整備。

Closes #343

## ロードマップ

ロードマップ外の改善対応（運用ルール整備）。

## レビューポイント

- `.claude/rules/supabase-db.md`: GRANTパターンが3ロール（anon / authenticated / service_role）の役割を正しく分けているか
- `.claude/skills/db-schema/SKILL.md`: マイグレーション例（watchlistテーブル）に組み込まれたGRANT文がパターンA（ユーザー固有データ）として適切か
- 公開マスターデータ用パターンBで `anon` にもSELECT付与する判断（未認証ユーザーに見せたいデータがある場合に必要）

## テスト

- ドキュメント変更のためテストなし
- 動作確認: 次回の新規テーブル作成マイグレーションで `/db-schema` を実行し、GRANT文が出力されることを確認する（フォローアップ）