### PR TITLE
test: フレーキーなE2E（watchlist/filterPersistence）を安定化

### DIFF
--- a/e2e/movies/filterPersistence.spec.ts
+++ b/e2e/movies/filterPersistence.spec.ts
@@ -6,6 +6,10 @@ import { test, expect } from '../fixtures/auth';
 import { resetFilters } from '../helpers/api';
 
 test.describe('フィルター条件がリロード後も保持される', () => {
+  // goto×2＋フィルタ操作＋PUT/GET待ち＋reload と重く、並列負荷下で30秒予算を
+  // 超過しうるためタイムアウトを延長する
+  test.describe.configure({ timeout: 60000 });
+
   test.beforeEach(async ({ request }) => {
     await resetFilters(request);
   });

--- a/e2e/movies/filterPersistence.spec.ts
+++ b/e2e/movies/filterPersistence.spec.ts
@@ -34,6 +34,7 @@ test.describe('フィルター条件がリロード後も保持される', () =>
     const putPromise = page.waitForResponse(
       (res) =>
         res.url().includes('/api/filters') && res.request().method() === 'PUT',
+      { timeout: 30000 },
     );
     await dialog.getByRole('button', { name: '適用' }).click();
     const putResponse = await putPromise;
@@ -48,6 +49,7 @@ test.describe('フィルター条件がリロード後も保持される', () =>
         res.url().includes('/api/filters') &&
         res.request().method() === 'GET' &&
         res.status() === 200,
+      { timeout: 30000 },
     );
     await page.reload();
     const getResponse = await getPromise;

--- a/e2e/watchlist/watchlist.spec.ts
+++ b/e2e/watchlist/watchlist.spec.ts
@@ -11,7 +11,9 @@ import { test, expect } from '../fixtures/auth';
 import { cleanupWatchlist } from '../helpers/api';
 import { movieTileButtons } from '../helpers/locators';
 
-test.describe.configure({ mode: 'serial' });
+// 同一ユーザーのウォッチリストを直列操作。並列負荷下でも goto＋タイル待ち＋
+// API応答（前準備の beforeEach 含む）が予算切れしないよう、テストタイムアウトを延長する
+test.describe.configure({ mode: 'serial', timeout: 90000 });
 
 /** ウォッチリストAPIレスポンスを待つ */
 function waitForWatchlistResponse(page: import('@playwright/test').Page) {
@@ -21,6 +23,7 @@ function waitForWatchlistResponse(page: import('@playwright/test').Page) {
       (res.request().method() === 'POST' ||
         res.request().method() === 'DELETE') &&
       res.status() < 500,
+    { timeout: 30000 },
   );
 }
 


### PR DESCRIPTION
## 概要
フルE2E（並列実行）で断続的に失敗していた2件を安定化する。

## 原因
`playwright.config` はローカル `workers: undefined`（多数並列）かつ `timeout: 30000`（テスト予算30秒）。
- `watchlist.spec.ts` の beforeEach（`addMovieToWatchlist`）は `goto` ＋ タイル待ち（最大30秒）＋ add ＋ `waitForResponse` を**30秒予算内**で実行 → 並列負荷でタイル読込が遅いと残り時間が枯渇し `waitForResponse` がタイムアウト
- `filterPersistence.spec.ts` も `goto`×2＋フィルタ操作＋PUT/GET待ち＋reload と重く、同様に予算超過

ロジックバグではなく**予算不足**が原因（単独再実行では通過していた）。

## 修正内容
- `watchlist.spec.ts`: describe の `timeout` を 90000 に延長、`waitForWatchlistResponse` に明示 `timeout: 30000`
- `filterPersistence.spec.ts`: describe の `timeout` を 60000 に延長

## 検証
- フルE2E（chromium）を**2回連続**実行 → いずれも **48 passed / 0 failed**（54.6s, 59.0s）

## ロードマップ
該当タスクなし（テスト安定化）

## レビューポイント
- タイムアウト延長が妥当か（予算枯渇の解消であり、ロジックのマスキングではない）

## テスト
E2Eテスト自体の変更。フルE2E 2回連続グリーンを確認。

Closes #375