### PR TITLE
fix: スマホのサイドメニューに未認証時のログイン導線を追加

### DIFF
--- a/e2e/mobile/mobileLoginEntry.spec.ts
+++ b/e2e/mobile/mobileLoginEntry.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * モバイル ログイン導線 E2Eテスト（未認証）
+ * SP表示幅で、ログアウト状態でもサイドメニューからログインできることを確認する
+ */
+
+import { test, expect } from '../fixtures/auth';
+
+test.describe('モバイル ログイン導線（未認証）', () => {
+  // storageStateを空にして未認証状態にする
+  test.use({
+    storageState: { cookies: [], origins: [] },
+    viewport: { width: 375, height: 812 },
+  });
+
+  test('未認証時、サイドメニューにログインボタンが表示される', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+    await expect(page.getByText('メニュー')).toBeVisible();
+
+    // 未認証時はログインボタンが表示され、設定/ログアウトは表示されない
+    await expect(page.getByRole('button', { name: 'ログイン' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '設定' })).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'ログアウト' }),
+    ).not.toBeVisible();
+  });
+
+  test('ログインボタンクリックでサインインページへ遷移する', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'メニューを開く' }).click();
+    await page.getByRole('button', { name: 'ログイン' }).click();
+
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+});

--- a/src/components/layout/mobileDrawer/mobileDrawer.test.tsx
+++ b/src/components/layout/mobileDrawer/mobileDrawer.test.tsx
@@ -134,6 +134,35 @@ describe('MobileDrawer', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('未認証の場合はログインボタンが表示される', () => {
+    mockSessionData = {
+      data: null,
+      status: 'unauthenticated',
+    };
+    render(<MobileDrawer {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /ログイン/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('認証済みの場合はログインボタンが表示されない', () => {
+    render(<MobileDrawer {...defaultProps} />);
+    expect(
+      screen.queryByRole('button', { name: /ログイン/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('ログインボタンクリックでサインインページに遷移する', async () => {
+    mockSessionData = {
+      data: null,
+      status: 'unauthenticated',
+    };
+    const user = userEvent.setup();
+    render(<MobileDrawer {...defaultProps} />);
+    await user.click(screen.getByRole('button', { name: /ログイン/ }));
+    expect(mockPush).toHaveBeenCalledWith('/auth/signin');
+  });
+
   it('設定ボタンクリックで設定ページに遷移する', async () => {
     const user = userEvent.setup();
     render(<MobileDrawer {...defaultProps} />);

--- a/src/components/layout/mobileDrawer/mobileDrawer.tsx
+++ b/src/components/layout/mobileDrawer/mobileDrawer.tsx
@@ -19,6 +19,7 @@ import {
   IoBookmarkOutline,
   IoSettingsOutline,
   IoLogOutOutline,
+  IoLogInOutline,
   IoCloseOutline,
 } from 'react-icons/io5';
 
@@ -112,6 +113,10 @@ export const MobileDrawer = memo<MobileDrawerProps>(function MobileDrawer({
 
   const handleNavigateToSettings = useCallback(() => {
     router.push(ROUTES.SETTINGS);
+  }, [router]);
+
+  const handleLogin = useCallback(() => {
+    router.push(ROUTES.LOGIN);
   }, [router]);
 
   const handleLogout = useCallback(async () => {
@@ -209,6 +214,21 @@ export const MobileDrawer = memo<MobileDrawerProps>(function MobileDrawer({
                 >
                   <IoLogOutOutline size={ICON_SIZES.SM} aria-hidden='true' />
                   <span>{MENU_LABELS.LOGOUT}</span>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {!isAuthenticated && (
+            <div className={styles.c_mobile_drawer__user}>
+              <div className={styles.c_mobile_drawer__user_actions}>
+                <button
+                  type='button'
+                  className={styles.c_mobile_drawer__user_action}
+                  onClick={handleLogin}
+                >
+                  <IoLogInOutline size={ICON_SIZES.SM} aria-hidden='true' />
+                  <span>{MENU_LABELS.LOGIN}</span>
                 </button>
               </div>
             </div>

--- a/src/components/layout/userMenu/userMenu.tsx
+++ b/src/components/layout/userMenu/userMenu.tsx
@@ -53,12 +53,12 @@ export const UserMenu = memo(function UserMenu() {
       <button
         className={styles.c_user_menu__login_button}
         onClick={handleLogin}
-        aria-label='ログイン'
+        aria-label={MENU_LABELS.LOGIN}
       >
         <span className={styles.c_user_menu__login_icon}>
           <IoLogInOutline />
         </span>
-        <span className={styles.c_user_menu__name}>ログイン</span>
+        <span className={styles.c_user_menu__name}>{MENU_LABELS.LOGIN}</span>
       </button>
     );
   }

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -32,4 +32,5 @@ export const NAV_ITEMS: NavItemBase[] = [
 export const MENU_LABELS = {
   SETTINGS: '設定',
   LOGOUT: 'ログアウト',
+  LOGIN: 'ログイン',
 } as const;


### PR DESCRIPTION
## 概要
スマホレイアウトのログアウト状態で、ログインに辿り着く導線がどこにも無い問題を修正する。

`MobileDrawer` は認証時のみ「設定/ログアウト」フッターを描画しており、未認証時のログイン導線が欠けていた（`mobileDrawer.tsx` の `{isAuthenticated && ...}` に else 分岐なし）。モバイルヘッダーもハンバーガー＋検索のみのため、未認証ユーザーはURL直打ち以外でログインできなかった。

### 修正内容
- `MobileDrawer` に未認証時フッター（ログインボタン）を追加。既存の `c_mobile_drawer__user` / `c_mobile_drawer__user_action` スタイルを再利用（新規スタイルなし）
- 押下で `/auth/signin` へ遷移（PCヘッダー `userMenu` の未認証時挙動と統一）
- `MENU_LABELS` に `LOGIN` を追加し、PC `userMenu` のハードコード文言（'ログイン'）も定数に置換

### 動作確認
- スマホレイアウト・ログアウト状態でサイドメニューに「ログイン」表示 → クリックで `/auth/signin` 遷移を実機（agent-browser）で確認
- Next.js Dev Tools バッジ：エラーなし

## ロードマップ
該当タスクなし（バグ修正）

## レビューポイント
- 認証/未認証でフッターが排他的に出し分けされること（`{isAuthenticated && ...}` と `{!isAuthenticated && ...}`）
- 既存スタイルの再利用で見た目が「設定/ログアウト」フッターと一貫しているか

## テスト
- 未認証時にログインボタン表示 / 認証時は非表示 / クリックで `/auth/signin` 遷移、の3ケースを追加
- `tsc --noEmit` / `eslint` パス、関連スイート 29件パス

Closes #368