### PR TITLE
fix: AIおすすめが最大10件に届かない問題を修正

### DIFF
--- a/src/app/api/cron/generate-recommendations/route.test.ts
+++ b/src/app/api/cron/generate-recommendations/route.test.ts
@@ -8,6 +8,11 @@
 
 import { NextRequest } from 'next/server';
 
+import {
+  RECOMMENDATIONS_MAX_COUNT,
+  RECOMMENDATIONS_GENERATION_BUFFER,
+} from '@/constants';
+
 import { GET } from './route';
 
 // --- Mocks ---
@@ -468,15 +473,15 @@ describe('GET /api/cron/generate-recommendations', () => {
 
     // fetchRecommendationsFromOpenAIが2回呼ばれる
     expect(mockFetchRecommendations).toHaveBeenCalledTimes(2);
-    // 1回目: 10件リクエスト
+    // 1回目: 最大件数＋バッファをリクエスト
     expect(mockFetchRecommendations).toHaveBeenNthCalledWith(
       1,
       [{ title: 'インターステラー', rating: 9 }],
       ['インターステラー'],
-      10,
+      RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER,
       [],
     );
-    // 2回目: 不足2件リクエスト、解決済みタイトルを除外
+    // 2回目: 不足2件＋バッファをリクエスト、解決済みタイトルを除外
     expect(mockFetchRecommendations).toHaveBeenNthCalledWith(
       2,
       [{ title: 'インターステラー', rating: 9 }],
@@ -484,7 +489,7 @@ describe('GET /api/cron/generate-recommendations', () => {
         'インターステラー',
         ...firstBatchResolved.map((r) => r.title),
       ]),
-      2,
+      2 + RECOMMENDATIONS_GENERATION_BUFFER,
       [],
     );
   });
@@ -568,15 +573,16 @@ describe('GET /api/cron/generate-recommendations', () => {
       1,
       [{ title: 'お気に入り映画', rating: 9 }],
       ['お気に入り映画', 'ウォッチリスト映画'],
-      10,
+      RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER,
       [],
     );
 
-    // 初回のresolveRecommendationsWithTMDbに除外IDセットが渡されていることを確認
+    // 初回のresolveRecommendationsWithTMDbに除外IDセットと必要件数が渡されていることを確認
     expect(mockResolveRecommendations).toHaveBeenNthCalledWith(
       1,
       expect.anything(),
       new Set([1, 2]),
+      RECOMMENDATIONS_MAX_COUNT,
     );
   });
 
@@ -670,7 +676,7 @@ describe('GET /api/cron/generate-recommendations', () => {
       1,
       [{ title: 'お気に入り映画', rating: 9 }],
       ['お気に入り映画', '興味なし映画A', '興味なし映画B'],
-      10,
+      RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER,
       [
         { tmdb_movie_id: 10, title: '興味なし映画A', genre_ids: [27] },
         { tmdb_movie_id: 20, title: '興味なし映画B', genre_ids: [27, 53] },
@@ -682,6 +688,7 @@ describe('GET /api/cron/generate-recommendations', () => {
       1,
       expect.anything(),
       new Set([1, 10, 20]),
+      RECOMMENDATIONS_MAX_COUNT,
     );
   });
 });

--- a/src/constants/recommendations.ts
+++ b/src/constants/recommendations.ts
@@ -13,6 +13,19 @@ export const RECOMMENDATIONS_MAX_COUNT = 10;
 export const RECOMMENDATIONS_MAX_RETRIES = 2;
 
 /**
+ * AI生成時の追加要求件数（バッファ）
+ * TMDb解決時の取りこぼし・除外を見越して、必要数より多めにAIへ推薦を要求する。
+ * これにより1回のAI呼び出しで RECOMMENDATIONS_MAX_COUNT 件を満たしやすくする。
+ */
+export const RECOMMENDATIONS_GENERATION_BUFFER = 5;
+
+/**
+ * TMDb候補選択時に許容する公開年の差（年）
+ * AIが返した公開年とTMDb検索結果の公開年がこの範囲内なら一致候補とみなす。
+ */
+export const RECOMMENDATIONS_YEAR_MATCH_TOLERANCE = 1;
+
+/**
  * アクティブユーザー判定期間（日数）
  * last_login_at がこの日数以内のユーザーのみレコメンド生成対象
  */

--- a/src/lib/openai/generateRecommendations.test.ts
+++ b/src/lib/openai/generateRecommendations.test.ts
@@ -357,4 +357,111 @@ describe('resolveRecommendationsWithTMDb', () => {
 
     expect(result).toHaveLength(10);
   });
+
+  it('公開年が一致する候補を関連度順より優先して選択する', async () => {
+    // 直前のテストで消費されなかった mockResolvedValueOnce キューを破棄
+    mockSearchMovies.mockReset();
+    mockSearchMovies.mockResolvedValue({
+      results: [
+        {
+          id: 1,
+          title: 'Dune',
+          poster_path: null,
+          release_date: '1984-12-14',
+          vote_average: 6.3,
+          genre_ids: [878],
+        },
+        {
+          id: 2,
+          title: 'Dune',
+          poster_path: null,
+          release_date: '2021-09-15',
+          vote_average: 7.8,
+          genre_ids: [878],
+        },
+      ],
+    });
+
+    const items = [createItem('Dune', 2021, '理由')];
+    const result = await resolveRecommendationsWithTMDb(items, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tmdb_movie_id).toBe(2);
+  });
+
+  it('公開年が許容範囲内の候補がない場合は先頭（関連度最上位）を選ぶ', async () => {
+    mockSearchMovies.mockReset();
+    mockSearchMovies.mockResolvedValue({
+      results: [
+        {
+          id: 10,
+          title: 'Old Movie',
+          poster_path: null,
+          release_date: '1990-01-01',
+          vote_average: 7.0,
+          genre_ids: [18],
+        },
+        {
+          id: 20,
+          title: 'Old Movie',
+          poster_path: null,
+          release_date: '1995-01-01',
+          vote_average: 6.0,
+          genre_ids: [18],
+        },
+      ],
+    });
+
+    const items = [createItem('Old Movie', 2020, '理由')];
+    const result = await resolveRecommendationsWithTMDb(items, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tmdb_movie_id).toBe(10);
+  });
+
+  it('release_dateが空文字の候補は年一致せず先頭を選ぶ', async () => {
+    mockSearchMovies.mockReset();
+    mockSearchMovies.mockResolvedValue({
+      results: [
+        {
+          id: 30,
+          title: 'No Date Movie',
+          poster_path: null,
+          release_date: '',
+          vote_average: 7.0,
+          genre_ids: [18],
+        },
+      ],
+    });
+
+    const items = [createItem('No Date Movie', 2020, '理由')];
+    const result = await resolveRecommendationsWithTMDb(items, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tmdb_movie_id).toBe(30);
+  });
+
+  it('limit引数で指定件数で打ち切る', async () => {
+    mockSearchMovies.mockReset();
+    const items: OpenAiRecommendationItem[] = [];
+    for (let i = 1; i <= 5; i++) {
+      items.push(createItem(`Movie ${i}`, 2020, `理由${i}`));
+      mockSearchMovies.mockResolvedValueOnce({
+        results: [
+          {
+            id: i,
+            title: `Movie ${i}`,
+            poster_path: null,
+            release_date: '2020-01-01',
+            vote_average: 7.0,
+            genre_ids: [28],
+          },
+        ],
+      });
+    }
+
+    const result = await resolveRecommendationsWithTMDb(items, new Set(), 2);
+
+    expect(result).toHaveLength(2);
+  });
 });

--- a/src/lib/openai/generateRecommendations.ts
+++ b/src/lib/openai/generateRecommendations.ts
@@ -2,8 +2,13 @@
  * OpenAI APIを使用したレコメンド生成ロジック
  */
 
-import { RECOMMENDATIONS_MAX_COUNT, OPENAI_CONFIG } from '@/constants';
+import {
+  RECOMMENDATIONS_MAX_COUNT,
+  RECOMMENDATIONS_YEAR_MATCH_TOLERANCE,
+  OPENAI_CONFIG,
+} from '@/constants';
 import { searchMovies } from '@/lib/tmdb/tmdb';
+import type { Movie } from '@/lib/types';
 import {
   openAiRecommendationsResponseSchema,
   type OpenAiRecommendationItem,
@@ -192,15 +197,59 @@ export async function fetchRecommendationsFromOpenAI(
 }
 
 /**
+ * 公開日文字列（YYYY-MM-DD）から公開年を取り出す
+ * @returns 年（数値）。空文字・不正値の場合は null
+ */
+function getReleaseYear(releaseDate: string | null | undefined): number | null {
+  if (!releaseDate) {
+    return null;
+  }
+  const year = Number.parseInt(releaseDate.slice(0, 4), 10);
+  return Number.isNaN(year) ? null : year;
+}
+
+/**
+ * TMDb検索結果から、AIが指定した公開年に最も近い候補を選ぶ
+ *
+ * 検索はタイトルのみで行う（TMDb APIのyearは厳密フィルタのため、1年ずれると
+ * 0件になる）ため、結果はTMDbの関連度順に並ぶ。その並びを尊重しつつ、AIが返した
+ * 公開年と許容範囲内で一致する最初の候補を優先する。一致がなければ先頭を採用する。
+ *
+ * @param results - TMDb検索結果
+ * @param year - AIが返した公開年
+ * @returns 採用する映画。結果が空なら undefined
+ */
+function selectBestMovieMatch(
+  results: Movie[],
+  year: number,
+): Movie | undefined {
+  if (results.length === 0) {
+    return undefined;
+  }
+
+  const matched = results.find((movie) => {
+    const releaseYear = getReleaseYear(movie.release_date);
+    return (
+      releaseYear !== null &&
+      Math.abs(releaseYear - year) <= RECOMMENDATIONS_YEAR_MATCH_TOLERANCE
+    );
+  });
+
+  return matched ?? results[0];
+}
+
+/**
  * OpenAIのレコメンド結果をTMDb検索で解決し、映画情報を取得する
  *
  * @param items - OpenAIが返したレコメンド項目
  * @param excludedIds - 除外するtmdb_movie_idの集合
+ * @param limit - 解決する最大件数（デフォルト: RECOMMENDATIONS_MAX_COUNT）
  * @returns 解決済みのレコメンド映画情報配列
  */
 export async function resolveRecommendationsWithTMDb(
   items: OpenAiRecommendationItem[],
   excludedIds: Set<number>,
+  limit: number = RECOMMENDATIONS_MAX_COUNT,
 ): Promise<ResolvedRecommendation[]> {
   const resolved: ResolvedRecommendation[] = [];
 
@@ -212,7 +261,7 @@ export async function resolveRecommendationsWithTMDb(
       });
 
       // タイトル一致かつ公開年が近い結果を優先的に選択
-      const movie = searchResult.results[0];
+      const movie = selectBestMovieMatch(searchResult.results, item.year);
       if (!movie) {
         continue;
       }
@@ -237,7 +286,7 @@ export async function resolveRecommendationsWithTMDb(
         display_order: resolved.length + 1,
       });
 
-      if (resolved.length >= RECOMMENDATIONS_MAX_COUNT) {
+      if (resolved.length >= limit) {
         break;
       }
     } catch (error) {

--- a/src/lib/recommendations/generateRecommendationsService.test.ts
+++ b/src/lib/recommendations/generateRecommendationsService.test.ts
@@ -10,6 +10,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
+  RECOMMENDATIONS_MAX_COUNT,
+  RECOMMENDATIONS_GENERATION_BUFFER,
+} from '@/constants';
+
+import {
   executeGenerateRecommendationsCron,
   fetchActiveUserIds,
   collectUserMovieData,
@@ -279,6 +284,19 @@ describe('generateRecommendationsService', () => {
   });
 
   describe('generateRecommendationsWithRetry', () => {
+    /** display_order を埋めた解決済みレコメンドを生成 */
+    const buildResolved = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        tmdb_movie_id: i + 1,
+        title: `Movie ${i + 1}`,
+        poster_path: null,
+        release_date: null,
+        vote_average: null,
+        genre_ids: null,
+        reason: `理由${i + 1}`,
+        display_order: i + 1,
+      }));
+
     it('OpenAIがnullを返したら空配列を返す', async () => {
       mockFetchRecommendations.mockResolvedValue(null);
 
@@ -290,6 +308,100 @@ describe('generateRecommendationsService', () => {
       );
 
       expect(result).toEqual([]);
+    });
+
+    it('初回は必要数＋バッファ件をAIに要求する', async () => {
+      mockFetchRecommendations.mockResolvedValueOnce(
+        Array.from({ length: RECOMMENDATIONS_MAX_COUNT }, (_, i) => ({
+          title: `Movie ${i + 1}`,
+          year: 2020,
+          reason: `理由${i + 1}`,
+        })),
+      );
+      // 初回で最大件数を解決 → リトライせず終了
+      mockResolveRecommendations.mockResolvedValueOnce(
+        buildResolved(RECOMMENDATIONS_MAX_COUNT),
+      );
+
+      await generateRecommendationsWithRetry(
+        [{ title: 'Fav', rating: 8 }],
+        [],
+        new Set(),
+        [],
+      );
+
+      // 第3引数（要求件数）が 最大件数＋バッファ であること
+      expect(mockFetchRecommendations.mock.calls[0][2]).toBe(
+        RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER,
+      );
+    });
+
+    it('バッファ分多く解決されても最大件数で丸める', async () => {
+      mockFetchRecommendations.mockResolvedValueOnce(
+        Array.from({ length: RECOMMENDATIONS_MAX_COUNT + 2 }, (_, i) => ({
+          title: `Movie ${i + 1}`,
+          year: 2020,
+          reason: `理由${i + 1}`,
+        })),
+      );
+      // 解決ロジックがバッファ込みで12件返しても、累積は10件で打ち切る
+      mockResolveRecommendations.mockResolvedValueOnce(
+        buildResolved(RECOMMENDATIONS_MAX_COUNT + 2),
+      );
+
+      const result = await generateRecommendationsWithRetry(
+        [{ title: 'Fav', rating: 8 }],
+        [],
+        new Set(),
+        [],
+      );
+
+      expect(result).toHaveLength(RECOMMENDATIONS_MAX_COUNT);
+      expect(result[result.length - 1].display_order).toBe(
+        RECOMMENDATIONS_MAX_COUNT,
+      );
+    });
+
+    it('初回で不足した場合、不足分＋バッファでリトライする', async () => {
+      // 初回: 9件解決（1件不足）
+      mockFetchRecommendations
+        .mockResolvedValueOnce(
+          Array.from({ length: RECOMMENDATIONS_MAX_COUNT }, (_, i) => ({
+            title: `Movie ${i + 1}`,
+            year: 2020,
+            reason: `理由${i + 1}`,
+          })),
+        )
+        .mockResolvedValueOnce([
+          { title: 'Extra', year: 2021, reason: '追加理由' },
+        ]);
+      mockResolveRecommendations
+        .mockResolvedValueOnce(buildResolved(RECOMMENDATIONS_MAX_COUNT - 1))
+        .mockResolvedValueOnce([
+          {
+            tmdb_movie_id: 999,
+            title: 'Extra',
+            poster_path: null,
+            release_date: null,
+            vote_average: null,
+            genre_ids: null,
+            reason: '追加理由',
+            display_order: 1,
+          },
+        ]);
+
+      const result = await generateRecommendationsWithRetry(
+        [{ title: 'Fav', rating: 8 }],
+        [],
+        new Set(),
+        [],
+      );
+
+      expect(result).toHaveLength(RECOMMENDATIONS_MAX_COUNT);
+      // リトライ時の要求件数は「不足1件＋バッファ」
+      expect(mockFetchRecommendations.mock.calls[1][2]).toBe(
+        1 + RECOMMENDATIONS_GENERATION_BUFFER,
+      );
     });
   });
 

--- a/src/lib/recommendations/generateRecommendationsService.ts
+++ b/src/lib/recommendations/generateRecommendationsService.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   RECOMMENDATIONS_MAX_COUNT,
   RECOMMENDATIONS_MAX_RETRIES,
+  RECOMMENDATIONS_GENERATION_BUFFER,
   RECOMMENDATIONS_ACTIVE_USER_DAYS,
   CRON_ERROR_MESSAGES,
 } from '@/constants';
@@ -190,10 +191,12 @@ export async function generateRecommendationsWithRetry(
   let retryExcludedIds = baseExcludedIds;
 
   for (let attempt = 0; attempt <= RECOMMENDATIONS_MAX_RETRIES; attempt++) {
+    // TMDb解決時の取りこぼし・除外を見越し、必要数より多め（+バッファ）に要求する
+    const requestCount = remainingCount + RECOMMENDATIONS_GENERATION_BUFFER;
     const aiRecommendations = await fetchRecommendationsFromOpenAI(
       favoriteMovies,
       retryExcludedTitles,
-      remainingCount,
+      requestCount,
       dismissedMovies,
     );
 
@@ -204,9 +207,14 @@ export async function generateRecommendationsWithRetry(
     const resolvedInAttempt = await resolveRecommendationsWithTMDb(
       aiRecommendations,
       retryExcludedIds,
+      remainingCount,
     );
 
     for (const item of resolvedInAttempt) {
+      // バッファ分多めに解決されても最大件数で丸める（オーバーシュート防止）
+      if (allResolved.length >= RECOMMENDATIONS_MAX_COUNT) {
+        break;
+      }
       if (allResolved.some((r) => r.tmdb_movie_id === item.tmdb_movie_id)) {
         continue;
       }

--- a/src/schema/recommendations.test.ts
+++ b/src/schema/recommendations.test.ts
@@ -3,10 +3,19 @@
  */
 
 import {
+  RECOMMENDATIONS_MAX_COUNT,
+  RECOMMENDATIONS_GENERATION_BUFFER,
+} from '@/constants';
+
+import {
   openAiRecommendationItemSchema,
   openAiRecommendationsResponseSchema,
   recommendationSchema,
 } from './recommendations';
+
+/** AIレスポンスで許容される最大件数（最大表示件数＋取りこぼし用バッファ） */
+const MAX_RESPONSE_COUNT =
+  RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER;
 
 describe('openAiRecommendationItemSchema', () => {
   it('有効な入力でパースが成功する', () => {
@@ -120,8 +129,8 @@ describe('openAiRecommendationsResponseSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('10件のレコメンドでパースが成功する（最大件数）', () => {
-    const items = Array.from({ length: 10 }, (_, i) => ({
+  it('最大件数＋バッファ件のレコメンドでパースが成功する（上限）', () => {
+    const items = Array.from({ length: MAX_RESPONSE_COUNT }, (_, i) => ({
       ...validItem,
       title: `映画${i + 1}`,
     }));
@@ -138,8 +147,8 @@ describe('openAiRecommendationsResponseSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('11件以上の場合エラーになる', () => {
-    const items = Array.from({ length: 11 }, (_, i) => ({
+  it('上限（最大件数＋バッファ）を超える場合エラーになる', () => {
+    const items = Array.from({ length: MAX_RESPONSE_COUNT + 1 }, (_, i) => ({
       ...validItem,
       title: `映画${i + 1}`,
     }));

--- a/src/schema/recommendations.ts
+++ b/src/schema/recommendations.ts
@@ -4,7 +4,18 @@
 
 import { z } from 'zod';
 
-import { RECOMMENDATIONS_MAX_COUNT, MOVIE_YEAR_RANGE } from '@/constants';
+import {
+  RECOMMENDATIONS_MAX_COUNT,
+  RECOMMENDATIONS_GENERATION_BUFFER,
+  MOVIE_YEAR_RANGE,
+} from '@/constants';
+
+/**
+ * AIに要求しうる最大件数（最大表示件数＋取りこぼし用バッファ）
+ * バッファ分多めに要求するため、レスポンス検証の上限もこれに合わせる。
+ */
+const OPENAI_RECOMMENDATIONS_MAX_RESPONSE =
+  RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER;
 
 /**
  * OpenAIレスポンスの個別レコメンド項目スキーマ
@@ -27,8 +38,8 @@ export const openAiRecommendationsResponseSchema = z.object({
     .array(openAiRecommendationItemSchema)
     .min(1, 'レコメンドは1件以上必要です')
     .max(
-      RECOMMENDATIONS_MAX_COUNT,
-      `レコメンドは${RECOMMENDATIONS_MAX_COUNT}件以下にしてください`,
+      OPENAI_RECOMMENDATIONS_MAX_RESPONSE,
+      `レコメンドは${OPENAI_RECOMMENDATIONS_MAX_RESPONSE}件以下にしてください`,
     ),
 });
 


### PR DESCRIPTION
## 概要
「あなたへのおすすめ」が最大10件（`RECOMMENDATIONS_MAX_COUNT`）の想定に対し9件以下になる問題を修正する。

実データ（adminユーザー）を確認した結果、取得時の `dismissed_movies` フィルタが原因ではなく、**生成段階でTMDb解決の取りこぼし・除外により10件に届かず、リトライでも埋められていない**ことが判明した。

### 修正内容
- **TMDb解決の年ベース選別**: AIが返した公開年(`year`)に最も近い候補を選ぶよう変更（従来は `results[0]` 固定で `year` を選別に未使用。同名異作への誤マッチによる衝突・脱落の一因だった）
- **バッファ付き要求**: 取りこぼし・除外を見越し、必要数＋`RECOMMENDATIONS_GENERATION_BUFFER`(=5) でAIに多めに要求し、1回の生成で最大件数を満たしやすくする
- **limit引数**: `resolveRecommendationsWithTMDb` に `limit` を追加し必要数で打ち切り
- **オーバーシュート防止**: 解決数が最大件数を超えても丸めるガードを追加
- **スキーマ上限緩和**: AIレスポンス検証の上限を 最大件数＋バッファ に変更

## ロードマップ
該当タスクなし（バグ修正）

## レビューポイント
- `selectBestMovieMatch` の年ベース選別ロジック（許容差 `RECOMMENDATIONS_YEAR_MATCH_TOLERANCE`=±1年、一致なしは関連度最上位にフォールバック）
- バッファ要求とオーバーシュート防止ガードの組み合わせで件数が最大件数を超えないこと
- スキーマ上限緩和が他の利用箇所に影響しないこと

## テスト
- 年ベース選別（一致優先 / 許容外は先頭 / 空日付）・`limit` 打ち切りのユニットテストを追加
- バッファ要求件数・オーバーシュート防止・不足時リトライのテストを追加
- スキーマ上限テストを新しい上限に更新
- 変更ファイルのカバレッジ: schema 100%、generateRecommendations 100/93、service 95/87（全て80%以上）
- `tsc --noEmit` / `eslint` パス

Closes #365