### PR TITLE
setup: Gemini Reviewのprompt強化（チェックリスト明記 + 行コメント化）

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -97,11 +97,45 @@ jobs:
 
             手順:
             1. GitHub MCP のツール `pull_request_read` で PR #${{ github.event.pull_request.number || github.event.issue.number }} の差分を取得する
-            2. GEMINI.md のルールと一般的なベストプラクティスに従って差分をレビューする
-            3. 指摘がある場合: `add_comment_to_pending_review` で該当行にコメント投稿後、`pull_request_review_write` で event="COMMENT" としてレビューを submit
-            4. 指摘がない場合: `pull_request_review_write` で body="✅ LGTM - 問題は見つかりませんでした", event="COMMENT" でレビューを submit
+            2. 下記の必須チェック項目を **一つずつ順番に機械的に確認** する（飛ばしや見落とし禁止）
+            3. 違反があれば `add_comment_to_pending_review` で該当行にコメント投稿後、`pull_request_review_write` で event="COMMENT" としてレビューを submit
+            4. 違反がなければ `pull_request_review_write` で body="✅ LGTM - 問題は見つかりませんでした", event="COMMENT" でレビューを submit
 
-            制約:
-            - コード本体にコメントを追加することを提案しない
+            ## 必須チェック項目（一つずつ確実に確認すること）
+
+            ### Reactコンポーネント
+            - [ ] すべてのコンポーネントが `React.memo` でラップされているか
+            - [ ] **すべてのイベントハンドラー（onClick, onChange, onSubmit等）に `useCallback` が使われているか**
+            - [ ] 計算コストの高い処理に `useMemo` が使われているか
+            - [ ] `displayName` が設定されているか
+            - [ ] ロジックがカスタムフックに分離されているか
+            - [ ] クラス名結合に `cn()` ヘルパー（`@/utils/cn`）が使われているか
+
+            ### スタイリング
+            - [ ] SCSS Modules を使っているか（インラインスタイル禁止）
+            - [ ] カラー/スペーシング/フォントサイズがデザインシステム変数を使っているか（ハードコード禁止）
+            - [ ] HTMLタグを直接スタイリングしていないか（独自クラス名必須）
+
+            ### アクセシビリティ
+            - [ ] WCAG AA準拠（適切なARIA属性、フォーカス表示、セマンティックHTML）
+            - [ ] クリック可能要素にbutton/aを使っているか（divのonClickは禁止）
+
+            ### 命名規則
+            - [ ] ファイル名: lowerCamelCase（例: movieCard.tsx）
+            - [ ] コンポーネント: PascalCase
+            - [ ] 変数・関数・props: lowerCamelCase（snake_case禁止）
+            - [ ] API Route: kebab-case
+
+            ### セキュリティ
+            - [ ] 環境変数・APIキーがハードコードされていないか
+            - [ ] ユーザー入力のバリデーション（zod等）があるか
+            - [ ] SQL injection / XSS / CSRF への対策があるか
+
+            ### テスト
+            - [ ] 新規 .ts(x) ファイルに対応するテストファイル（<filename>.test.ts(x)）があるか
+
+            ## 制約
+            - コード本体にコメントを追加する提案はしない
             - 過剰な抽象化やリファクタリング提案は行わない
             - レビューコメントは日本語で書く
+            - 上記のチェック項目は**すべて見落とさず順番に確認**すること

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -98,8 +98,18 @@ jobs:
             手順:
             1. GitHub MCP のツール `pull_request_read` で PR #${{ github.event.pull_request.number || github.event.issue.number }} の差分を取得する
             2. 下記の必須チェック項目を **一つずつ順番に機械的に確認** する（飛ばしや見落とし禁止）
-            3. 違反があれば `add_comment_to_pending_review` で該当行にコメント投稿後、`pull_request_review_write` で event="COMMENT" としてレビューを submit
-            4. 違反がなければ `pull_request_review_write` で body="✅ LGTM - 問題は見つかりませんでした", event="COMMENT" でレビューを submit
+            3. 違反を発見するたびに、**違反ごと**に以下を実行する:
+               a. 該当ファイル名と行番号（差分の "+" 側＝新ファイルの行）を特定する
+               b. `add_comment_to_pending_review` で**その違反だけ**に該当する**単独の行コメント**を投稿
+               c. コメント内容には「違反内容」と「修正例（コード片）」を含める
+            4. 全違反コメント投稿後、`pull_request_review_write` を event="COMMENT" で submit する
+               - body は短いサマリー（例: "⚠️ N件の指摘あり"）でよい
+            5. 違反がない場合は行コメント投稿はスキップし、`pull_request_review_write` で body="✅ LGTM - 問題は見つかりませんでした", event="COMMENT" として submit
+
+            ## 行コメントの原則
+            - **1違反 = 1行コメント**。複数違反を1コメントにまとめない
+            - 同じ行に複数違反があれば、違反ごとに別コメントで投稿
+            - 行番号は diff の "+" 側（追加された新ファイル）の行を指定
 
             ## 必須チェック項目（一つずつ確実に確認すること）
 


### PR DESCRIPTION
## 概要
PR #357 のテストで判明した精度・形式の課題への対処として、`gemini-review.yml` の prompt を 2 点強化する。

## ロードマップ
該当なし（運用調整）

## 変更内容

### 1. 必須チェックリストの明記
Gemini 3.1 flash-lite が useCallback の違反を見落とした問題への対処。prompt に必須チェック項目を箇条書きで明示。useCallback は特に強調表示。

カテゴリ:
- Reactコンポーネント（React.memo / useCallback / useMemo / displayName / cn() / カスタムフック分離）
- スタイリング（SCSS Modules / デザインシステム変数 / 独自クラス名）
- アクセシビリティ（WCAG AA / button要素）
- 命名規則（lowerCamelCase / PascalCase / kebab-case）
- セキュリティ（環境変数 / バリデーション / OWASP）
- テスト（テストファイル併設）

### 2. 行コメント化
前回のテストでは 1 ファイル末尾に違反まとめコメントが投稿されていたが、本来は違反ごとに該当行にインラインコメントすべき。prompt で以下を明示:

- **1違反 = 1行コメント**（複数違反を1つに集約しない）
- 違反ごとに `add_comment_to_pending_review` を呼び出す
- 行番号は diff の `+` 側を指定
- コメント内容に修正例を含める

## レビューポイント
- prompt のみの変更（workflow構造は変更なし）
- Gemini 3.1 flash-lite が複数 tool call を正確に発行できるかは試行検証が必要

## テスト
- [ ] このPRをマージ
- [ ] PR #357 で再度 `@gemini-cli /review` を実行
- [ ] useCallback の指摘が出ること
- [ ] 違反ごとに行コメントが分離されて投稿されること

## 次のフェーズ（別PR）
Phase 1（このPR）が動けば Phase 2 として critic workflow（Gemma 4 31B で漏れ補完）を追加予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)