### PR TITLE
fix: お気に入り操作後に movieKeys.detail キャッシュも更新する

### DIFF
--- a/src/features/favorites/hooks/useFavorites.test.ts
+++ b/src/features/favorites/hooks/useFavorites.test.ts
@@ -303,12 +303,17 @@ describe('useFavorites', () => {
       });
 
       const { wrapper, queryClient } = createWrapperWithClient();
+      // useMovieDetail のキャッシュは { success, data: MovieDetail } 構造
       queryClient.setQueryData(movieKeys.detail(999), {
-        id: 999,
-        title: '詳細キャッシュ映画',
-        overview: '...',
-        poster_path: null,
-        release_date: null,
+        success: true,
+        data: {
+          id: 999,
+          title: '詳細キャッシュ映画',
+          overview: '...',
+          poster_path: null,
+          release_date: null,
+          favorite: null,
+        },
       });
 
       const { result } = renderHook(() => useFavorites(), { wrapper });
@@ -333,9 +338,16 @@ describe('useFavorites', () => {
           expect.objectContaining({ variant: 'success' }),
         );
       });
+
+      // 詳細キャッシュの favorite が実 ID で更新されている
+      const detail = queryClient.getQueryData<{
+        success: true;
+        data: { favorite: { id: string; rating: number } | null };
+      }>(movieKeys.detail(999));
+      expect(detail?.data.favorite).toEqual({ id: 'fav-x', rating: 7 });
     });
 
-    it('詳細キャッシュ存在下でも updateRating が成功する', async () => {
+    it('詳細キャッシュの favorite.rating が updateRating で更新される', async () => {
       mockUpdateFavoriteRating.mockResolvedValue({
         success: true,
         message: '評価を更新しました',
@@ -352,11 +364,15 @@ describe('useFavorites', () => {
 
       const { wrapper, queryClient } = createWrapperWithClient();
       queryClient.setQueryData(movieKeys.detail(100), {
-        id: 100,
-        title: '映画A',
-        overview: '...',
-        poster_path: '/a.jpg',
-        release_date: '2026-01-01',
+        success: true,
+        data: {
+          id: 100,
+          title: '映画A',
+          overview: '...',
+          poster_path: '/a.jpg',
+          release_date: '2026-01-01',
+          favorite: { id: 'fav-1', rating: 5 },
+        },
       });
 
       const { result } = renderHook(() => useFavorites(), { wrapper });
@@ -371,18 +387,28 @@ describe('useFavorites', () => {
       await waitFor(() => {
         expect(mockUpdateFavoriteRating).toHaveBeenCalled();
       });
+
+      const detail = queryClient.getQueryData<{
+        success: true;
+        data: { favorite: { id: string; rating: number } | null };
+      }>(movieKeys.detail(100));
+      expect(detail?.data.favorite).toEqual({ id: 'fav-1', rating: 9 });
     });
 
-    it('詳細キャッシュ存在下でも removeFromFavorites が成功する', async () => {
+    it('詳細キャッシュの favorite が removeFromFavorites で null になる', async () => {
       mockRemoveFavorite.mockResolvedValue(undefined);
 
       const { wrapper, queryClient } = createWrapperWithClient();
       queryClient.setQueryData(movieKeys.detail(100), {
-        id: 100,
-        title: '映画A',
-        overview: '...',
-        poster_path: '/a.jpg',
-        release_date: '2026-01-01',
+        success: true,
+        data: {
+          id: 100,
+          title: '映画A',
+          overview: '...',
+          poster_path: '/a.jpg',
+          release_date: '2026-01-01',
+          favorite: { id: 'fav-1', rating: 5 },
+        },
       });
 
       const { result } = renderHook(() => useFavorites(), { wrapper });
@@ -397,6 +423,12 @@ describe('useFavorites', () => {
       await waitFor(() => {
         expect(mockRemoveFavorite).toHaveBeenCalled();
       });
+
+      const detail = queryClient.getQueryData<{
+        success: true;
+        data: { favorite: { id: string; rating: number } | null };
+      }>(movieKeys.detail(100));
+      expect(detail?.data.favorite).toBeNull();
     });
   });
 

--- a/src/features/favorites/hooks/useFavorites.ts
+++ b/src/features/favorites/hooks/useFavorites.ts
@@ -88,32 +88,48 @@ export function useFavorites(params?: GetFavoritesRequest): UseFavoritesReturn {
     enabled: isAuthenticated,
   });
 
-  // 映画一覧キャッシュ内のfavoriteフィールドを更新するユーティリティ
-  // movieKeys.all (= ['movies']) は一覧と詳細の両方にマッチするため、
-  // 一覧形式 (pages を持つ) のキャッシュのみ更新する
+  // 映画関連キャッシュ内のfavoriteフィールドを更新するユーティリティ
+  // movieKeys.all (= ['movies']) は一覧 (pages 構造) と詳細 ({ data: MovieDetail } 構造)
+  // の両方にマッチするため、構造を判別して適切に更新する
   const updateMovieCacheFavorite = useCallback(
     (tmdbMovieId: number, favorite: MovieFavoriteInfo | null) => {
-      queryClient.setQueriesData<{
-        pages: GetMoviesResponse[];
-        pageParams: number[];
-      }>({ queryKey: movieKeys.all }, (old) => {
-        if (!old || !Array.isArray(old.pages)) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => {
-            if (!page?.data?.movies) return page;
+      queryClient.setQueriesData(
+        { queryKey: movieKeys.all },
+        (old: unknown) => {
+          if (!old || typeof old !== 'object') return old;
+
+          // 一覧キャッシュ (useInfiniteQuery: { pages, pageParams })
+          const list = old as {
+            pages?: GetMoviesResponse[];
+            pageParams?: number[];
+          };
+          if (Array.isArray(list.pages)) {
             return {
-              ...page,
-              data: {
-                ...page.data,
-                movies: page.data.movies.map((movie) =>
-                  movie.id === tmdbMovieId ? { ...movie, favorite } : movie,
-                ),
-              },
+              ...list,
+              pages: list.pages.map((page) => {
+                if (!page?.data?.movies) return page;
+                return {
+                  ...page,
+                  data: {
+                    ...page.data,
+                    movies: page.data.movies.map((movie) =>
+                      movie.id === tmdbMovieId ? { ...movie, favorite } : movie,
+                    ),
+                  },
+                };
+              }),
             };
-          }),
-        };
-      });
+          }
+
+          // 詳細キャッシュ (useQuery: { success, data: MovieDetail })
+          const detail = old as { data?: { id?: number } };
+          if (detail.data?.id === tmdbMovieId) {
+            return { ...detail, data: { ...detail.data, favorite } };
+          }
+
+          return old;
+        },
+      );
     },
     [queryClient],
   );
@@ -178,30 +194,49 @@ export function useFavorites(params?: GetFavoritesRequest): UseFavoritesReturn {
         pageParams: number[];
       }>({ queryKey: movieKeys.all });
 
-      // 映画一覧キャッシュからtmdbMovieIdを探して楽観的更新
-      queryClient.setQueriesData<{
-        pages: GetMoviesResponse[];
-        pageParams: number[];
-      }>({ queryKey: movieKeys.all }, (old) => {
-        if (!old || !Array.isArray(old.pages)) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => {
-            if (!page?.data?.movies) return page;
+      // 映画関連キャッシュからお気に入りIDを探して楽観的更新（一覧＋詳細）
+      queryClient.setQueriesData(
+        { queryKey: movieKeys.all },
+        (old: unknown) => {
+          if (!old || typeof old !== 'object') return old;
+
+          const list = old as {
+            pages?: GetMoviesResponse[];
+            pageParams?: number[];
+          };
+          if (Array.isArray(list.pages)) {
             return {
-              ...page,
-              data: {
-                ...page.data,
-                movies: page.data.movies.map((movie) =>
-                  movie.favorite?.id === id
-                    ? { ...movie, favorite: { id, rating } }
-                    : movie,
-                ),
-              },
+              ...list,
+              pages: list.pages.map((page) => {
+                if (!page?.data?.movies) return page;
+                return {
+                  ...page,
+                  data: {
+                    ...page.data,
+                    movies: page.data.movies.map((movie) =>
+                      movie.favorite?.id === id
+                        ? { ...movie, favorite: { id, rating } }
+                        : movie,
+                    ),
+                  },
+                };
+              }),
             };
-          }),
-        };
-      });
+          }
+
+          const detail = old as {
+            data?: { favorite?: { id?: string } | null };
+          };
+          if (detail.data?.favorite?.id === id) {
+            return {
+              ...detail,
+              data: { ...detail.data, favorite: { id, rating } },
+            };
+          }
+
+          return old;
+        },
+      );
 
       return { previousMoviesCache };
     },
@@ -239,30 +274,46 @@ export function useFavorites(params?: GetFavoritesRequest): UseFavoritesReturn {
         pageParams: number[];
       }>({ queryKey: movieKeys.all });
 
-      // 映画一覧キャッシュからfavoriteをnullに設定
-      queryClient.setQueriesData<{
-        pages: GetMoviesResponse[];
-        pageParams: number[];
-      }>({ queryKey: movieKeys.all }, (old) => {
-        if (!old || !Array.isArray(old.pages)) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => {
-            if (!page?.data?.movies) return page;
+      // 映画関連キャッシュからお気に入りをnullに設定（一覧＋詳細）
+      queryClient.setQueriesData(
+        { queryKey: movieKeys.all },
+        (old: unknown) => {
+          if (!old || typeof old !== 'object') return old;
+
+          const list = old as {
+            pages?: GetMoviesResponse[];
+            pageParams?: number[];
+          };
+          if (Array.isArray(list.pages)) {
             return {
-              ...page,
-              data: {
-                ...page.data,
-                movies: page.data.movies.map((movie) =>
-                  movie.favorite?.id === id
-                    ? { ...movie, favorite: null }
-                    : movie,
-                ),
-              },
+              ...list,
+              pages: list.pages.map((page) => {
+                if (!page?.data?.movies) return page;
+                return {
+                  ...page,
+                  data: {
+                    ...page.data,
+                    movies: page.data.movies.map((movie) =>
+                      movie.favorite?.id === id
+                        ? { ...movie, favorite: null }
+                        : movie,
+                    ),
+                  },
+                };
+              }),
             };
-          }),
-        };
-      });
+          }
+
+          const detail = old as {
+            data?: { favorite?: { id?: string } | null };
+          };
+          if (detail.data?.favorite?.id === id) {
+            return { ...detail, data: { ...detail.data, favorite: null } };
+          }
+
+          return old;
+        },
+      );
 
       return { previousMoviesCache };
     },


### PR DESCRIPTION
## 概要
PR #363 で詳細キャッシュ更新をスキップするガードを入れた結果、映画詳細モーダル内の `FavoriteButton`（`movie.favorite` を参照）が評価/削除後に状態反映されない副作用が発生していた。これを修正する。

`useFavorites` 内の3箇所の `setQueriesData` updater を「一覧形式」と「詳細形式」両対応に変更：
- 一覧キャッシュ（`{ pages, pageParams }`）: 対象 movie の `favorite` を更新
- 詳細キャッシュ（`{ success, data: MovieDetail }`）: `data.id` または `data.favorite.id` でマッチする場合に `favorite` を更新

これで詳細モーダルを開いた状態で評価/削除しても、モーダル内の `FavoriteButton` が即座にアクティブ表示へ切り替わる。

## ロードマップ
該当タスクなし（PR #363 の副作用に対するバグ修正フォローアップ）

## レビューポイント
- 詳細キャッシュ構造（`{ success, data }`）の判定・更新ロジックが正しいか
- 一覧キャッシュ形式との分岐が漏れなく3箇所すべてに適用されているか

## テスト
回帰テストを「mutationFn が呼ばれること」だけでなく「詳細キャッシュの `favorite` フィールドが実際に更新される」まで検証するよう強化：
- addToFavorites 後、詳細キャッシュ `data.favorite` が実IDで更新される
- updateRating 後、詳細キャッシュ `data.favorite.rating` が更新される
- removeFromFavorites 後、詳細キャッシュ `data.favorite` が `null` になる