### PR TITLE
setup: Gemini Review workflowでcore toolsを有効化

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -90,9 +90,6 @@ jobs:
                     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
                   }
                 }
-              },
-              "tools": {
-                "core": []
               }
             }
           prompt: |-


### PR DESCRIPTION
## 概要
PR #352 で `@gemini-cli /review` の tool call 0回問題への対処試行 2。

前回（extension外し: PR #354）では`INVALID_STREAM`は消えたが、Geminiが `<call:tool_name />` 形式の疑似XMLでツール呼び出しを書くだけで、実際の function call を発行できなかった。

`settings.tools.core: []` で Gemini CLI の core tool 全部が無効化されており、MCP tool しか使えない状態。MCP との連携が機能していない可能性が高いため、core tools を有効化して shell tool 経由でも動けるようにする。

## ロードマップ
該当なし（運用調査）

## 変更内容
- `settings.tools.core: []` を削除
- これにより Gemini が `run_shell_command`, `read_file`, `grep`, `glob` 等の core tool を利用可能になる

## 仮説
- core tool 有効化により、Gemini が gh CLI を直接 shell で呼べるようになる
- MCP に依存せずレビューが完了する可能性

## レビューポイント
- 1ブロック削除のみ
- Gemini に shell 実行権限を渡す形になるが、`--yolo` モード（既定）なので元々 shell 可

## テスト
- [ ] このPRをマージ
- [ ] PR #352 で再度 `@gemini-cli /review` を実行
- [ ] Gemini からレビューコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)