### PR TITLE
setup: Issue作成時の自動triage起動を無効化

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types:
       - 'opened'
-  issues:
-    types:
-      - 'opened'
-      - 'reopened'
   issue_comment:
     types:
       - 'created'
@@ -24,17 +20,13 @@ defaults:
 
 jobs:
   dispatch:
-    # OWNER のみ: PR作成時 (Draft除外) / Issue作成時 / @gemini-cli コメント時に起動
+    # OWNER のみ: PR作成時 (Draft除外) / @gemini-cli コメント時に起動
     if: |-
       (
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
         github.event.pull_request.draft == false &&
         github.event.pull_request.author_association == 'OWNER'
-      ) || (
-        github.event_name == 'issues' &&
-        contains(fromJSON('["opened", "reopened"]'), github.event.action) &&
-        github.event.issue.author_association == 'OWNER'
       ) || (
         github.event.sender.type == 'User' &&
         startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
@@ -65,8 +57,6 @@ jobs:
 
             if (eventType === 'pull_request.opened') {
               core.setOutput('command', 'review');
-            } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
-              core.setOutput('command', 'triage');
             } else if (request.startsWith('@gemini-cli /review')) {
               core.setOutput('command', 'review');
               const additionalContext = request.replace(/^@gemini-cli \/review/, '').trim();


### PR DESCRIPTION
## 概要
GitHub Issue 作成時に gemini-triage workflow が自動起動して quota を消費する問題への対処。

## ロードマップ
該当なし（運用調整）

## 変更内容
`gemini-dispatch.yml`:
- `on.issues` トリガーを削除
- dispatch の `if` 条件から issues 分岐を削除
- extract_command から `issues.opened/reopened` → triage マッピングを削除

`@gemini-cli /triage` コメント経由の手動起動は維持。

## レビューポイント
- 単純な機能除去のため副作用なし
- triage の workflow ファイル自体は残しているので、コメント起動で復活可能

## テスト
- [ ] このPRをマージ
- [ ] 次回 Issue 作成時に dispatch workflow が起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)