### PR TITLE
setup: Geminiモデルをgemini-3.1-flash-liteに変更

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN || github.token }}'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
-          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
+          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-3.1-flash-lite' }}"
           workflow_name: 'gemini-invoke'
           github_pr_number: '${{ github.event.pull_request.number }}'
           github_issue_number: '${{ github.event.issue.number }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -55,7 +55,7 @@ jobs:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
-          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
+          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-3.1-flash-lite' }}"
           gemini_debug: 'true'
           upload_artifacts: 'true'
           workflow_name: 'gemini-review'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ''
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
-          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}"
+          gemini_model: "${{ vars.GEMINI_MODEL || 'gemini-3.1-flash-lite' }}"
           workflow_name: 'gemini-triage'
           github_issue_number: '${{ github.event.issue.number }}'
           settings: |-


### PR DESCRIPTION
## 概要
Gemini API の無料枠の実 RPD がアカウント上で flash 系全モデル 20 に絞られている問題への対処。管理画面で確認した結果、`gemini-3.1-flash-lite` は 500 RPD と 25 倍多いため、こちらに切り替える。

## ロードマップ
該当なし（運用調整）

## 変更内容
3つの workflow で `gemini_model` のデフォルト値を変更:
- `gemini-review.yml`: gemini-2.5-flash → gemini-3.1-flash-lite
- `gemini-invoke.yml`: 同上
- `gemini-triage.yml`: 同上

## レビューポイント
- preview モデルなので安定性に若干の懸念あるが、free tier 枯渇よりはマシ
- `vars.GEMINI_MODEL` で repository variable から上書き可能

## テスト
- [ ] マージ後、PR #352 で `@gemini-cli /review` を再実行
- [ ] レビューコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)