### PR TITLE
fix(security): CSPをnonceベース化しscript-srcのunsafe-inlineを除去

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,10 +84,22 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
-          // Content-Security-Policy は nonce ベースへ移行したため
+          // HTML ページ向けの Content-Security-Policy は nonce ベースへ移行したため
           // src/middleware.ts でリクエストごとに動的生成する。
           // ここで静的に定義すると二重定義になるため、あえて設定しない。
           // （CSP 以外のセキュリティヘッダは静的でよいため本ファイルで維持）
+        ],
+      },
+      {
+        // /api/* は middleware の matcher 対象外（nonce CSP が付与されない）。
+        // JSON API はスクリプト実行やフレーム化を一切必要としないため、
+        // 最も制限的な CSP を静的に付与して多層防御を維持する。
+        source: '/api/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'none'; frame-ancestors 'none'",
+          },
         ],
       },
     ];

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,23 +84,10 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' https://image.tmdb.org data: blob:",
-              // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
-              // base64エンコードした data: URI で読み込むために必要
-              "font-src 'self' data:",
-              "connect-src 'self' https://*.supabase.co",
-              'frame-src https://www.youtube.com',
-              "frame-ancestors 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
-          },
+          // Content-Security-Policy は nonce ベースへ移行したため
+          // src/middleware.ts でリクエストごとに動的生成する。
+          // ここで静的に定義すると二重定義になるため、あえて設定しない。
+          // （CSP 以外のセキュリティヘッダは静的でよいため本ファイルで維持）
         ],
       },
     ];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import { Noto_Sans_JP } from 'next/font/google';
 
 import { AppQueryProvider } from '@/components/providers/queryProvider';
@@ -18,16 +19,21 @@ export const metadata: Metadata = {
   description: '映画ウォッチリスト管理アプリケーション',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // CSP nonce を middleware が設定した x-nonce ヘッダから取得し、
+  // インライン初期化スクリプトに付与する（'unsafe-inline' 除去のため）。
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+
   return (
     <html lang='ja' suppressHydrationWarning>
       <head>
         {/* ストレージキーは STORAGE_KEYS.THEME ('movie-app:theme') と同期すること */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html:
               "(function(){try{var t=localStorage.getItem('movie-app:theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark')}catch(e){}})()",

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -1,0 +1,100 @@
+/**
+ * CSP ヘッダ生成ロジックのテスト
+ */
+
+import { buildCspHeader, generateNonce } from './csp';
+
+describe('generateNonce', () => {
+  it('base64 文字列を返す', () => {
+    const nonce = generateNonce();
+    // base64 として復元できることを確認
+    expect(nonce).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(nonce.length).toBeGreaterThan(0);
+  });
+
+  it('呼び出しごとに異なる値を生成する', () => {
+    const a = generateNonce();
+    const b = generateNonce();
+    expect(a).not.toBe(b);
+  });
+
+  it('復元すると UUID 形式になる', () => {
+    const nonce = generateNonce();
+    const decoded = Buffer.from(nonce, 'base64').toString('utf8');
+    expect(decoded).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe('buildCspHeader', () => {
+  const nonce = 'test-nonce-value';
+
+  describe('本番環境（isDev=false）', () => {
+    const header = buildCspHeader(nonce, false);
+
+    it("script-src に nonce と 'strict-dynamic' を含む", () => {
+      expect(header).toContain(
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+      );
+    });
+
+    it("script-src から 'unsafe-inline' が除去されている", () => {
+      const scriptSrc = header
+        .split('; ')
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptSrc).toBeDefined();
+      expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
+
+    it("本番では script-src に 'unsafe-eval' を含まない", () => {
+      const scriptSrc = header
+        .split('; ')
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptSrc).not.toContain("'unsafe-eval'");
+    });
+
+    it('既存の他ディレクティブを維持する', () => {
+      expect(header).toContain("default-src 'self'");
+      expect(header).toContain("frame-ancestors 'none'");
+      expect(header).toContain("base-uri 'self'");
+      expect(header).toContain("form-action 'self'");
+      expect(header).toContain('frame-src https://www.youtube.com');
+      expect(header).toContain("connect-src 'self' https://*.supabase.co");
+      expect(header).toContain(
+        "img-src 'self' https://image.tmdb.org data: blob:",
+      );
+      expect(header).toContain("font-src 'self' data:");
+      // style-src は今回のスコープ外のため 'unsafe-inline' を維持
+      expect(header).toContain("style-src 'self' 'unsafe-inline'");
+    });
+
+    it('ディレクティブは "; " で連結される', () => {
+      expect(header).not.toContain('\n');
+      expect(header.split('; ').length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('開発環境（isDev=true）', () => {
+    const header = buildCspHeader(nonce, true);
+
+    it("script-src に 'unsafe-eval' を含む（Next.js 開発ツール向け）", () => {
+      const scriptSrc = header
+        .split('; ')
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptSrc).toContain("'unsafe-eval'");
+    });
+
+    it("開発でも 'unsafe-inline' は含まない", () => {
+      const scriptSrc = header
+        .split('; ')
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
+  });
+
+  it('nonce の値がヘッダに反映される', () => {
+    const header = buildCspHeader('another-nonce', false);
+    expect(header).toContain("'nonce-another-nonce'");
+  });
+});

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,48 @@
+/**
+ * Content Security Policy (CSP) ヘッダ生成ロジック
+ *
+ * nonce ベースの CSP を採用し、`script-src` から `'unsafe-inline'` を除去する。
+ * インラインスクリプト（layout.tsx のテーマ初期化）にはリクエストごとに生成した
+ * nonce を付与することで実行を許可する。
+ *
+ * `'strict-dynamic'` を併用することで、nonce 付きスクリプトが動的に読み込む
+ * スクリプト（Next.js の chunk 等）を信頼し、明示的なホワイトリスト維持を不要にする。
+ */
+
+/** リクエストごとに一意な nonce を生成する（base64 エンコードした UUID） */
+export function generateNonce(): string {
+  return Buffer.from(crypto.randomUUID()).toString('base64');
+}
+
+/**
+ * CSP ヘッダ値を生成する。
+ *
+ * @param nonce リクエストごとの nonce
+ * @param isDev 開発環境かどうか。開発時のみ `script-src` に `'unsafe-eval'` を付与する
+ *   （Next.js の開発ツールが eval を利用するため）。本番では付与しない。
+ * @returns 1 行に整形した CSP ヘッダ値
+ */
+export function buildCspHeader(nonce: string, isDev: boolean): string {
+  const directives = [
+    "default-src 'self'",
+    // nonce + strict-dynamic により 'unsafe-inline' を除去。
+    // 本番では 'unsafe-eval' を付与しない（多層防御の強化）。
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${
+      isDev ? " 'unsafe-eval'" : ''
+    }`,
+    // style-src は Next.js / 各種ライブラリのインラインスタイルに依存するため
+    // 'unsafe-inline' を維持する（今回の対応スコープ外）。
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' https://image.tmdb.org data: blob:",
+    // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
+    // base64エンコードした data: URI で読み込むために必要
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co",
+    'frame-src https://www.youtube.com',
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ];
+
+  return directives.join('; ');
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -3,18 +3,20 @@
  */
 
 // next/serverをモック
+// mockNextResponseNext は NextResponse.next() に渡される init 引数
+// （{ request: { headers } }）を記録し、リクエストヘッダへの nonce/CSP 伝播を検証する。
 const mockNextResponseNext = jest.fn();
 const mockNextResponseRedirect = jest.fn();
 const mockCookiesDelete = jest.fn();
 
 jest.mock('next/server', () => ({
   NextResponse: {
-    next: () => {
+    next: (init?: { request?: { headers?: Headers } }) => {
+      mockNextResponseNext(init);
       const response = {
         headers: new Headers(),
         cookies: { delete: mockCookiesDelete },
       };
-      mockNextResponseNext.mockReturnValue(response);
       return response;
     },
     redirect: (url: URL) => {
@@ -227,6 +229,33 @@ describe('middleware', () => {
       const csp2 = middleware(req2).headers.get('content-security-policy');
 
       expect(csp1).not.toBe(csp2);
+    });
+
+    it('x-nonce と CSP がリクエストヘッダに伝播する（Server Component / Next.js 参照用）', () => {
+      const req = createMockRequest({
+        pathname: '/movies/now-showing',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const response = middleware(req);
+
+      // NextResponse.next() に渡された init から伝播先のリクエストヘッダを取得
+      const init = mockNextResponseNext.mock.calls[0][0] as {
+        request?: { headers?: Headers };
+      };
+      const requestHeaders = init?.request?.headers;
+      expect(requestHeaders).toBeInstanceOf(Headers);
+
+      const nonceHeader = requestHeaders?.get('x-nonce');
+      const requestCsp = requestHeaders?.get('content-security-policy');
+      const responseCsp = response.headers.get('content-security-policy');
+
+      // x-nonce が設定され、レスポンス CSP の nonce 値と一致する
+      expect(nonceHeader).toBeTruthy();
+      expect(responseCsp).toContain(`'nonce-${nonceHeader}'`);
+      // リクエストヘッダにも同一の CSP が伝播している
+      expect(requestCsp).toBe(responseCsp);
     });
   });
 });

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -48,7 +48,10 @@ jest.mock('@/lib/auth/auth', () => ({
 
 // middleware.tsのdefault exportはauth(callback)の結果＝callback自体
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const middleware = require('./middleware').default as (req: unknown) => unknown;
+const middleware = require('./middleware').default as (req: unknown) => {
+  headers: Headers;
+  cookies?: { delete: jest.Mock };
+};
 
 /** テスト用のモックリクエストを生成 */
 function createMockRequest(options: {
@@ -60,6 +63,7 @@ function createMockRequest(options: {
   return {
     auth: options.auth ?? null,
     nextUrl: new URL(options.pathname, origin),
+    headers: new Headers(),
     cookies: {
       has: (name: string) =>
         options.hasSessionCookie && name === 'next-auth.session-token',
@@ -84,10 +88,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req) as {
-        headers: Headers;
-        cookies: { delete: jest.Mock };
-      };
+      const response = middleware(req);
 
       // NextResponse.next()が返される（リダイレクトではない）
       expect(response.headers.get('location')).toBeNull();
@@ -102,10 +103,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req) as {
-        headers: Headers;
-        cookies: { delete: jest.Mock };
-      };
+      const response = middleware(req);
 
       expect(response.headers.get('location')).toContain('/auth/signin');
       expect(mockCookiesDelete).toHaveBeenCalledWith('next-auth.session-token');
@@ -120,7 +118,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req) as { headers: Headers };
+      const response = middleware(req);
 
       expect(response.headers.get('location')).toContain('/auth/signin');
     });
@@ -134,7 +132,8 @@ describe('middleware', () => {
 
       const response = middleware(req);
 
-      expect(response).toBeUndefined();
+      // リダイレクトではなく通常応答（location ヘッダが無い）
+      expect(response.headers.get('location')).toBeNull();
     });
   });
 
@@ -146,7 +145,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req) as { headers: Headers };
+      const response = middleware(req);
 
       expect(response.headers.get('location')).toContain(
         'http://localhost:3000/',
@@ -163,7 +162,7 @@ describe('middleware', () => {
 
       const response = middleware(req);
 
-      expect(response).toBeUndefined();
+      expect(response.headers.get('location')).toBeNull();
     });
 
     it('非保護ページにアクセスするとそのまま表示する', () => {
@@ -175,7 +174,59 @@ describe('middleware', () => {
 
       const response = middleware(req);
 
-      expect(response).toBeUndefined();
+      expect(response.headers.get('location')).toBeNull();
+    });
+  });
+
+  describe('CSP nonce / ヘッダ付与', () => {
+    it('通常応答に Content-Security-Policy ヘッダが付与される', () => {
+      const req = createMockRequest({
+        pathname: '/movies/now-showing',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const response = middleware(req);
+      const csp = response.headers.get('content-security-policy');
+
+      expect(csp).not.toBeNull();
+      expect(csp).toContain("script-src 'self' 'nonce-");
+      expect(csp).toContain("'strict-dynamic'");
+      // 多層防御強化: 'unsafe-inline' は script-src から除去されている
+      const scriptSrc = csp
+        ?.split('; ')
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
+
+    it('リダイレクト応答にも Content-Security-Policy ヘッダが付与される', () => {
+      const req = createMockRequest({
+        pathname: '/watchlist',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = middleware(req);
+
+      expect(response.headers.get('content-security-policy')).not.toBeNull();
+    });
+
+    it('リクエストごとに異なる nonce を生成する', () => {
+      const req1 = createMockRequest({
+        pathname: '/movies/now-showing',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+      const req2 = createMockRequest({
+        pathname: '/movies/now-showing',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const csp1 = middleware(req1).headers.get('content-security-policy');
+      const csp2 = middleware(req2).headers.get('content-security-policy');
+
+      expect(csp1).not.toBe(csp2);
     });
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,12 @@
 /**
- * Next.js Middleware - 認証保護
+ * Next.js Middleware - 認証保護 + CSP nonce 付与
  */
 
 import { NextResponse } from 'next/server';
 
 import { auth } from '@/lib/auth/auth';
 import { ROUTES, AUTH_REQUIRED_ROUTES } from '@/constants/common';
+import { buildCspHeader, generateNonce } from '@/lib/security/csp';
 
 /** セッションcookie名（環境に応じて切り替え） */
 const SESSION_COOKIE_NAME =
@@ -22,6 +23,34 @@ const authPaths = [ROUTES.LOGIN, ROUTES.REGISTER];
 export default auth((req) => {
   const { nextUrl } = req;
   const isAuthenticated = !!req.auth;
+
+  // --- CSP nonce の生成とヘッダ準備 ---
+  // リクエストごとに nonce を生成し CSP ヘッダを組み立てる。
+  // x-nonce はリクエストヘッダに載せ、Server Component（layout.tsx）から
+  // 参照できるようにする。CSP はリクエスト/レスポンス双方に設定する
+  // （Next.js が自身のスクリプトへ nonce を付与するにはリクエスト側の CSP が必要）。
+  const nonce = generateNonce();
+  const isDev = process.env.NODE_ENV === 'development';
+  const cspHeader = buildCspHeader(nonce, isDev);
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', cspHeader);
+
+  /** 通常応答（NextResponse.next）に nonce 付きリクエストヘッダと CSP を適用する */
+  const buildNextResponse = () => {
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    response.headers.set('Content-Security-Policy', cspHeader);
+    return response;
+  };
+
+  /** リダイレクト応答にも CSP を付与する */
+  const withCsp = (response: NextResponse) => {
+    response.headers.set('Content-Security-Policy', cspHeader);
+    return response;
+  };
 
   const isProtectedPath = protectedPaths.some((path) =>
     nextUrl.pathname.startsWith(path),
@@ -45,23 +74,23 @@ export default auth((req) => {
 
   if (!isAuthenticated && hasSessionCookie) {
     const response = isProtectedPath
-      ? NextResponse.redirect(buildSignInUrl())
-      : NextResponse.next();
+      ? withCsp(NextResponse.redirect(buildSignInUrl()))
+      : buildNextResponse();
     response.cookies.delete(SESSION_COOKIE_NAME);
     return response;
   }
 
   // 未認証で保護されたパスにアクセス → サインインページへリダイレクト（戻り先を保持）
   if (isProtectedPath && !isAuthenticated) {
-    return Response.redirect(buildSignInUrl());
+    return withCsp(NextResponse.redirect(buildSignInUrl()));
   }
 
   // 認証済みで認証ページにアクセス → ホームへリダイレクト
   if (isAuthPath && isAuthenticated) {
-    return Response.redirect(new URL(ROUTES.HOME, nextUrl));
+    return withCsp(NextResponse.redirect(new URL(ROUTES.HOME, nextUrl)));
   }
 
-  return;
+  return buildNextResponse();
 });
 
 // Middlewareを適用するパスを設定


### PR DESCRIPTION
## 概要

CSP を **nonce ベース**へ移行し、`script-src` から `'unsafe-inline'` を除去して XSS 多層防御を強化しました。`middleware` でリクエストごとに nonce を生成し、CSP ヘッダと `layout.tsx` のインラインスクリプト（テーマ初期化）に付与します。`'unsafe-eval'` は本番から除去し、開発時のみ保持します。

## ロードマップ

該当なし（セキュリティ改善 Issue #415）

## レビューポイント

- ⚠️ **重要なトレードオフ**: per-request nonce のため、**全ページが動的レンダリング（`ƒ`）になります**（静的生成 / ISR が実質無効化）。パフォーマンス影響を許容できるか要判断。
- **`'unsafe-eval'` の扱い**: 本番は除去、開発時のみ保持。1st-party および three / @react-three 等の WebGL 系ビルド成果物に `eval` / `new Function` が無いことを grep で確認済み。GLSL は raw import の文字列で eval 実行なし。
- 本番ビルド + `next start` で `/`・`/movies/now-showing`・`/theater-experience`(WebGL) の CSP が `script-src 'self' 'nonce-...' 'strict-dynamic'`（unsafe-inline/eval なし）になること、HTML の nonce と CSP ヘッダの nonce が一致・リクエスト毎に変化することを確認。theater-experience で **CSP 違反 0 件**。
- `next.config.mjs` の静的 CSP を削除し middleware で動的付与（二重定義回避）。他のセキュリティヘッダ（frame-ancestors 'none' / X-Frame-Options: DENY / HSTS 等）は維持。
- `middleware`→`proxy` の deprecation 警告はファイル名由来の既存挙動でスコープ外として据え置き。

## テスト

- `npx jest --coverage`: **225 suites / 2303 tests 全成功**、全体カバレッジ 91.34%（80% 維持）。`csp.ts` 100% / `middleware.ts` 97.72%
- `npm run build`: 成功（全 34 ページ生成）／ `npx tsc --noEmit`: pass ／ `npm run lint`: 0 errors（既存の無関係 warning のみ）／ `prettier:check`: OK
- 追加テスト: `src/lib/security/csp.test.ts`（nonce 生成・CSP 組み立て）、`src/middleware.test.ts`（CSP/nonce 付与、リダイレクトにも付与、既存認証テスト維持）

Closes #415
