### PR TITLE
setup: Gemini PR Reviewer workflow追加

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Gemini AI Code Reviewer
-        uses: truongnh1992/gemini-ai-code-reviewer@7c4b01afa073e48a44c72cdc1d010f9e3b95686f  # v9.2.1
+        uses: truongnh1992/gemini-ai-code-reviewer@7c4b01afa073e48a44c72cdc1d010f9e3b95686f # v9.2.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,31 @@
+name: Gemini PR Reviewer (Manual Trigger)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.author_association == 'OWNER' &&
+      (github.event.comment.body == '/gemini-review' || startsWith(github.event.comment.body, '/gemini-review '))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+
+      - name: Gemini AI Code Reviewer
+        uses: truongnh1992/gemini-ai-code-reviewer@7c4b01afa073e48a44c72cdc1d010f9e3b95686f  # v9.2.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_MODEL: gemini-2.5-flash


### PR DESCRIPTION
## 概要
PRコメントで `/gemini-review` と投稿すると Gemini AI がコードレビューを実行する GitHub Actions ワークフローを追加。

## ロードマップ
該当なし（運用ツール整備）

## レビューポイント
- **トリガー権限**: `author_association == 'OWNER'` でリポジトリ所有者のみ起動可能（外部からの不正起動による API クレジット消費対策）
- **トリガー条件の厳密性**: `/gemini-review` の完全一致または `/gemini-review ` プレフィックスのみ発火（`/gemini-reviewers` のような誤発火を防止）
- **third-party action の SHA 固定**: `truongnh1992/gemini-ai-code-reviewer@7c4b01afa073e48a44c72cdc1d010f9e3b95686f` (v9.2.1) でピン留め。タグ付け替えによるサプライチェーン攻撃対策
- **必要な Secret**: `GEMINI_API_KEY` を Repository Secrets に登録する必要あり

## テスト
- [ ] `GEMINI_API_KEY` を Repository Secrets に登録
- [ ] このPRに `/gemini-review` とコメントしてワークフローが起動することを確認
- [ ] OWNER 以外（例: bot や外部 contributor）のコメントでは起動しないことを確認
- [ ] `/gemini-reviewers` のような類似文字列で誤発火しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)