### PR TITLE
setup: Gemini Reviewer workflowにenvironment指定追加

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -11,6 +11,7 @@ jobs:
       github.event.comment.author_association == 'OWNER' &&
       (github.event.comment.body == '/gemini-review' || startsWith(github.event.comment.body, '/gemini-review '))
     runs-on: ubuntu-latest
+    environment: Production
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
## 概要
Gemini PR Reviewer workflow が Environment Secrets 配下の `GEMINI_API_KEY` を読み込めるよう、job に `environment: Production` を追加。

## ロードマップ
該当なし（運用ツール整備）

## 背景
PR #347 で `/gemini-review` を実行したところ、Environment Secrets に登録された `GEMINI_API_KEY` が読み込まれず `Missing required environment variables: GEMINI_API_KEY` で失敗した。
他のワークフロー（`build.yml` / `e2e.yml`）と同様に `environment: Production` を指定することで解消する。

## レビューポイント
- `environment: Production` の指定追加のみ（1行）
- 他ワークフローと一貫した環境指定

## テスト
- [ ] このPRをマージ
- [ ] PR #347 に再度 `/gemini-review` とコメント
- [ ] Gemini Reviewer workflow が正常に起動し、レビューコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)