### PR TITLE
setup: PR作成時にGemini AIレビューを自動起動

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,6 +1,9 @@
 name: '🔀 Gemini Dispatch'
 
 on:
+  pull_request:
+    types:
+      - 'opened'
   issues:
     types:
       - 'opened'
@@ -21,9 +24,14 @@ defaults:
 
 jobs:
   dispatch:
-    # OWNER のみ: コメントで @gemini-cli から始まる、または Issue 作成時のみ起動
+    # OWNER のみ: PR作成時 (Draft除外) / Issue作成時 / @gemini-cli コメント時に起動
     if: |-
       (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'opened' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.author_association == 'OWNER'
+      ) || (
         github.event_name == 'issues' &&
         contains(fromJSON('["opened", "reopened"]'), github.event.action) &&
         github.event.issue.author_association == 'OWNER'
@@ -55,7 +63,9 @@ jobs:
             const request = process.env.REQUEST;
             core.setOutput('request', request);
 
-            if (['issues.opened', 'issues.reopened'].includes(eventType)) {
+            if (eventType === 'pull_request.opened') {
+              core.setOutput('command', 'review');
+            } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');
             } else if (request.startsWith('@gemini-cli /review')) {
               core.setOutput('command', 'review');


### PR DESCRIPTION
## 概要
OWNER が PR を作成した時点で自動的に Gemini AI レビュー（`@gemini-cli /review` 相当）を起動するよう dispatch を拡張。

## ロードマップ
該当なし（運用調整）

## 変更内容
`gemini-dispatch.yml`:
- `on:` に `pull_request: opened` トリガーを追加
- `if` 条件に PR open 時の発火条件を追加（OWNER + Draft 除外）
- `extract_command` で `pull_request.opened` イベントを `review` コマンドにマッピング

## 起動条件
| イベント | 条件 |
|---|---|
| PR 作成 | OWNER + Draft でない（**今回追加**） |
| `@gemini-cli /review` コメント | OWNER（既存） |
| `@gemini-cli /triage` / `@gemini-cli <自由>` | OWNER（既存） |
| Issue 作成・再オープン | OWNER → triage（既存） |

## レビューポイント
- 既存のコメントトリガーは維持されている
- Draft PR は自動レビュー対象外
- bot PR（dependabot 等）は `author_association == 'OWNER'` の判定で自然に除外される

## テスト
- [ ] このPRをマージ
- [ ] 次回 PR 作成時にACK + Gemini レビューコメントが自動投稿されることを確認
- [ ] Draft PR では自動起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)