### PR TITLE
test(e2e): 詳細モーダルE2EをTMDb非依存に安定化（Closes #405）

### DIFF
--- a/e2e/favorites/favorites.spec.ts
+++ b/e2e/favorites/favorites.spec.ts
@@ -11,6 +11,7 @@
 import { test, expect } from '../fixtures/auth';
 import { cleanupFavorites } from '../helpers/api';
 import { movieTileButtons } from '../helpers/locators';
+import { mockMovieDetail } from '../helpers/movieDetail';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -145,6 +146,7 @@ test.describe('お気に入り — 一覧ページ', () => {
 test.describe('お気に入り — 詳細モーダルとの連携', () => {
   test.beforeEach(async ({ page }) => {
     await cleanupFavorites();
+    await mockMovieDetail(page);
     await page.goto('/movies/now-showing');
     await movieTileButtons(page).first().waitFor({ timeout: 30000 });
   });

--- a/e2e/helpers/movieDetail.ts
+++ b/e2e/helpers/movieDetail.ts
@@ -1,0 +1,80 @@
+/**
+ * 詳細モーダル用 E2Eヘルパー
+ *
+ * 詳細モーダルは GET /api/movies/:id（サーバ側で TMDb 取得）に依存するため、
+ * TMDb のレート制限/一時障害で「詳細情報」が描画されず E2E が flaky になる。
+ * このヘルパーで /api/movies/:id をモックし、TMDb 非依存で安定させる。
+ *
+ * ※ 一覧API（GET /api/movies?...）は対象外にするため、末尾が数値IDの
+ *   パスのみにマッチする正規表現を使う（glob `**​/api/movies**` との衝突回避）。
+ */
+
+import type { Page, Route } from '@playwright/test';
+import type { MovieDetail } from '@/lib/types';
+
+/** /api/movies/<id> のみにマッチ（一覧 /api/movies?... は除外） */
+const MOVIE_DETAIL_URL = /\/api\/movies\/\d+(?:$|\?)/;
+
+/**
+ * 「詳細情報」セクションが確実に描画される、型を満たした完全な MovieDetail を返す。
+ * 配列は空配列、数値は数値で埋め、favorite は null（お気に入り未登録）。
+ */
+function buildMovieDetail(
+  id: number,
+  overrides: Partial<MovieDetail>,
+): MovieDetail {
+  return {
+    id,
+    title: 'E2E詳細映画',
+    original_title: 'E2E Detail Movie',
+    overview: 'E2E用の概要テキスト',
+    poster_path: null,
+    backdrop_path: null,
+    release_date: '2026-01-01',
+    vote_average: 7.5,
+    vote_count: 100,
+    popularity: 12.3,
+    adult: false,
+    original_language: 'ja',
+    runtime: 120,
+    genres: [{ id: 28, name: 'アクション' }],
+    production_companies: [],
+    production_countries: [],
+    spoken_languages: [],
+    budget: 0,
+    revenue: 0,
+    tagline: '',
+    status: 'Released',
+    homepage: null,
+    favorite: null,
+    ...overrides,
+  };
+}
+
+/**
+ * 詳細モーダルの取得API（GET /api/movies/:id）をモックする。
+ * URL からリクエストされた ID を読み取り、その ID の詳細を返す。
+ *
+ * @param page Playwright Page
+ * @param overrides 返す MovieDetail の一部を上書き（例: { favorite: {...} }）
+ */
+export async function mockMovieDetail(
+  page: Page,
+  overrides: Partial<MovieDetail> = {},
+): Promise<void> {
+  await page.route(MOVIE_DETAIL_URL, async (route: Route) => {
+    const match = route
+      .request()
+      .url()
+      .match(/\/api\/movies\/(\d+)/);
+    const id = match ? Number(match[1]) : 0;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: buildMovieDetail(id, overrides),
+      }),
+    });
+  });
+}

--- a/e2e/movies/watchlistButton.spec.ts
+++ b/e2e/movies/watchlistButton.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect } from '../fixtures/auth';
 import { cleanupWatchlist } from '../helpers/api';
 import { movieTileButtons } from '../helpers/locators';
+import { mockMovieDetail } from '../helpers/movieDetail';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -62,6 +63,7 @@ test.describe('ウォッチリストボタン — 状態トグル', () => {
 
 test.describe('ウォッチリストボタン — モーダル↔タイル状態同期', () => {
   test.beforeEach(async ({ page }) => {
+    await mockMovieDetail(page);
     await page.goto('/movies/now-showing');
     await movieTileButtons(page).first().waitFor({ timeout: 30000 });
   });

--- a/e2e/recommendations/recommendations.spec.ts
+++ b/e2e/recommendations/recommendations.spec.ts
@@ -10,6 +10,7 @@
  */
 
 import { test, expect } from '../fixtures/auth';
+import { mockMovieDetail } from '../helpers/movieDetail';
 
 test.describe('レコメンドセクション — ホームページ表示', () => {
   test('ホームページにレコメンドセクションが表示される', async ({ page }) => {
@@ -26,6 +27,7 @@ test.describe('レコメンドセクション — ホームページ表示', () 
   test('レコメンド映画タイルクリックで詳細モーダルが表示される', async ({
     page,
   }) => {
+    await mockMovieDetail(page);
     await page.goto('/');
 
     const section = page.getByRole('region', { name: 'あなたへのおすすめ' });

--- a/e2e/watchlist/watchlist.spec.ts
+++ b/e2e/watchlist/watchlist.spec.ts
@@ -10,6 +10,7 @@
 import { test, expect } from '../fixtures/auth';
 import { cleanupWatchlist } from '../helpers/api';
 import { movieTileButtons } from '../helpers/locators';
+import { mockMovieDetail } from '../helpers/movieDetail';
 
 // 同一ユーザーのウォッチリストを直列操作。並列負荷下でも goto＋タイル待ち＋
 // API応答（前準備の beforeEach 含む）が予算切れしないよう、テストタイムアウトを延長する
@@ -57,6 +58,7 @@ async function addMovieToWatchlist(page: import('@playwright/test').Page) {
 test.describe('ウォッチリスト — ページ表示・詳細モーダル', () => {
   test.beforeEach(async ({ page }) => {
     await cleanupWatchlist();
+    await mockMovieDetail(page);
     await addMovieToWatchlist(page);
   });
 


### PR DESCRIPTION
## 概要
詳細モーダルの「詳細情報」表示を待つ E2E が、CIの **TMDbレート制限/一時障害時に一斉に flaky で落ちる**問題（#405）を解消。詳細取得API（GET `/api/movies/:id`）をモックして TMDb 非依存で安定化する。

## 原因
`MovieDetailModal → MovieDetailContent → useMovieDetail → getMovieDetail → GET /api/movies/:id`（サーバ側でTMDb取得）。TMDb失敗時は `isError` となり「詳細情報」セクションが描画されず、`getByText('詳細情報')` が15sタイムアウトしていた（#404 のCIで実際に連続失敗）。

## 対応
- **`e2e/helpers/movieDetail.ts`** に `mockMovieDetail(page, overrides?)` を追加
  - **末尾が数値IDのパスのみ**にマッチする正規表現 `/\/api\/movies\/\d+/` を使用し、一覧API `/api/movies?...` や既存の `**/api/movies**` モックとの**glob衝突を回避**
  - `MovieDetail` 型を満たす**完全なオブジェクト**を返す（配列は空配列・数値は数値・`favorite: null`）。URLからリクエストIDを読み取り反映
- 「詳細情報」を待つ4スペックに配線：`favorites` / `watchlistButton` / `watchlist` / `recommendations`

## テスト
- 対象スペックはローカルで**各単独グリーン**（詳細情報の表示が安定）
- ※ バッチ実行時に稀に watchlist トグルの実API操作がタイミングで揺れるが、本PRのモック対象（詳細モーダル）とは別要因の既存事象（`/api/watchlist` には非干渉）

## 関連
Closes #405 / 発覚元: #404（この安定化後に #404 の E2E 再実行→マージ予定）