### PR TITLE
setup: Gemini Review workflowからcode-review extensionを外す

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -95,8 +95,16 @@ jobs:
                 "core": []
               }
             }
-          extensions: |
-            [
-              "https://github.com/gemini-cli-extensions/code-review"
-            ]
-          prompt: '/pr-code-review'
+          prompt: |-
+            あなたはコードレビュアーです。プロジェクト固有のルールは GEMINI.md に記載されています。
+
+            手順:
+            1. GitHub MCP のツール `pull_request_read` で PR #${{ github.event.pull_request.number || github.event.issue.number }} の差分を取得する
+            2. GEMINI.md のルールと一般的なベストプラクティスに従って差分をレビューする
+            3. 指摘がある場合: `add_comment_to_pending_review` で該当行にコメント投稿後、`pull_request_review_write` で event="COMMENT" としてレビューを submit
+            4. 指摘がない場合: `pull_request_review_write` で body="✅ LGTM - 問題は見つかりませんでした", event="COMMENT" でレビューを submit
+
+            制約:
+            - コード本体にコメントを追加することを提案しない
+            - 過剰な抽象化やリファクタリング提案は行わない
+            - レビューコメントは日本語で書く


### PR DESCRIPTION
## 概要
PR #352 で `@gemini-cli /review` が tool call 0回で `INVALID_STREAM` エラーになる問題への対処試行。code-review extension の agent skill 注入が Gemini の tool call 生成を破壊している仮説に基づき、extension を外して自前プロンプトに変更。

## ロードマップ
該当なし（運用調査）

## 仮説
- Gemini はテキストで「`code-review-commons` skill を起動します」と宣言まではした
- その直後の function call 生成段階で stream が壊れて空レスポンス
- code-review extension が複雑な system prompt（agent skill）を注入したのが原因の可能性

## 変更内容
- `extensions: ["gemini-cli-extensions/code-review"]` を削除
- `prompt: '/pr-code-review'` を手順を直接記述したシンプルなプロンプトに変更
  - `pull_request_read` で diff取得
  - GEMINI.md のルールでレビュー
  - 指摘有/無に応じて `pull_request_review_write` で COMMENT review を submit

## レビューポイント
- extension 外しは仮説検証目的
- 治れば「extension の skill 注入が原因」と確定する
- 治らなければ次の候補（gemini_cli_version pin）に進む

## テスト
- [ ] このPRをマージ
- [ ] PR #352 で再度 `@gemini-cli /review` を実行
- [ ] Gemini からレビューコメントが投稿されることを確認（指摘有/無問わず）

🤖 Generated with [Claude Code](https://claude.com/claude-code)