### PR TITLE
feat: Gemini AIレビューをrun-gemini-cli (Google公式) に移行

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,12 @@
 <details>
 <summary>🤖 AI レビューについて</summary>
 
-このPRに `/gemini-review` とコメントすると、Gemini AI による自動コードレビューが実行されます（OWNER のみ起動可能）。
+このPRに `@gemini-cli /review` とコメントすると、Gemini AI による自動コードレビューが実行されます（OWNER のみ起動可能）。
+
+その他のコマンド:
+
+- `@gemini-cli /review` - PRのコードレビュー
+- `@gemini-cli /triage` - 関連Issueの分類
+- `@gemini-cli <自由テキスト>` - 自由質問（例: `@gemini-cli この設計のリスクは？`）
 
 </details>

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,0 +1,152 @@
+name: '🔀 Gemini Dispatch'
+
+on:
+  issues:
+    types:
+      - 'opened'
+      - 'reopened'
+  issue_comment:
+    types:
+      - 'created'
+  pull_request_review_comment:
+    types:
+      - 'created'
+  pull_request_review:
+    types:
+      - 'submitted'
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  dispatch:
+    # OWNER のみ: コメントで @gemini-cli から始まる、または Issue 作成時のみ起動
+    if: |-
+      (
+        github.event_name == 'issues' &&
+        contains(fromJSON('["opened", "reopened"]'), github.event.action) &&
+        github.event.issue.author_association == 'OWNER'
+      ) || (
+        github.event.sender.type == 'User' &&
+        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
+        (github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association) == 'OWNER'
+      )
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      issues: 'write'
+      pull-requests: 'write'
+    outputs:
+      command: '${{ steps.extract_command.outputs.command }}'
+      request: '${{ steps.extract_command.outputs.request }}'
+      additional_context: '${{ steps.extract_command.outputs.additional_context }}'
+      issue_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
+    steps:
+      - name: 'Extract command'
+        id: 'extract_command'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        env:
+          EVENT_TYPE: '${{ github.event_name }}.${{ github.event.action }}'
+          REQUEST: '${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}'
+        with:
+          script: |
+            const eventType = process.env.EVENT_TYPE;
+            const request = process.env.REQUEST;
+            core.setOutput('request', request);
+
+            if (['issues.opened', 'issues.reopened'].includes(eventType)) {
+              core.setOutput('command', 'triage');
+            } else if (request.startsWith('@gemini-cli /review')) {
+              core.setOutput('command', 'review');
+              const additionalContext = request.replace(/^@gemini-cli \/review/, '').trim();
+              core.setOutput('additional_context', additionalContext);
+            } else if (request.startsWith('@gemini-cli /triage')) {
+              core.setOutput('command', 'triage');
+            } else if (request.startsWith('@gemini-cli')) {
+              const additionalContext = request.replace(/^@gemini-cli/, '').trim();
+              core.setOutput('command', 'invoke');
+              core.setOutput('additional_context', additionalContext);
+            } else {
+              core.setOutput('command', 'fallthrough');
+            }
+
+      - name: 'Acknowledge request'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN || github.token }}'
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          MESSAGE: |-
+            🤖 Hi @${{ github.actor }}, リクエストを受け付けました。実行ログは [こちら](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) で確認できます。
+          REPOSITORY: '${{ github.repository }}'
+        run: |-
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body "${MESSAGE}" \
+            --repo "${REPOSITORY}"
+
+  review:
+    needs: 'dispatch'
+    if: |-
+      ${{ needs.dispatch.outputs.command == 'review' }}
+    uses: './.github/workflows/gemini-review.yml'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+    with:
+      additional_context: '${{ needs.dispatch.outputs.additional_context }}'
+    secrets: 'inherit'
+
+  triage:
+    needs: 'dispatch'
+    if: |-
+      ${{ needs.dispatch.outputs.command == 'triage' }}
+    uses: './.github/workflows/gemini-triage.yml'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+    with:
+      additional_context: '${{ needs.dispatch.outputs.additional_context }}'
+    secrets: 'inherit'
+
+  invoke:
+    needs: 'dispatch'
+    if: |-
+      ${{ needs.dispatch.outputs.command == 'invoke' }}
+    uses: './.github/workflows/gemini-invoke.yml'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+    with:
+      additional_context: '${{ needs.dispatch.outputs.additional_context }}'
+    secrets: 'inherit'
+
+  fallthrough:
+    needs:
+      - 'dispatch'
+      - 'review'
+      - 'triage'
+      - 'invoke'
+    if: |-
+      ${{ always() && !cancelled() && (failure() || needs.dispatch.outputs.command == 'fallthrough') }}
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      issues: 'write'
+      pull-requests: 'write'
+    steps:
+      - name: 'Send failure comment'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN || github.token }}'
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          MESSAGE: |-
+            🤖 申し訳ありません @${{ github.actor }}、リクエストの処理に失敗しました。詳細は [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) を確認してください。
+          REPOSITORY: '${{ github.repository }}'
+        run: |-
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body "${MESSAGE}" \
+            --repo "${REPOSITORY}"

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -1,4 +1,4 @@
-name: '🔎 Gemini Review'
+name: '▶️ Gemini Invoke'
 
 on:
   workflow_call:
@@ -9,26 +9,25 @@ on:
         required: false
 
 concurrency:
-  group: '${{ github.workflow }}-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}'
-  cancel-in-progress: true
+  group: '${{ github.workflow }}-invoke-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}'
+  cancel-in-progress: false
 
 defaults:
   run:
     shell: 'bash'
 
 jobs:
-  review:
+  invoke:
     runs-on: 'ubuntu-latest'
     environment: 'Production'
-    timeout-minutes: 7
     permissions:
       contents: 'read'
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
     steps:
-      - name: 'Checkout repository'
-        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v6
+      - name: 'Checkout Code'
+        uses: 'actions/checkout@v4' # ratchet:exclude
         with:
           persist-credentials: 'false'
 
@@ -37,27 +36,35 @@ jobs:
         run: |-
           mkdir -p .gemini
           jq -n \
+            --arg title "${TITLE}" \
+            --arg desc "${DESCRIPTION}" \
+            --arg event "${EVENT_NAME}" \
+            --arg pr "${IS_PULL_REQUEST}" \
+            --arg num "${ISSUE_NUMBER}" \
             --arg repo "${REPOSITORY}" \
-            --arg pr "${PULL_REQUEST_NUMBER}" \
             --arg context "${ADDITIONAL_CONTEXT}" \
-            '{repository: $repo, pull_request_number: $pr, additional_context: $context}' > .gemini/context.json
+            '{title: $title, description: $desc, event_name: $event, is_pull_request: $pr, issue_number: $num, repository: $repo, additional_context: $context}' > .gemini/context.json
         env:
+          TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
+          DESCRIPTION: '${{ github.event.pull_request.body || github.event.issue.body }}'
+          EVENT_NAME: '${{ github.event_name }}'
+          IS_PULL_REQUEST: '${{ !!github.event.pull_request }}'
+          ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
-          PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
 
-      - name: 'Run Gemini pull request review'
+      - name: 'Run Gemini CLI'
+        id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
-        id: 'gemini_pr_review'
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN || github.token }}'
-          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
-          workflow_name: 'gemini-review'
-          github_pr_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
+          workflow_name: 'gemini-invoke'
+          github_pr_number: '${{ github.event.pull_request.number }}'
+          github_issue_number: '${{ github.event.issue.number }}'
           settings: |-
             {
               "model": {
@@ -80,9 +87,17 @@ jobs:
                     "ghcr.io/github/github-mcp-server:v0.27.0"
                   ],
                   "includeTools": [
-                    "add_comment_to_pending_review",
+                    "add_issue_comment",
+                    "issue_read",
+                    "list_issues",
+                    "search_issues",
                     "pull_request_read",
-                    "pull_request_review_write"
+                    "list_pull_requests",
+                    "search_pull_requests",
+                    "get_commit",
+                    "get_file_contents",
+                    "list_commits",
+                    "search_code"
                   ],
                   "env": {
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
@@ -93,8 +108,4 @@ jobs:
                 "core": []
               }
             }
-          extensions: |
-            [
-              "https://github.com/gemini-cli-extensions/code-review"
-            ]
-          prompt: '/pr-code-review'
+          prompt: '/gemini-invoke'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -1,0 +1,139 @@
+name: '🔀 Gemini Triage'
+
+on:
+  workflow_call:
+    inputs:
+      additional_context:
+        type: 'string'
+        description: 'Any additional context from the request'
+        required: false
+
+concurrency:
+  group: '${{ github.workflow }}-triage-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  triage:
+    runs-on: 'ubuntu-latest'
+    environment: 'Production'
+    timeout-minutes: 7
+    outputs:
+      available_labels: '${{ steps.get_labels.outputs.available_labels }}'
+      selected_labels: '${{ steps.gemini_analysis.outputs.summary }}'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'read'
+      pull-requests: 'read'
+    steps:
+      - name: 'Get repository labels'
+        id: 'get_labels'
+        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8.0.0
+        with:
+          script: |-
+            const labels = [];
+            for await (const response of github.paginate.iterator(github.rest.issues.listLabelsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            })) {
+              labels.push(...response.data);
+            }
+
+            if (!labels || labels.length === 0) {
+              core.setFailed('There are no issue labels in this repository.')
+            }
+
+            const labelNames = labels.map(label => label.name).sort();
+            core.setOutput('available_labels', labelNames.join(','));
+            core.info(`Found ${labelNames.length} labels: ${labelNames.join(', ')}`);
+            return labelNames;
+
+      - name: 'Prepare prompt context'
+        shell: 'bash'
+        run: |-
+          mkdir -p .gemini
+          jq -n \
+            --arg labels "${AVAILABLE_LABELS}" \
+            --arg title "${ISSUE_TITLE}" \
+            --arg body "${ISSUE_BODY}" \
+            '{available_labels: $labels, issue_title: $title, issue_body: $body}' > .gemini/context.json
+        env:
+          AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
+          ISSUE_TITLE: '${{ github.event.issue.title }}'
+          ISSUE_BODY: '${{ github.event.issue.body }}'
+
+      - name: 'Run Gemini issue analysis'
+        id: 'gemini_analysis'
+        if: |-
+          ${{ steps.get_labels.outputs.available_labels != '' }}
+        uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ''
+        with:
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
+          workflow_name: 'gemini-triage'
+          github_issue_number: '${{ github.event.issue.number }}'
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "telemetry": {
+                "enabled": true,
+                "target": "local",
+                "outfile": ".gemini/telemetry.log"
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          prompt: '/gemini-triage'
+
+  label:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'triage'
+    if: |-
+      ${{ needs.triage.outputs.selected_labels != '' }}
+    permissions:
+      contents: 'read'
+      issues: 'write'
+      pull-requests: 'write'
+    steps:
+      - name: 'Apply labels'
+        env:
+          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          AVAILABLE_LABELS: '${{ needs.triage.outputs.available_labels }}'
+          SELECTED_LABELS: '${{ needs.triage.outputs.selected_labels }}'
+        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8.0.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN || github.token }}'
+          script: |-
+            const availableLabels = (process.env.AVAILABLE_LABELS || '').split(',')
+              .map((label) => label.trim())
+              .sort()
+
+            const selectedLabels = (process.env.SELECTED_LABELS || '').split(',')
+              .map((label) => label.trim())
+              .filter((label) => availableLabels.includes(label))
+              .sort()
+
+            const issueNumber = process.env.ISSUE_NUMBER;
+            if (selectedLabels && selectedLabels.length > 0) {
+              await github.rest.issues.setLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: selectedLabels,
+              });
+              core.info(`Successfully set labels: ${selectedLabels.join(',')}`);
+            } else {
+              core.info(`Failed to determine labels to set. There may not be enough information in the issue or pull request.`)
+            }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,101 @@
+# Movie App - Gemini AI レビューガイド
+
+Gemini CLI がこのリポジトリでレビュー・分類・質問対応を行う際の指針。
+
+## プロジェクト概要
+
+映画ウォッチリスト管理アプリケーション（Next.js 16 + React 19 + TypeScript + Supabase + NextAuth.js）。
+
+## レビュー観点（PRレビュー時の優先事項）
+
+### 必須チェック項目
+
+#### React コンポーネント
+
+- `React.memo` ですべてのコンポーネントをラップしているか
+- イベントハンドラーに `useCallback` を使っているか
+- 計算コストの高い処理に `useMemo` を使っているか
+- `displayName` が設定されているか
+- ロジックがカスタムフックに分離されているか
+- UIライブラリは Radix UI を使っているか
+- クラス名結合は `cn()` ヘルパー（`@/utils/cn`）を使っているか
+- HTMLタグの直接スタイリング・セレクタを避けて独自クラス名を使っているか
+
+#### アクセシビリティ
+
+- WCAG AA 準拠
+- 適切な ARIA 属性が付与されているか
+- フォーカス表示があるか
+- セマンティック HTML が使われているか
+
+#### スタイリング（SCSS Modules）
+
+- SCSS Modules を使っているか
+- デザインシステム変数を使っているか（カラー・スペーシング等のハードコード禁止）
+- アニメーションは最小限（opacity / transform 程度）か
+
+#### API Route
+
+- NextAuth.js による認証チェックがあるか
+- DB-based レート制限が実装されているか
+- 統一エラーレスポンス形式を使っているか
+
+#### Supabase / DB
+
+- スキーマ変更は `supabase/migrations/` のマイグレーションファイル経由か
+- Row Level Security (RLS) が有効化されているか
+- `public` スキーマのテーブルには適切な `GRANT` が付与されているか
+  - ユーザー固有データ: `authenticated` + `service_role`
+  - 公開マスターデータ: `anon` + `authenticated` + `service_role`
+- UUID 主キー・論理削除（`deleted_at` カラム）に対応しているか
+
+#### カスタムフック
+
+- コールバック関数に `useCallback` を使っているか
+- 計算コストの高い処理に `useMemo` を使っているか
+- エラーハンドリングが実装されているか
+
+#### テスト
+
+- 機能追加時に対応する単体テストがあるか
+- テストファイルが対象ファイルと同じディレクトリに `<filename>.test.ts(x)` で配置されているか
+- アクセシビリティ優先クエリ（`getByRole`, `getByLabelText` 等）を使っているか
+- カバレッジ 80% 以上を維持しているか
+
+#### 命名規則
+
+- ファイル名: lowerCamelCase（例: `movieCard.tsx`, `useMovieData.ts`）
+- コンポーネント: PascalCase
+- 変数・関数: lowerCamelCase
+- API Route: kebab-case（例: `watchlist/add`）
+
+### セキュリティ重点項目
+
+- 環境変数・APIキーがハードコードされていないか
+- ユーザー入力のバリデーション（zod 等）があるか
+- SQL injection / XSS / CSRF への対策
+- 認証チェックの抜けがないか
+- タイミングセーフな比較（パスワード・トークン照合）
+
+### 指摘の優先度
+
+- **高**: セキュリティ脆弱性、認証バイパス、データ漏洩リスク、RLSの欠如
+- **中**: 必須パターン（React.memo, useCallback等）の欠落、アクセシビリティ違反、テスト不足
+- **低**: 命名規則の軽微なブレ、コメントの過不足
+
+### 指摘しないこと
+
+- コードコメント追加の提案（必要な場合のみコメントを書く方針）
+- 過剰な抽象化・リファクタリングの提案
+- 機能要件外の改善（「ついで」の修正は不要）
+
+## レポジトリ構成
+
+- `src/app/` - Next.js App Router（ページ・API Routes）
+- `src/components/` - React コンポーネント
+- `src/hooks/` - カスタムフック
+- `src/utils/` - ユーティリティ関数
+- `src/types/` - 型定義（`database.types.ts` は自動生成のため編集禁止）
+- `supabase/migrations/` - DB マイグレーション
+- `.claude/rules/` - 詳細なコーディング規約（このファイルの元情報）
+- `.claude/documents/` - 設計ドキュメント


### PR DESCRIPTION
## 概要
Gemini AI レビューを `truongnh1992/gemini-ai-code-reviewer` から Google 公式の `google-github-actions/run-gemini-cli` に移行。プロジェクト固有のレビュー観点（`.claude/rules/`）を `GEMINI.md` 経由で Gemini に伝達できるようになる。

## ロードマップ
該当なし（運用ツール整備）

## 変更内容

### Workflow ファイル
| ファイル | 役割 |
|---|---|
| `gemini-dispatch.yml` | コメント受信→コマンド振り分け（OWNER限定、PR作成時の自動レビューは無効） |
| `gemini-review.yml` | PR レビュー実行（`/pr-code-review` プロンプト + code-review extension） |
| `gemini-triage.yml` | Issue 自動分類・ラベル付け |
| `gemini-invoke.yml` | 自由質問対応（`@gemini-cli <自由テキスト>`） |

### サポートコマンド
- `@gemini-cli /review` - PRコードレビュー
- `@gemini-cli /triage` - Issue分類
- `@gemini-cli <自由テキスト>` - 自由質問
- Issue作成時（`opened` / `reopened`）に自動triage

### GEMINI.md（新規）
プロジェクト固有のレビュー観点を Gemini に伝達：
- React.memo / useCallback / useMemo / displayName 必須
- WCAG AA 準拠・ARIA属性・セマンティックHTML
- SCSS Modules + デザインシステム変数
- API Route の認証チェック・レート制限・統一エラー形式
- Supabase RLS必須・GRANT付与ルール・UUID主キー・論理削除
- 命名規則（lowerCamelCase / PascalCase / kebab-case）
- テストカバレッジ80%・アクセシビリティ優先クエリ
- セキュリティ重点項目（環境変数ハードコード禁止・zodバリデーション等）
- 指摘の優先度（高/中/低）と「指摘しないこと」

### PR template
コマンド表記を `/gemini-review` → `@gemini-cli /review` に変更。

## レビューポイント
- **OWNER限定**: `dispatch.yml` の `if` 条件で `author_association == 'OWNER'` に制限
- **PR作成時の自動レビュー無効**: 公式デフォルトの `pull_request: opened` トリガーを削除（コスト管理）
- **`plan-execute` コマンド未導入**: AI が直接コミットする `/approve` コマンドは危険度高のため除外
- **environment: Production**: 各workflowに環境指定（Environment Secretsの`GEMINI_API_KEY`読み込みのため）
- **進捗/失敗通知**: 公式 dispatch が自動投稿するため独自実装は廃止

## 移行理由
1. 既存action（v9.2.1）は汎用バグ・セキュリティ・パフォーマンスチェックのみで、プロジェクト固有ルール（`.claude/rules/`）を考慮できない
2. `run-gemini-cli` は `GEMINI.md` でプロジェクトルール（React.memo必須、RLS必須等）を Gemini に渡せる
3. 進捗ACK・失敗通知が公式実装済みで独自実装不要
4. Google 公式 OSS で長期メンテナンス安心

## テスト
- [ ] このPRをマージ
- [ ] 別PRで `@gemini-cli /review` を実行し、開始ACKコメントとレビューが投稿されることを確認
- [ ] レビュー内容に GEMINI.md のプロジェクト固有観点が反映されているか確認
- [ ] Saved replies の `/gemini-review` を `@gemini-cli /review` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)