### PR TITLE
improve: ナビの保護ルートを未認証時はログイン誘導に統一

### DIFF
--- a/e2e/auth/navLoginPrompt.spec.ts
+++ b/e2e/auth/navLoginPrompt.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * ナビゲーションからのログイン誘導 E2Eテスト（未認証）
+ * 保護ルートのナビリンクを未認証で押すと、無言リダイレクトではなく
+ * ログイン誘導モーダルが表示されることを確認する。
+ */
+
+import { test, expect } from '../fixtures/auth';
+
+test.describe('ナビゲーションからのログイン誘導（未認証）', () => {
+  // storageStateを空にして未認証状態にする
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('未認証でお気に入りリンクを押すとログイン誘導モーダルが表示される', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'お気に入り' }).click();
+
+    // リダイレクトされずモーダルが表示される
+    await expect(page).toHaveURL('/');
+    const dialog = page.getByRole('dialog', { name: 'ログインが必要です' });
+    await expect(dialog).toBeVisible();
+    await expect(
+      page.getByText('お気に入りを見るにはログインが必要です。'),
+    ).toBeVisible();
+  });
+
+  test('ログイン誘導モーダルのログインボタンでサインインページへ遷移する', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'ウォッチリスト' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'ログインが必要です' });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'ログイン' }).click();
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+});

--- a/src/components/layout/mobileDrawer/mobileDrawer.test.tsx
+++ b/src/components/layout/mobileDrawer/mobileDrawer.test.tsx
@@ -36,6 +36,13 @@ jest.mock('next-auth/react', () => ({
   signOut: (...args: unknown[]) => mockSignOut(...args),
 }));
 
+// ログイン誘導ストアのモック（useNavAuthGuard が使用）
+const mockOpenLoginPrompt = jest.fn();
+jest.mock('@/lib/store/useLoginPromptStore', () => ({
+  useLoginPromptStore: (selector: (s: { open: jest.Mock }) => unknown) =>
+    selector({ open: mockOpenLoginPrompt }),
+}));
+
 describe('MobileDrawer', () => {
   const defaultProps = {
     open: true,
@@ -161,6 +168,23 @@ describe('MobileDrawer', () => {
     render(<MobileDrawer {...defaultProps} />);
     await user.click(screen.getByRole('button', { name: /ログイン/ }));
     expect(mockPush).toHaveBeenCalledWith('/auth/signin');
+  });
+
+  it('未認証で保護ルート(お気に入り)クリックでログイン誘導が表示されドロワーが閉じる', async () => {
+    mockSessionData = {
+      data: null,
+      status: 'unauthenticated',
+    };
+    const onOpenChange = jest.fn();
+    const user = userEvent.setup();
+    render(<MobileDrawer {...defaultProps} onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole('link', { name: 'お気に入り' }));
+
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'お気に入りを見るにはログインが必要です。',
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('設定ボタンクリックで設定ページに遷移する', async () => {

--- a/src/components/layout/mobileDrawer/mobileDrawer.tsx
+++ b/src/components/layout/mobileDrawer/mobileDrawer.tsx
@@ -6,6 +6,7 @@
 'use client';
 
 import { memo, useCallback, useMemo } from 'react';
+import type { MouseEvent } from 'react';
 import { signOut, useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -33,6 +34,7 @@ import {
   MODAL_TITLES,
 } from '@/constants';
 import { getInitial } from '@/utils/user';
+import { useNavAuthGuard } from '@/hooks/useNavAuthGuard';
 
 import styles from './mobileDrawer.module.scss';
 
@@ -95,6 +97,7 @@ export const MobileDrawer = memo<MobileDrawerProps>(function MobileDrawer({
   const { data: session, status } = useSession();
   const pathname = usePathname();
   const router = useRouter();
+  const { handleProtectedNavClick } = useNavAuthGuard();
 
   const userName = session?.user?.name ?? '';
   const userEmail = session?.user?.email ?? '';
@@ -109,6 +112,18 @@ export const MobileDrawer = memo<MobileDrawerProps>(function MobileDrawer({
         isActive: pathname === item.href,
       })),
     [pathname],
+  );
+
+  const handleNavLinkClick = useCallback(
+    (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+      handleProtectedNavClick(href)(event);
+      // 未認証で保護ルートを押した場合は遷移せずモーダルを出すため、
+      // ドロワーを閉じてオーバーレイの重なりを避ける
+      if (event.defaultPrevented) {
+        onOpenChange(false);
+      }
+    },
+    [handleProtectedNavClick, onOpenChange],
   );
 
   const handleNavigateToSettings = useCallback(() => {
@@ -158,6 +173,7 @@ export const MobileDrawer = memo<MobileDrawerProps>(function MobileDrawer({
                     href={item.href}
                     className={`${styles.c_mobile_drawer__nav_link} ${item.isActive ? styles['c_mobile_drawer__nav_link--active'] : ''}`}
                     aria-current={item.isActive ? 'page' : undefined}
+                    onClick={handleNavLinkClick(item.href)}
                   >
                     <span
                       className={styles.c_mobile_drawer__nav_icon}

--- a/src/components/layout/sideNav/sideNav.test.tsx
+++ b/src/components/layout/sideNav/sideNav.test.tsx
@@ -4,6 +4,7 @@
 
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { SideNav } from './sideNav';
 
@@ -13,9 +14,24 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
 }));
 
+// next-auth のモック（useNavAuthGuard が使用）
+let mockAuthStatus = 'unauthenticated';
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: mockAuthStatus }),
+}));
+
+// ログイン誘導ストアのモック
+const mockOpenLoginPrompt = jest.fn();
+jest.mock('@/lib/store/useLoginPromptStore', () => ({
+  useLoginPromptStore: (selector: (s: { open: jest.Mock }) => unknown) =>
+    selector({ open: mockOpenLoginPrompt }),
+}));
+
 describe('SideNav', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockPathname.mockReturnValue('/');
+    mockAuthStatus = 'unauthenticated';
   });
 
   it('ナビゲーションリンクが表示される', () => {
@@ -89,5 +105,16 @@ describe('SideNav', () => {
 
     const upcomingLink = screen.getByText('公開予定');
     expect(upcomingLink).not.toHaveAttribute('aria-current');
+  });
+
+  it('未認証で保護ルート(お気に入り)クリックでログイン誘導が表示される', async () => {
+    const user = userEvent.setup();
+    render(<SideNav />);
+
+    await user.click(screen.getByText('お気に入り'));
+
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'お気に入りを見るにはログインが必要です。',
+    );
   });
 });

--- a/src/components/layout/sideNav/sideNav.tsx
+++ b/src/components/layout/sideNav/sideNav.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { NAV_ITEMS } from '@/constants';
+import { useNavAuthGuard } from '@/hooks/useNavAuthGuard';
 
 import styles from './sideNav.module.scss';
 
@@ -18,6 +19,7 @@ import styles from './sideNav.module.scss';
  */
 export const SideNav = memo(function SideNav() {
   const pathname = usePathname();
+  const { handleProtectedNavClick } = useNavAuthGuard();
 
   const navItems = useMemo(
     () =>
@@ -37,6 +39,7 @@ export const SideNav = memo(function SideNav() {
               href={item.href}
               className={`${styles.c_side_nav__link} ${item.isActive ? styles['c_side_nav__link--active'] : ''}`}
               aria-current={item.isActive ? 'page' : undefined}
+              onClick={handleProtectedNavClick(item.href)}
             >
               {item.label}
             </Link>

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -45,6 +45,17 @@ export const ROUTES = {
 } as const;
 
 /**
+ * 認証が必要なルート（middleware と ナビゲーションの共通定義）
+ * 未認証アクセス時は middleware がリダイレクトし、ナビからはログイン誘導を表示する。
+ */
+export const AUTH_REQUIRED_ROUTES = [
+  ROUTES.WATCHLIST,
+  ROUTES.SETTINGS,
+  ROUTES.FAVORITES,
+  ROUTES.THEATER_EXPERIENCE,
+] as const;
+
+/**
  * エラーメッセージ生成ヘルパー
  */
 export const errorMessage = {

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -36,11 +36,17 @@ export const MENU_LABELS = {
 } as const;
 
 /**
- * 保護ルートをナビゲーションから開こうとした際の、未認証ユーザー向け誘導メッセージ
- * ルートのパスをキーに引く。
+ * 保護ルートをナビゲーションから開こうとした際の、未認証ユーザー向け誘導メッセージ。
+ * 「保護対象かどうか」の判定は AUTH_REQUIRED_ROUTES が真実源であり、ここは表示文言のみ。
+ * AUTH_REQUIRED_ROUTES のうちナビに出るルートはここに文言を用意し、
+ * 未定義のルートは NAV_AUTH_PROMPT_DEFAULT_MESSAGE にフォールバックする。
  */
 export const NAV_AUTH_PROMPT_MESSAGES: Record<string, string> = {
   [ROUTES.FAVORITES]: 'お気に入りを見るにはログインが必要です。',
   [ROUTES.WATCHLIST]: 'ウォッチリストを見るにはログインが必要です。',
   [ROUTES.THEATER_EXPERIENCE]: 'シアター体験を見るにはログインが必要です。',
 };
+
+/** 保護ルート用メッセージが未定義の場合のデフォルト誘導文言 */
+export const NAV_AUTH_PROMPT_DEFAULT_MESSAGE =
+  'このページを見るにはログインが必要です。';

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -34,3 +34,13 @@ export const MENU_LABELS = {
   LOGOUT: 'ログアウト',
   LOGIN: 'ログイン',
 } as const;
+
+/**
+ * 保護ルートをナビゲーションから開こうとした際の、未認証ユーザー向け誘導メッセージ
+ * ルートのパスをキーに引く。
+ */
+export const NAV_AUTH_PROMPT_MESSAGES: Record<string, string> = {
+  [ROUTES.FAVORITES]: 'お気に入りを見るにはログインが必要です。',
+  [ROUTES.WATCHLIST]: 'ウォッチリストを見るにはログインが必要です。',
+  [ROUTES.THEATER_EXPERIENCE]: 'シアター体験を見るにはログインが必要です。',
+};

--- a/src/hooks/useNavAuthGuard.test.ts
+++ b/src/hooks/useNavAuthGuard.test.ts
@@ -78,4 +78,17 @@ describe('useNavAuthGuard', () => {
       'シアター体験を見るにはログインが必要です。',
     );
   });
+
+  it('個別メッセージ未定義の保護ルート(設定)はデフォルト文言で誘導する', () => {
+    const { result } = renderHook(() => useNavAuthGuard());
+    const event = createEvent();
+
+    // SETTINGS は AUTH_REQUIRED_ROUTES に含まれるが個別メッセージは未定義
+    result.current.handleProtectedNavClick(ROUTES.SETTINGS)(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'このページを見るにはログインが必要です。',
+    );
+  });
 });

--- a/src/hooks/useNavAuthGuard.test.ts
+++ b/src/hooks/useNavAuthGuard.test.ts
@@ -1,0 +1,81 @@
+/**
+ * useNavAuthGuard フックのテスト
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { MouseEvent } from 'react';
+
+import { ROUTES } from '@/constants/common';
+
+import { useNavAuthGuard } from './useNavAuthGuard';
+
+let mockAuthStatus = 'unauthenticated';
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: mockAuthStatus }),
+}));
+
+const mockOpenLoginPrompt = jest.fn();
+jest.mock('@/lib/store/useLoginPromptStore', () => ({
+  useLoginPromptStore: (selector: (s: { open: jest.Mock }) => unknown) =>
+    selector({ open: mockOpenLoginPrompt }),
+}));
+
+/** preventDefault を持つ最小限のイベントモック */
+const createEvent = () =>
+  ({ preventDefault: jest.fn() }) as unknown as MouseEvent<HTMLAnchorElement>;
+
+describe('useNavAuthGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthStatus = 'unauthenticated';
+  });
+
+  it('未認証で保護ルートをクリックすると遷移をキャンセルしログイン誘導を表示する', () => {
+    const { result } = renderHook(() => useNavAuthGuard());
+    const event = createEvent();
+
+    result.current.handleProtectedNavClick(ROUTES.FAVORITES)(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'お気に入りを見るにはログインが必要です。',
+    );
+  });
+
+  it('未認証でも公開ルートは遷移を許可しログイン誘導を出さない', () => {
+    const { result } = renderHook(() => useNavAuthGuard());
+    const event = createEvent();
+
+    result.current.handleProtectedNavClick(ROUTES.UPCOMING)(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockOpenLoginPrompt).not.toHaveBeenCalled();
+  });
+
+  it('認証済みなら保護ルートでも遷移を許可しログイン誘導を出さない', () => {
+    mockAuthStatus = 'authenticated';
+    const { result } = renderHook(() => useNavAuthGuard());
+    const event = createEvent();
+
+    result.current.handleProtectedNavClick(ROUTES.WATCHLIST)(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(mockOpenLoginPrompt).not.toHaveBeenCalled();
+  });
+
+  it('保護ルートごとに適切なメッセージを表示する', () => {
+    const { result } = renderHook(() => useNavAuthGuard());
+
+    result.current.handleProtectedNavClick(ROUTES.WATCHLIST)(createEvent());
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'ウォッチリストを見るにはログインが必要です。',
+    );
+
+    result.current.handleProtectedNavClick(ROUTES.THEATER_EXPERIENCE)(
+      createEvent(),
+    );
+    expect(mockOpenLoginPrompt).toHaveBeenCalledWith(
+      'シアター体験を見るにはログインが必要です。',
+    );
+  });
+});

--- a/src/hooks/useNavAuthGuard.ts
+++ b/src/hooks/useNavAuthGuard.ts
@@ -13,7 +13,11 @@ import { useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import type { MouseEvent } from 'react';
 
-import { NAV_AUTH_PROMPT_MESSAGES } from '@/constants';
+import {
+  AUTH_REQUIRED_ROUTES,
+  NAV_AUTH_PROMPT_MESSAGES,
+  NAV_AUTH_PROMPT_DEFAULT_MESSAGE,
+} from '@/constants';
 import { useLoginPromptStore } from '@/lib/store/useLoginPromptStore';
 
 /**
@@ -26,17 +30,20 @@ export function useNavAuthGuard() {
 
   const handleProtectedNavClick = useCallback(
     (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
-      // 認証済み、または保護対象でないルートは通常遷移
+      // 認証済みは通常遷移
       if (isAuthenticated) {
         return;
       }
-      const message = NAV_AUTH_PROMPT_MESSAGES[href];
-      if (!message) {
+      // 「保護対象か」は middleware と共通の AUTH_REQUIRED_ROUTES を真実源に判定する
+      const isProtected = AUTH_REQUIRED_ROUTES.some((route) => route === href);
+      if (!isProtected) {
         return;
       }
       // 未認証 かつ 保護ルート → 遷移をキャンセルしてログイン誘導
       event.preventDefault();
-      openLoginPrompt(message);
+      openLoginPrompt(
+        NAV_AUTH_PROMPT_MESSAGES[href] ?? NAV_AUTH_PROMPT_DEFAULT_MESSAGE,
+      );
     },
     [isAuthenticated, openLoginPrompt],
   );

--- a/src/hooks/useNavAuthGuard.ts
+++ b/src/hooks/useNavAuthGuard.ts
@@ -1,0 +1,45 @@
+/**
+ * useNavAuthGuard
+ * ナビゲーションの保護ルートに対する未認証時のクリック制御フック。
+ *
+ * 未認証ユーザーが保護ルート（お気に入り・ウォッチリスト・シアター体験）の
+ * ナビリンクを押した場合、遷移をキャンセルしてログイン誘導モーダルを表示する。
+ * これによりミドルウェアの無言リダイレクトではなく、ボタン操作と同じ体験に統一する。
+ */
+
+'use client';
+
+import { useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import type { MouseEvent } from 'react';
+
+import { NAV_AUTH_PROMPT_MESSAGES } from '@/constants';
+import { useLoginPromptStore } from '@/lib/store/useLoginPromptStore';
+
+/**
+ * @returns handleProtectedNavClick - ナビリンクの href を受け取り、onClick ハンドラを返す
+ */
+export function useNavAuthGuard() {
+  const { status } = useSession();
+  const isAuthenticated = status === 'authenticated';
+  const openLoginPrompt = useLoginPromptStore((s) => s.open);
+
+  const handleProtectedNavClick = useCallback(
+    (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+      // 認証済み、または保護対象でないルートは通常遷移
+      if (isAuthenticated) {
+        return;
+      }
+      const message = NAV_AUTH_PROMPT_MESSAGES[href];
+      if (!message) {
+        return;
+      }
+      // 未認証 かつ 保護ルート → 遷移をキャンセルしてログイン誘導
+      event.preventDefault();
+      openLoginPrompt(message);
+    },
+    [isAuthenticated, openLoginPrompt],
+  );
+
+  return { handleProtectedNavClick };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,7 @@
 import { NextResponse } from 'next/server';
 
 import { auth } from '@/lib/auth/auth';
-import { ROUTES } from '@/constants/common';
+import { ROUTES, AUTH_REQUIRED_ROUTES } from '@/constants/common';
 
 /** セッションcookie名（環境に応じて切り替え） */
 const SESSION_COOKIE_NAME =
@@ -13,13 +13,8 @@ const SESSION_COOKIE_NAME =
     ? '__Secure-next-auth.session-token'
     : 'next-auth.session-token';
 
-/** 認証が必要なパス */
-const protectedPaths = [
-  ROUTES.WATCHLIST,
-  ROUTES.SETTINGS,
-  ROUTES.FAVORITES,
-  ROUTES.THEATER_EXPERIENCE,
-];
+/** 認証が必要なパス（ナビゲーションと共通定義） */
+const protectedPaths = AUTH_REQUIRED_ROUTES;
 
 /** 認証ページ */
 const authPaths = [ROUTES.LOGIN, ROUTES.REGISTER];


### PR DESCRIPTION
## 概要
「要ログイン」の伝え方を統一する。未認証ユーザーが保護ルート（お気に入り/ウォッチリスト/シアター体験）のナビリンクを押した際、`middleware` の**無言リダイレクト**ではなく、ボタン操作（❤️・ウォッチリスト）と同じ `LoginPromptModal` で理由を提示してログインへ誘導する。

### 修正内容
- **`useNavAuthGuard` フック追加**：未認証 × 保護ルートのクリックを `preventDefault` し、ルート別メッセージで `openLoginPrompt` を呼ぶ
- **`SideNav` / `MobileDrawer`** のナビリンクに適用。`MobileDrawer` では誘導表示時にドロワーを閉じ、オーバーレイの重なりを回避
- **保護ルートを `AUTH_REQUIRED_ROUTES` に集約**（`constants/common.ts`）し、`middleware` と ナビで共有（真実源を一元化）。`NAV_AUTH_PROMPT_MESSAGES` でルート別メッセージを定義
- **`middleware` は防御の最終ライン**として維持（直URLアクセス・JS無効時のフォールバック）

### 動作確認
- 未認証で「お気に入り」クリック → 遷移せず `LoginPromptModal`（「お気に入りを見るにはログインが必要です。」）表示を実機（agent-browser）で確認
- Next.js Dev Tools バッジ：エラーなし

## ロードマップ
該当タスクなし（UX改善）

## レビューポイント
- `useNavAuthGuard` の判定（未認証 × 保護ルートのみ `preventDefault`、公開・認証済みは通常遷移）
- `MobileDrawer` でモーダル表示時にドロワーが閉じること（`event.defaultPrevented` で判定）
- `AUTH_REQUIRED_ROUTES` 一元化による `middleware` への影響がないこと

## テスト
- `useNavAuthGuard` 単体（未認証×保護/公開・認証済み・ルート別メッセージ）
- `SideNav` / `MobileDrawer` の配線テスト（誘導表示・ドロワー閉じ）
- E2E：未認証ナビクリックでモーダル表示・ログイン遷移（`e2e/auth/navLoginPrompt.spec.ts`）
- 全ユニット 2258件 / 追加E2E 3件 パス、`tsc` / `eslint` パス

Closes #369