### PR TITLE
improve: ログイン後に元のページへ戻す（callbackUrl 保持）

### DIFF
--- a/e2e/auth/signin.spec.ts
+++ b/e2e/auth/signin.spec.ts
@@ -21,6 +21,22 @@ test.describe('ログイン認証フロー', () => {
     await expect(page).toHaveURL('/');
   });
 
+  test('保護ページへの未認証アクセス後、ログインすると元のページへ戻る', async ({
+    page,
+  }) => {
+    // 未認証で保護ページにアクセス → callbackUrl付きでサインインへリダイレクト
+    await page.goto('/watchlist');
+    await expect(page).toHaveURL(/\/auth\/signin\?callbackUrl=/);
+
+    await page.getByLabel('メールアドレス').fill(TEST_USER.email);
+    await page.getByLabel('パスワード').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
+
+    // ホームではなく元の保護ページに戻る
+    await page.waitForURL('/watchlist');
+    await expect(page).toHaveURL('/watchlist');
+  });
+
   test('不正な認証情報でエラーメッセージが表示される', async ({ page }) => {
     await page.goto('/auth/signin');
 

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -12,10 +12,14 @@ export const metadata: Metadata = {
 };
 
 interface SignInPageProps {
-  searchParams: Promise<{ callbackUrl?: string }>;
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
 }
 
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const { callbackUrl } = await searchParams;
-  return <SignInContent callbackUrl={callbackUrl} />;
+  // 重複指定（?callbackUrl=a&callbackUrl=b）で配列になる場合は先頭を採用
+  const normalizedCallbackUrl = Array.isArray(callbackUrl)
+    ? callbackUrl[0]
+    : callbackUrl;
+  return <SignInContent callbackUrl={normalizedCallbackUrl} />;
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -17,9 +17,9 @@ interface SignInPageProps {
 
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const { callbackUrl } = await searchParams;
-  // 重複指定（?callbackUrl=a&callbackUrl=b）で配列になる場合は先頭を採用
-  const normalizedCallbackUrl = Array.isArray(callbackUrl)
-    ? callbackUrl[0]
-    : callbackUrl;
-  return <SignInContent callbackUrl={normalizedCallbackUrl} />;
+  // 重複指定（?callbackUrl=a&callbackUrl=b）等で配列になった場合は不正として扱い、
+  // resolveSafeCallbackUrl と同様にホームへフォールバックさせる（文字列のみ採用）
+  const callbackUrlParam =
+    typeof callbackUrl === 'string' ? callbackUrl : undefined;
+  return <SignInContent callbackUrl={callbackUrlParam} />;
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   description: 'Movie Appにログイン',
 };
 
-export default function SignInPage() {
-  return <SignInContent />;
+interface SignInPageProps {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const { callbackUrl } = await searchParams;
+  return <SignInContent callbackUrl={callbackUrl} />;
 }

--- a/src/features/auth/loginForm/loginForm.tsx
+++ b/src/features/auth/loginForm/loginForm.tsx
@@ -23,11 +23,14 @@ import {
 } from '@/constants';
 import { useToast } from '@/hooks/useToast';
 import { handleApiError } from '@/utils/error';
+import { resolveSafeCallbackUrl } from '@/utils/url';
 import { SocialLoginButtons } from '@/features/auth/socialLoginButtons/socialLoginButtons';
 import styles from './loginForm.module.scss';
 
 interface LoginFormProps {
   onOtpLoginClick?: () => void;
+  /** ログイン後の戻り先（callbackUrl） */
+  callbackUrl?: string;
 }
 
 /**
@@ -35,6 +38,7 @@ interface LoginFormProps {
  */
 export const LoginForm = memo<LoginFormProps>(function LoginForm({
   onOtpLoginClick,
+  callbackUrl,
 }) {
   const router = useRouter();
   const { toast } = useToast();
@@ -79,7 +83,7 @@ export const LoginForm = memo<LoginFormProps>(function LoginForm({
           variant: 'success',
         });
 
-        router.push(ROUTES.HOME);
+        router.push(resolveSafeCallbackUrl(callbackUrl));
       } catch (error) {
         const { message } = handleApiError(error);
         setApiError(message);
@@ -90,7 +94,7 @@ export const LoginForm = memo<LoginFormProps>(function LoginForm({
         });
       }
     },
-    [router, toast],
+    [router, toast, callbackUrl],
   );
 
   return (
@@ -146,7 +150,7 @@ export const LoginForm = memo<LoginFormProps>(function LoginForm({
         </div>
       </form>
 
-      <SocialLoginButtons disabled={isSubmitting} />
+      <SocialLoginButtons disabled={isSubmitting} callbackUrl={callbackUrl} />
 
       {onOtpLoginClick && (
         <p className={styles.c_login_form__footer}>

--- a/src/features/auth/otpLoginForm/hooks/useOtpLogin.ts
+++ b/src/features/auth/otpLoginForm/hooks/useOtpLogin.ts
@@ -11,14 +11,10 @@ import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 
 import { OTP_ACTION } from '@/constants/otp';
-import {
-  AUTH_ERROR_MESSAGES,
-  TOAST_TITLES,
-  TOAST_MESSAGES,
-  ROUTES,
-} from '@/constants';
+import { AUTH_ERROR_MESSAGES, TOAST_TITLES, TOAST_MESSAGES } from '@/constants';
 import { useToast } from '@/hooks/useToast';
 import { handleApiError } from '@/utils/error';
+import { resolveSafeCallbackUrl } from '@/utils/url';
 
 type OtpLoginStep = 'email' | 'otp';
 
@@ -32,7 +28,7 @@ interface UseOtpLoginReturn {
   handleBackToEmail: () => void;
 }
 
-export function useOtpLogin(): UseOtpLoginReturn {
+export function useOtpLogin(callbackUrl?: string): UseOtpLoginReturn {
   const router = useRouter();
   const { toast } = useToast();
   const [step, setStep] = useState<OtpLoginStep>('email');
@@ -100,7 +96,7 @@ export function useOtpLogin(): UseOtpLoginReturn {
         variant: 'success',
       });
 
-      router.push(ROUTES.HOME);
+      router.push(resolveSafeCallbackUrl(callbackUrl));
     } catch (error) {
       const { message } = handleApiError(error);
       setApiError(message || AUTH_ERROR_MESSAGES.INVALID_CREDENTIALS);
@@ -112,7 +108,7 @@ export function useOtpLogin(): UseOtpLoginReturn {
     } finally {
       setIsSubmitting(false);
     }
-  }, [email, router, toast]);
+  }, [email, router, toast, callbackUrl]);
 
   const handleBackToEmail = useCallback(() => {
     setStep('email');

--- a/src/features/auth/otpLoginForm/otpLoginForm.tsx
+++ b/src/features/auth/otpLoginForm/otpLoginForm.tsx
@@ -22,10 +22,13 @@ import styles from './otpLoginForm.module.scss';
 
 interface OtpLoginFormProps {
   onPasswordLoginClick?: () => void;
+  /** ログイン後の戻り先（callbackUrl） */
+  callbackUrl?: string;
 }
 
 export const OtpLoginForm = memo<OtpLoginFormProps>(function OtpLoginForm({
   onPasswordLoginClick,
+  callbackUrl,
 }) {
   const {
     step,
@@ -35,7 +38,7 @@ export const OtpLoginForm = memo<OtpLoginFormProps>(function OtpLoginForm({
     handleSendOtp,
     handleOtpVerifySuccess,
     handleBackToEmail,
-  } = useOtpLogin();
+  } = useOtpLogin(callbackUrl);
 
   const {
     register,

--- a/src/features/auth/signInContent/signInContent.tsx
+++ b/src/features/auth/signInContent/signInContent.tsx
@@ -13,7 +13,14 @@ import { OtpLoginForm } from '@/features/auth/otpLoginForm/otpLoginForm';
 
 type LoginMode = 'password' | 'otp';
 
-export const SignInContent = memo(function SignInContent() {
+interface SignInContentProps {
+  /** ログイン後の戻り先（middlewareが付与する callbackUrl） */
+  callbackUrl?: string;
+}
+
+export const SignInContent = memo<SignInContentProps>(function SignInContent({
+  callbackUrl,
+}) {
   const [loginMode, setLoginMode] = useState<LoginMode>('password');
 
   const handleOtpLoginClick = useCallback(() => {
@@ -25,10 +32,20 @@ export const SignInContent = memo(function SignInContent() {
   }, []);
 
   if (loginMode === 'otp') {
-    return <OtpLoginForm onPasswordLoginClick={handlePasswordLoginClick} />;
+    return (
+      <OtpLoginForm
+        onPasswordLoginClick={handlePasswordLoginClick}
+        callbackUrl={callbackUrl}
+      />
+    );
   }
 
-  return <LoginForm onOtpLoginClick={handleOtpLoginClick} />;
+  return (
+    <LoginForm
+      onOtpLoginClick={handleOtpLoginClick}
+      callbackUrl={callbackUrl}
+    />
+  );
 });
 
 SignInContent.displayName = 'SignInContent';

--- a/src/features/auth/socialLoginButtons/socialLoginButtons.tsx
+++ b/src/features/auth/socialLoginButtons/socialLoginButtons.tsx
@@ -11,33 +11,40 @@ import { signIn } from 'next-auth/react';
 import { FaGoogle, FaGithub } from 'react-icons/fa';
 
 import { Button } from '@/components/ui/button/button';
+import { resolveSafeCallbackUrl } from '@/utils/url';
 import styles from './socialLoginButtons.module.scss';
 
 interface SocialLoginButtonsProps {
   disabled?: boolean;
+  /** ログイン後の戻り先（callbackUrl） */
+  callbackUrl?: string;
 }
 
 export const SocialLoginButtons = memo<SocialLoginButtonsProps>(
-  function SocialLoginButtons({ disabled = false }) {
+  function SocialLoginButtons({ disabled = false, callbackUrl }) {
     const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
 
     const handleGoogleLogin = useCallback(async () => {
       try {
         setLoadingProvider('google');
-        await signIn('google', { callbackUrl: '/' });
+        await signIn('google', {
+          callbackUrl: resolveSafeCallbackUrl(callbackUrl),
+        });
       } finally {
         setLoadingProvider(null);
       }
-    }, []);
+    }, [callbackUrl]);
 
     const handleGithubLogin = useCallback(async () => {
       try {
         setLoadingProvider('github');
-        await signIn('github', { callbackUrl: '/' });
+        await signIn('github', {
+          callbackUrl: resolveSafeCallbackUrl(callbackUrl),
+        });
       } finally {
         setLoadingProvider(null);
       }
-    }, []);
+    }, [callbackUrl]);
 
     const isDisabled = disabled || loadingProvider !== null;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,20 +30,30 @@ export default auth((req) => {
     nextUrl.pathname.startsWith(path),
   );
 
+  // ログイン後に元のページへ戻すための callbackUrl 付きサインインURLを生成する
+  const buildSignInUrl = () => {
+    const signInUrl = new URL(ROUTES.LOGIN, nextUrl);
+    signInUrl.searchParams.set(
+      'callbackUrl',
+      nextUrl.pathname + nextUrl.search,
+    );
+    return signInUrl;
+  };
+
   // セッション期限切れ検知: cookieはあるがJWT検証に失敗 → cookieを削除してログアウト
   const hasSessionCookie = req.cookies.has(SESSION_COOKIE_NAME);
 
   if (!isAuthenticated && hasSessionCookie) {
     const response = isProtectedPath
-      ? NextResponse.redirect(new URL(ROUTES.LOGIN, nextUrl))
+      ? NextResponse.redirect(buildSignInUrl())
       : NextResponse.next();
     response.cookies.delete(SESSION_COOKIE_NAME);
     return response;
   }
 
-  // 未認証で保護されたパスにアクセス → サインインページへリダイレクト
+  // 未認証で保護されたパスにアクセス → サインインページへリダイレクト（戻り先を保持）
   if (isProtectedPath && !isAuthenticated) {
-    return Response.redirect(new URL(ROUTES.LOGIN, nextUrl));
+    return Response.redirect(buildSignInUrl());
   }
 
   // 認証済みで認証ページにアクセス → ホームへリダイレクト

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -11,6 +11,10 @@ describe('resolveSafeCallbackUrl', () => {
     expect(resolveSafeCallbackUrl('')).toBe('/');
   });
 
+  it('配列（クエリ重複指定）が渡された場合はホームを返す', () => {
+    expect(resolveSafeCallbackUrl(['/watchlist', '/favorites'])).toBe('/');
+  });
+
   it('同一オリジンの相対パスはそのまま返す', () => {
     expect(resolveSafeCallbackUrl('/watchlist')).toBe('/watchlist');
     expect(resolveSafeCallbackUrl('/favorites?sort=desc')).toBe(

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,43 @@
+/**
+ * resolveSafeCallbackUrl のテスト
+ */
+
+import { resolveSafeCallbackUrl } from './url';
+
+describe('resolveSafeCallbackUrl', () => {
+  it('未指定（null/undefined/空）の場合はホームを返す', () => {
+    expect(resolveSafeCallbackUrl(null)).toBe('/');
+    expect(resolveSafeCallbackUrl(undefined)).toBe('/');
+    expect(resolveSafeCallbackUrl('')).toBe('/');
+  });
+
+  it('同一オリジンの相対パスはそのまま返す', () => {
+    expect(resolveSafeCallbackUrl('/watchlist')).toBe('/watchlist');
+    expect(resolveSafeCallbackUrl('/favorites?sort=desc')).toBe(
+      '/favorites?sort=desc',
+    );
+  });
+
+  it('外部URLはホームを返す', () => {
+    expect(resolveSafeCallbackUrl('https://evil.com')).toBe('/');
+    expect(resolveSafeCallbackUrl('http://evil.com/path')).toBe('/');
+  });
+
+  it('プロトコル相対URL（//）はホームを返す', () => {
+    expect(resolveSafeCallbackUrl('//evil.com')).toBe('/');
+  });
+
+  it('バックスラッシュを含むパスはホームを返す', () => {
+    expect(resolveSafeCallbackUrl('/\\evil.com')).toBe('/');
+  });
+
+  it("'/' で始まらないパスはホームを返す", () => {
+    expect(resolveSafeCallbackUrl('watchlist')).toBe('/');
+    expect(resolveSafeCallbackUrl('javascript:alert(1)')).toBe('/');
+  });
+
+  it('認証ページ自身はループ防止のためホームを返す', () => {
+    expect(resolveSafeCallbackUrl('/auth/signin')).toBe('/');
+    expect(resolveSafeCallbackUrl('/auth/signup?x=1')).toBe('/');
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -16,11 +16,14 @@ import { ROUTES } from '@/constants/common';
  * - バックスラッシュを含むURL（`/\evil.com` 等の回避策）
  * - 認証ページ自身（リダイレクトループ防止）
  *
- * @param raw - クエリ等から受け取った callbackUrl 文字列
+ * @param raw - クエリ等から受け取った callbackUrl（重複指定で配列になる場合も考慮）
  * @returns 安全な遷移先パス。不正なら ROUTES.HOME
  */
-export function resolveSafeCallbackUrl(raw: string | null | undefined): string {
-  if (!raw) {
+export function resolveSafeCallbackUrl(
+  raw: string | string[] | null | undefined,
+): string {
+  // 文字列以外（null/undefined/空文字/配列）は不正としてホームへ
+  if (typeof raw !== 'string' || !raw) {
     return ROUTES.HOME;
   }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,43 @@
+/**
+ * URL関連ユーティリティ
+ */
+
+import { ROUTES } from '@/constants/common';
+
+/**
+ * ログイン後のリダイレクト先（callbackUrl）を安全に解決する。
+ *
+ * オープンリダイレクト対策として、同一オリジンの相対パスのみを許可する。
+ * 不正・未指定の場合はホームを返す。
+ *
+ * 許可しない例:
+ * - 外部URL（`https://evil.com`）
+ * - プロトコル相対URL（`//evil.com`）
+ * - バックスラッシュを含むURL（`/\evil.com` 等の回避策）
+ * - 認証ページ自身（リダイレクトループ防止）
+ *
+ * @param raw - クエリ等から受け取った callbackUrl 文字列
+ * @returns 安全な遷移先パス。不正なら ROUTES.HOME
+ */
+export function resolveSafeCallbackUrl(raw: string | null | undefined): string {
+  if (!raw) {
+    return ROUTES.HOME;
+  }
+
+  // 相対パス（'/' 始まり）のみ許可。'//' はプロトコル相対URLのため拒否
+  if (!raw.startsWith('/') || raw.startsWith('//')) {
+    return ROUTES.HOME;
+  }
+
+  // バックスラッシュによる回避（'/\evil.com' 等）を拒否
+  if (raw.includes('\\')) {
+    return ROUTES.HOME;
+  }
+
+  // 認証ページへ戻すとループするため拒否
+  if (raw.startsWith(ROUTES.LOGIN) || raw.startsWith(ROUTES.REGISTER)) {
+    return ROUTES.HOME;
+  }
+
+  return raw;
+}


### PR DESCRIPTION
## 概要
未認証で保護ページにアクセスすると middleware が**無言でホームへ**飛ばしており、ログイン後も意図したページに戻れなかった。`callbackUrl` を付与・解決して、ログイン後に元のページへ戻す。

### 修正内容
- **middleware**: 保護パスへの未認証アクセス時、`?callbackUrl=<元パス+クエリ>` を付与してサインインへリダイレクト（セッション期限切れ経路も同様）
- **`resolveSafeCallbackUrl` ユーティリティ追加**: オープンリダイレクト対策として**同一オリジンの相対パスのみ許可**。外部URL / プロトコル相対(`//`) / バックスラッシュ / 認証ページ自身（ループ防止）はホームへフォールバック
- **signin page（Server Component）** で `searchParams.callbackUrl` を読み、`SignInContent` 経由で各ログインフォームへ伝播
- **credentials / OTP / ソーシャル** の各ログイン成功後に `callbackUrl`（解決済み）へ遷移

### 動作確認
- 未認証で `/watchlist` → `/auth/signin?callbackUrl=%2Fwatchlist` → ログイン → **`/watchlist` に復帰**を実機（agent-browser）で確認
- Next.js Dev Tools バッジ：エラーなし

## ロードマップ
該当タスクなし（UX改善）

## レビューポイント
- `resolveSafeCallbackUrl` の許可/拒否条件（オープンリダイレクト対策）
- middleware が付与する `callbackUrl` の値（`pathname + search`）と各ログイン経路での解決の一貫性
- 既存挙動（callbackUrl 無し時はホームへ）の互換性

## テスト
- `resolveSafeCallbackUrl` 単体（外部URL / 相対 / `//` / バックスラッシュ / ループ防止 / 未指定）
- E2E: 未認証 `/watchlist` → callbackUrl付き signin → ログイン → `/watchlist` 復帰（`e2e/auth/signin.spec.ts`）
- 関連ユニット 65件 / auth系E2E 11件 パス、`tsc` / `eslint` パス

Closes #370