### PR TITLE
fix(auth): OTP検証エンドポイントに独立の試行レート制限を追加

### DIFF
--- a/src/app/api/auth/otp/verify/route.test.ts
+++ b/src/app/api/auth/otp/verify/route.test.ts
@@ -17,6 +17,11 @@ jest.mock('@/helpers/supabase', () => ({
     new Response(JSON.stringify({ success: false }), { status: 500 }),
 }));
 
+const mockCheckRateLimit = jest.fn().mockResolvedValue({ allowed: true });
+jest.mock('@/lib/rateLimit/rateLimit', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}));
+
 // --- Helpers ---
 
 const createRequest = (body: Record<string, unknown>) =>
@@ -34,6 +39,7 @@ const pastDate = new Date(Date.now() - 10 * 60 * 1000).toISOString();
 describe('POST /api/auth/otp/verify', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it('registration: 正常にOTPを検証して認証完了できる', async () => {
@@ -400,5 +406,90 @@ describe('POST /api/auth/otp/verify', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
+  });
+
+  it('検証試行のレート制限超過の場合429を返し、コード照合をスキップする', async () => {
+    mockCheckRateLimit.mockResolvedValue({ allowed: false, retryAfter: 600 });
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        code: '123456',
+        action: 'registration',
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(json.success).toBe(false);
+    expect(response.headers.get('Retry-After')).toBe('600');
+    // レート制限で早期リターンするため、otp_codes取得は行われない
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('検証試行のレート制限超過（retryAfterなし）でも429を返す', async () => {
+    mockCheckRateLimit.mockResolvedValue({ allowed: false });
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        code: '123456',
+        action: 'registration',
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBeNull();
+  });
+
+  it('email単位でレート制限が掛かる（識別子・アクション種別・上限が正しい）', async () => {
+    // OTPレコード取得（正常系にして通過させる）
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            is: () => ({
+              order: () => ({
+                limit: () => ({
+                  single: () => ({
+                    data: {
+                      id: 'otp-1',
+                      email: 'test@example.com',
+                      code: '123456',
+                      action_type: 'login',
+                      attempts: 0,
+                      expires_at: futureDate,
+                      verified_at: null,
+                    },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+    mockFrom.mockReturnValueOnce({
+      update: () => ({
+        eq: () => ({ data: null, error: null }),
+      }),
+    });
+
+    await POST(
+      createRequest({
+        email: 'test@example.com',
+        code: '123456',
+        action: 'login',
+      }),
+    );
+
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'test@example.com',
+      'otp_verify',
+      10,
+      10,
+    );
   });
 });

--- a/src/app/api/auth/otp/verify/route.test.ts
+++ b/src/app/api/auth/otp/verify/route.test.ts
@@ -18,8 +18,10 @@ jest.mock('@/helpers/supabase', () => ({
 }));
 
 const mockCheckRateLimit = jest.fn().mockResolvedValue({ allowed: true });
+const mockResetRateLimit = jest.fn().mockResolvedValue(undefined);
 jest.mock('@/lib/rateLimit/rateLimit', () => ({
   checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  resetRateLimit: (...args: unknown[]) => mockResetRateLimit(...args),
 }));
 
 // --- Helpers ---
@@ -95,6 +97,12 @@ describe('POST /api/auth/otp/verify', () => {
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.message).toContain('メール認証');
+    // 検証成功時にレート制限がリセットされる
+    expect(mockResetRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'test@example.com',
+      'otp_verify',
+    );
   });
 
   it('login: 正常にOTPを検証して検証済みフラグを設定できる', async () => {
@@ -143,6 +151,12 @@ describe('POST /api/auth/otp/verify', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
+    // 検証成功時にレート制限がリセットされる
+    expect(mockResetRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'test@example.com',
+      'otp_verify',
+    );
   });
 
   it('バリデーションエラーで400を返す', async () => {
@@ -406,6 +420,57 @@ describe('POST /api/auth/otp/verify', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
+    // 検証成功時にレート制限がリセットされる
+    expect(mockResetRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'test@example.com',
+      'otp_verify',
+    );
+  });
+
+  it('コード不一致（検証失敗）時はレート制限をリセットしない', async () => {
+    // OTPレコード取得
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            is: () => ({
+              order: () => ({
+                limit: () => ({
+                  single: () => ({
+                    data: {
+                      id: 'otp-1',
+                      code: '123456',
+                      attempts: 0,
+                      expires_at: futureDate,
+                      verified_at: null,
+                    },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+    // attempts更新
+    mockFrom.mockReturnValueOnce({
+      update: () => ({
+        eq: () => ({ data: null, error: null }),
+      }),
+    });
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        code: '999999',
+        action: 'registration',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockResetRateLimit).not.toHaveBeenCalled();
   });
 
   it('検証試行のレート制限超過の場合429を返し、コード照合をスキップする', async () => {

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -9,7 +9,7 @@ import {
   createServiceRoleClient,
   dbConnectionErrorResponse,
 } from '@/helpers/supabase';
-import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
+import { checkRateLimit, resetRateLimit } from '@/lib/rateLimit/rateLimit';
 import { otpVerifySchema } from '@/schema/otp';
 import {
   OTP_ACTION,
@@ -48,7 +48,8 @@ export async function POST(request: Request) {
 
     // 検証試行のレート制限チェック（メールアドレス単位）
     // OTP行のattemptsは送信のたびにリセットされるため、
-    // エンドポイント単位で独立した試行カウントを設けて多層防御とする
+    // エンドポイント単位で独立した試行カウントを設けて多層防御とする。
+    // 上限超過時はウィンドウ分だけロックし、検証成功時に後述の resetRateLimit で解除する
     const verifyLimitResult = await checkRateLimit(
       supabase,
       email,
@@ -166,6 +167,9 @@ export async function POST(request: Request) {
       // OTPレコード削除
       await supabase.from('otp_codes').delete().eq('id', otpRecord.id);
 
+      // 検証成功のためレート制限をリセット（正当なユーザーの再検証を妨げない）
+      await resetRateLimit(supabase, email, 'otp_verify');
+
       return NextResponse.json(
         {
           success: true,
@@ -181,6 +185,9 @@ export async function POST(request: Request) {
         .from('otp_codes')
         .update({ verified_at: now.toISOString() })
         .eq('id', otpRecord.id);
+
+      // 検証成功のためレート制限をリセット（正当なユーザーの再検証を妨げない）
+      await resetRateLimit(supabase, email, 'otp_verify');
 
       return NextResponse.json(
         {

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -9,6 +9,7 @@ import {
   createServiceRoleClient,
   dbConnectionErrorResponse,
 } from '@/helpers/supabase';
+import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 import { otpVerifySchema } from '@/schema/otp';
 import {
   OTP_ACTION,
@@ -44,6 +45,35 @@ export async function POST(request: Request) {
     }
 
     const { email, code, action } = result.data;
+
+    // 検証試行のレート制限チェック（メールアドレス単位）
+    // OTP行のattemptsは送信のたびにリセットされるため、
+    // エンドポイント単位で独立した試行カウントを設けて多層防御とする
+    const verifyLimitResult = await checkRateLimit(
+      supabase,
+      email,
+      'otp_verify',
+      OTP_CONFIG.VERIFY_RATE_LIMIT,
+      OTP_CONFIG.VERIFY_RATE_LIMIT_WINDOW_MINUTES,
+    );
+
+    if (!verifyLimitResult.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: ERROR_CODE.RATE_LIMIT_EXCEEDED,
+            message: OTP_ERROR_MESSAGES.VERIFY_RATE_LIMIT_EXCEEDED,
+          },
+        },
+        {
+          status: HTTP_STATUS.TOO_MANY_REQUESTS,
+          headers: verifyLimitResult.retryAfter
+            ? { 'Retry-After': String(verifyLimitResult.retryAfter) }
+            : undefined,
+        },
+      );
+    }
 
     // otp_codesテーブルから該当レコード検索（最新の未検証OTP）
     const { data: otpRecord, error: fetchError } = await supabase

--- a/src/constants/otp.ts
+++ b/src/constants/otp.ts
@@ -34,9 +34,9 @@ export const OTP_CONFIG = {
   DAILY_SEND_WINDOW_MINUTES: 1440,
   /** OTP検証済みトークンの有効期限（分） — verified_atからの経過時間 */
   VERIFIED_TOKEN_EXPIRY_MINUTES: 5,
-  /** 検証試行のレート制限上限（回） — attemptsとは独立したエンドポイント単位の多層防御 */
+  /** 検証試行のレート制限上限（回） — attemptsとは独立したエンドポイント単位の多層防御。この回数を超えるとロックされる */
   VERIFY_RATE_LIMIT: 10,
-  /** 検証試行のレート制限ウィンドウ（分） — 超過時のロック時間 */
+  /** 検証試行の超過後ロック継続時間（分） — スライディングウィンドウの集計幅ではなく、上限超過時点からこの時間ロックする */
   VERIFY_RATE_LIMIT_WINDOW_MINUTES: 10,
 } as const;
 

--- a/src/constants/otp.ts
+++ b/src/constants/otp.ts
@@ -34,6 +34,10 @@ export const OTP_CONFIG = {
   DAILY_SEND_WINDOW_MINUTES: 1440,
   /** OTP検証済みトークンの有効期限（分） — verified_atからの経過時間 */
   VERIFIED_TOKEN_EXPIRY_MINUTES: 5,
+  /** 検証試行のレート制限上限（回） — attemptsとは独立したエンドポイント単位の多層防御 */
+  VERIFY_RATE_LIMIT: 10,
+  /** 検証試行のレート制限ウィンドウ（分） — 超過時のロック時間 */
+  VERIFY_RATE_LIMIT_WINDOW_MINUTES: 10,
 } as const;
 
 /**
@@ -51,6 +55,9 @@ export const OTP_ERROR_MESSAGES = {
   RESEND_TOO_SOON: 'しばらく待ってから再送信してください。',
   /** 日次送信上限超過 */
   DAILY_LIMIT_EXCEEDED: '本日の送信上限に達しました。明日再度お試しください。',
+  /** 検証試行のレート制限超過 */
+  VERIFY_RATE_LIMIT_EXCEEDED:
+    '検証の試行回数が多すぎます。しばらく待ってから再度お試しください。',
   /** OTPコードが見つからない */
   CODE_NOT_FOUND: '有効な確認コードが見つかりません。再送信してください。',
   /** ユーザーが見つからない */


### PR DESCRIPTION
## 概要

OTP 検証エンドポイント `/api/auth/otp/verify` に、`rate_limits` テーブルを用いた独立の試行レート制限（**email 単位・10 回 / 10 分**）を追加しました。従来はレート制限がなく、`attempts`（最大 5）＋送信側の日次上限のみで、コード総当たりに対する多層防御が欠如していました。超過時は統一エラーレスポンスで **429** を返し、`retryAfter` があれば `Retry-After` ヘッダを付与します。

## ロードマップ

該当なし（セキュリティ改善 Issue #413）

## レビューポイント

- コード照合の**前**にレート制限を掛けている点（総当たりの試行自体を抑制）
- 新規テーブルは不要（`action_type` は文字列カラムのため `otp_verify` を追加するのみ）。`otp/send` の日次上限実装のスタイルを踏襲
- 識別子は **email 単位**（IP は未認証・分散で回避容易なため）
- 送信のたびに `attempts` が実質リセットされる既存構造とは別に、verify 試行を独立してカウント

## テスト

- `npx jest src/app/api/auth/otp/verify/route.test.ts`: **12 passed**（route.ts カバレッジ Stmts 95.34% / Branch 92.3% / Funcs 100% / Lines 97.61%、いずれも 80% 以上）
- レート制限超過（429 / Retry-After あり・なし）、識別子・アクション種別・上限値の検証を追加
- `npm run lint` / `npx tsc --noEmit` / `npm run prettier:check`: すべて pass

Closes #413
