### PR TITLE
setup: E2E結果スクショをPRに添付するルールを追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -167,8 +167,9 @@
 
 **【必須】E2E結果のスクショをPRに添付**：
 - PRでE2Eを実行したら、各シナリオの結果スクリーンショットをPR本文に埋め込む
-- 画像は `docs/e2e-screenshots/` 配下にコミットし、PR本文に raw URL（`https://github.com/Fn-front/movie-app/blob/<branch>/docs/e2e-screenshots/<file>.png?raw=true`）で埋め込む
+- 画像は `docs/e2e-screenshots/` 配下にコミットし、PR本文に raw URL で埋め込む
 - ファイル名はシナリオ単位で安定させ、**同じテストの再取得は上書き**する（重複画像を増やさない）。例: `<feature>-<scenario>.png`
+- URLは**コミットSHA固定のpermalink**を使う（`https://github.com/Fn-front/movie-app/blob/<commit-sha>/docs/e2e-screenshots/<file>.png?raw=true`）。`<branch>` 指定はマージ後のブランチ削除でリンク切れ（404）になるため避ける
 
 ## 設計ドキュメント
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -165,6 +165,11 @@
 - バッジが**赤色**でエラー件数（例：「1 Issue」「N Issues」）を表示していたら**エラー状態**と認識する（ページが正常に見えても見逃さない）
 - 赤バッジを検知したら、エラー内容（コンソール/ランタイムエラー）を取得して原因を切り分ける
 
+**【必須】E2E結果のスクショをPRに添付**：
+- PRでE2Eを実行したら、各シナリオの結果スクリーンショットをPR本文に埋め込む
+- 画像は `docs/e2e-screenshots/` 配下にコミットし、PR本文に raw URL（`https://github.com/Fn-front/movie-app/blob/<branch>/docs/e2e-screenshots/<file>.png?raw=true`）で埋め込む
+- ファイル名はシナリオ単位で安定させ、**同じテストの再取得は上書き**する（重複画像を増やさない）。例: `<feature>-<scenario>.png`
+
 ## 設計ドキュメント
 
 詳細な設計仕様は`.claude/documents/`を参照：


### PR DESCRIPTION
## 概要
E2E をPRで実行した際、各シナリオの結果スクリーンショットをPR本文に埋め込む運用を `.claude/CLAUDE.md`「ローカル動作確認」に明文化する。

- 画像は `docs/e2e-screenshots/` にコミットし、PR本文へ raw URL で埋め込む（gh CLI では画像直接アップロード不可のため）
- ファイル名はシナリオ単位で安定させ、**同じテストの再取得は上書き**（重複画像を増やさない）

## ロードマップ
該当タスクなし（開発ルールの整備）

## レビューポイント
- 文言・配置が既存の「ローカル動作確認」ルール群と整合しているか

## テスト
ドキュメントのみの変更のためコードテストなし。

## 補足
本ルールは次回以降のE2Eを伴うPRから適用予定。