### PR TITLE
setup: Gemini Review workflowのデバッグ出力有効化

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
+          gemini_debug: 'true'
+          upload_artifacts: 'true'
           workflow_name: 'gemini-review'
           github_pr_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
           settings: |-


### PR DESCRIPTION
## 概要
PR #352 で `@gemini-cli /review` がレビューコメント未投稿で正常終了する問題の調査用に、デバッグ出力とartifacts保存を一時的に有効化。

## ロードマップ
該当なし（運用調査）

## 背景
PR #352 で `@gemini-cli /review` を実行したところ、dispatch / review ともに success として完了したが、Gemini からのコメントが PR に投稿されなかった。ログには以下のwarningのみ：

```
##[warning]Gemini CLI stderr was not valid JSON
```

stdout/stderrの中身が見えないため原因特定不可。本PRでデバッグ出力を有効化する。

## 変更内容
- `gemini_debug: 'true'` 追加 → Actionsログに stdout/stderr を直接出力
- `upload_artifacts: 'true'` 追加 → 完全ログをartifactsとして保存

## レビューポイント
- 一時的なデバッグ設定（原因特定後に削除予定）
- `gemini_debug: true` は機密情報漏洩リスクあり（公式warning）。OWNER限定運用なので許容範囲

## テスト
- [ ] このPRをマージ
- [ ] PR #352 で再度 `@gemini-cli /review` を実行
- [ ] Actionsログに stdout/stderr の詳細が出力されることを確認
- [ ] artifacts として gemini-artifacts/{stdout,stderr}.log が保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)