### PR TITLE
improve: pre-commit AIレビューの失敗理由をログに残す

### DIFF
--- a/scripts/ai-pre-commit-review.js
+++ b/scripts/ai-pre-commit-review.js
@@ -15,6 +15,24 @@ const path = require('path');
 const sh = (cmd) => execSync(cmd, { encoding: 'utf8' });
 const log = (msg) => process.stdout.write(msg + '\n');
 
+/** Claude CLI 実行のタイムアウト（ms） */
+const CLAUDE_TIMEOUT_MS = 90000;
+
+/** 失敗・診断情報を履歴ログに追記する（原因不明化の解消用） */
+function logHistory(line) {
+  try {
+    const cacheDir = path.resolve('.cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
+    fs.appendFileSync(
+      path.join(cacheDir, 'ai-review-history.log'),
+      `[${ts}] ${line}\n`,
+    );
+  } catch {
+    /* ログ失敗は無視（コミットをブロックしない） */
+  }
+}
+
 function which(cmd) {
   const r = spawnSync('command', ['-v', cmd], {
     encoding: 'utf8',
@@ -65,15 +83,28 @@ try {
   const r = spawnSync(
     'claude',
     ['-p', '--output-format', 'json', '--max-turns', '1', prompt],
-    { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 },
+    { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, timeout: CLAUDE_TIMEOUT_MS },
   );
   if (r.status !== 0) {
+    // 失敗理由（タイムアウト/シグナル/stderr）を履歴に残し、原因不明化を防ぐ
+    const isTimeout =
+      r.error?.code === 'ETIMEDOUT' || r.signal === 'SIGTERM';
+    const reason = isTimeout
+      ? `timeout (${CLAUDE_TIMEOUT_MS}ms)`
+      : (r.stderr || '').trim().slice(0, 500) ||
+        `exit=${r.status} signal=${r.signal}`;
     log('⚠️  Claude CLI の実行に失敗しました。スキップします。');
+    logHistory(`FAILED claude CLI: ${reason}`);
     process.exit(0);
   }
   outer = JSON.parse(r.stdout);
+  // CLIは成功(exit 0)でもAPI側エラーが乗る場合があるため記録する
+  if (outer.api_error_status) {
+    logHistory(`API error status: ${outer.api_error_status}`);
+  }
 } catch (e) {
   log(`⚠️  Claude のレスポンスを解析できませんでした: ${e.message}`);
+  logHistory(`PARSE error: ${e.message}`);
   process.exit(0);
 }
 
@@ -94,16 +125,14 @@ fs.writeFileSync(
   path.join(cacheDir, 'ai-review-latest.json'),
   JSON.stringify(review, null, 2) + '\n',
 );
-const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
 let prev = '(no previous commit)';
 try {
   prev = sh('git log -1 --format=%s').trim();
 } catch {
   /* ignore */
 }
-fs.appendFileSync(
-  path.join(cacheDir, 'ai-review-history.log'),
-  `[${ts}] blockers=${review.blockers.length} warnings=${review.warnings.length} / prev: ${prev}\n`,
+logHistory(
+  `blockers=${review.blockers.length} warnings=${review.warnings.length} / prev: ${prev}`,
 );
 
 const fmt = (items) =>


### PR DESCRIPTION
## 概要
pre-commit の Claude AIレビュー（`scripts/ai-pre-commit-review.js`）が失敗時に汎用メッセージのみで**原因不明**だった問題を解消する。

## 修正内容
- `spawnSync` に **timeout(90s)** を設定し、タイムアウトを検出
- 失敗時に**理由**（timeout / シグナル / stderr 抜粋）を `.cache/ai-review-history.log` に記録
- CLI成功(exit 0)でも `api_error_status` が乗る場合は記録（レート制限等の検知）
- パースエラーも記録
- 履歴書き込みを `logHistory` ヘルパーに集約（成功サマリーも共通化＝DRY）

## 動作確認
- 本PRのコミット時、**更新後スクリプトが pre-commit で正常実行**（「✅ AI レビュー: 問題なし」）
- `.cache/ai-review-history.log` に成功サマリーが追記されることを確認
- `.cache/` は gitignore 済み（リポジトリを汚さない）

## ロードマップ
該当タスクなし（開発ツール改善）

## レビューポイント
- 失敗時も `process.exit(0)` を維持しコミットをブロックしないこと（Phase 1 設計の踏襲）
- `logHistory` のログ失敗時も握りつぶしてコミットを止めないこと

## テスト
フック用スクリプト（eslint/jest対象外）。`node --check` で構文確認、実コミットで成功パスを確認。失敗パスは設計上 exit 0 維持。

Closes #377