### PR TITLE
refactor: スクレイピング対象の外部URLを環境変数に切り出す

### DIFF
--- a/.claude/documents/environment-variables.md
+++ b/.claude/documents/environment-variables.md
@@ -157,6 +157,30 @@ OPENAI_MODEL=gpt-4o-mini
 
 ---
 
+### スクレイピング対象URL（外部データ取得）
+
+publicリポジトリのため、スクレイピング対象の外部URLはソースコードに直接記載せず環境変数で管理する（対象URLの非公開が目的）。**実URLはドキュメント・Git追跡ファイルに記載しない**。値は各開発者の `.env.local` および本番/CIの環境変数で設定する。
+
+```bash
+# eiga.com アカデミー賞特集ページのベースURL（末尾スラッシュなし）
+EIGA_OSCAR_BASE_URL=
+
+# eiga.com 公開予定作品のiCalフィードURL
+EIGA_ICAL_URL=
+
+# Wikipedia API のベースURL（api.php まで）
+WIKIPEDIA_API_BASE_URL=
+```
+
+**利用箇所:**
+- `EIGA_OSCAR_BASE_URL`: `src/lib/eiga/fetchEigaOscarAwards.ts`（アカデミー賞ノミネート・受賞データ取得）
+- `EIGA_ICAL_URL`: `src/lib/eiga/eiga.ts`（公開予定映画のiCalフィード取得）
+- `WIKIPEDIA_API_BASE_URL`: `src/lib/wikipedia/fetchArticle.ts`（受賞記事のwikitext取得）
+
+**注意:** これらはサーバーサイドのみで使用（`NEXT_PUBLIC_` 不要）。いずれも未設定時は `getRequiredEnv`（`src/utils/env.ts`）が明確なエラーを投げて設定漏れを早期検知する。
+
+---
+
 ## オプション環境変数
 
 ### アプリケーション設定
@@ -224,6 +248,11 @@ USE_MOCK_DATA=false
 ```bash
 # TMDb API（サーバーサイドのみ）
 TMDB_API_KEY=your_tmdb_api_key_here
+
+# スクレイピング対象URL（値は非公開。実URLは記載しない）
+EIGA_OSCAR_BASE_URL=
+EIGA_ICAL_URL=
+WIKIPEDIA_API_BASE_URL=
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co

--- a/.env.local.example
+++ b/.env.local.example
@@ -11,6 +11,14 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # TMDb API
 NEXT_PUBLIC_TMDB_API_KEY=your-tmdb-api-token
 
+# スクレイピング対象URL（publicリポのため値は非公開。実URLは各担当者・Vercelの環境変数で設定）
+# eiga.com アカデミー賞特集ページのベースURL（末尾スラッシュなし）
+EIGA_OSCAR_BASE_URL=
+# eiga.com 公開予定作品のiCalフィードURL
+EIGA_ICAL_URL=
+# Wikipedia API のベースURL（api.php まで）
+WIKIPEDIA_API_BASE_URL=
+
 # Playwright (テスト用)
 PLAYWRIGHT_BROWSERS_PATH=node_modules/.cache/ms-playwright
 

--- a/src/constants/movies.ts
+++ b/src/constants/movies.ts
@@ -121,11 +121,6 @@ export const ALLOWED_LANGUAGES = [
 ] as const;
 
 /**
- * 映画.com iCalフィードURL
- */
-export const EIGA_ICAL_URL = 'https://eiga.com/movie/coming.ics';
-
-/**
  * バッチ更新: 1回のバッチで処理する映画数
  */
 export const BATCH_UPDATE_SIZE = 100;

--- a/src/lib/eiga/eiga.test.ts
+++ b/src/lib/eiga/eiga.test.ts
@@ -166,8 +166,15 @@ END:VCALENDAR`;
 });
 
 describe('fetchEigaMovies', () => {
+  const EIGA_ICAL_URL = 'https://example.test/coming.ics';
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EIGA_ICAL_URL = EIGA_ICAL_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.EIGA_ICAL_URL;
   });
 
   it('iCalフィードを取得してパースした結果を返す', async () => {
@@ -175,7 +182,7 @@ describe('fetchEigaMovies', () => {
 
     const result = await fetchEigaMovies();
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), {
+    expect(mockedAxios.get).toHaveBeenCalledWith(EIGA_ICAL_URL, {
       responseType: 'text',
       timeout: 30000,
     });
@@ -188,6 +195,12 @@ describe('fetchEigaMovies', () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('Network Error'));
 
     await expect(fetchEigaMovies()).rejects.toThrow('Network Error');
+  });
+
+  it('EIGA_ICAL_URL 未設定時はエラーを投げる', async () => {
+    delete process.env.EIGA_ICAL_URL;
+
+    await expect(fetchEigaMovies()).rejects.toThrow('EIGA_ICAL_URL');
   });
 });
 

--- a/src/lib/eiga/eiga.ts
+++ b/src/lib/eiga/eiga.ts
@@ -5,7 +5,6 @@
 import ICAL from 'ical.js';
 import axios from 'axios';
 
-import { EIGA_ICAL_URL } from '@/constants/movies';
 import {
   EIGA_FETCH_TIMEOUT_MS,
   EIGA_ORIGINAL_TITLE_TIMEOUT_MS,
@@ -13,6 +12,7 @@ import {
   EIGA_ORIGINAL_TITLE_PATTERN,
   EIGA_ENGLISH_TITLE_PATTERN,
 } from '@/constants/eiga';
+import { getRequiredEnv } from '@/utils/env';
 
 /**
  * iCalから抽出した映画情報
@@ -32,7 +32,7 @@ export interface EigaMovie {
  * @returns 映画タイトルと公開日の配列
  */
 export async function fetchEigaMovies(): Promise<EigaMovie[]> {
-  const response = await axios.get<string>(EIGA_ICAL_URL, {
+  const response = await axios.get<string>(getRequiredEnv('EIGA_ICAL_URL'), {
     responseType: 'text',
     timeout: EIGA_FETCH_TIMEOUT_MS,
   });

--- a/src/lib/eiga/fetchEigaOscarAwards.test.ts
+++ b/src/lib/eiga/fetchEigaOscarAwards.test.ts
@@ -289,9 +289,15 @@ describe('extractOthersPageNominees', () => {
 
 describe('fetchEigaOscarAwards', () => {
   const mockedAxios = axios as jest.Mocked<typeof axios>;
+  const EIGA_OSCAR_BASE_URL = 'https://example.test/oscar';
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EIGA_OSCAR_BASE_URL = EIGA_OSCAR_BASE_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.EIGA_OSCAR_BASE_URL;
   });
 
   /** 作品賞ページ用HTML */
@@ -411,12 +417,20 @@ describe('fetchEigaOscarAwards', () => {
     await fetchEigaOscarAwards(2025);
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      'https://eiga.com/official/oscar/2025/all.html',
+      `${EIGA_OSCAR_BASE_URL}/2025/all.html`,
       expect.anything(),
     );
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      'https://eiga.com/official/oscar/2025/all-others.html',
+      `${EIGA_OSCAR_BASE_URL}/2025/all-others.html`,
       expect.anything(),
+    );
+  });
+
+  it('EIGA_OSCAR_BASE_URL 未設定時はエラーを投げる', async () => {
+    delete process.env.EIGA_OSCAR_BASE_URL;
+
+    await expect(fetchEigaOscarAwards(2025)).rejects.toThrow(
+      'EIGA_OSCAR_BASE_URL',
     );
   });
 });

--- a/src/lib/eiga/fetchEigaOscarAwards.ts
+++ b/src/lib/eiga/fetchEigaOscarAwards.ts
@@ -8,8 +8,8 @@
 import axios from 'axios';
 
 import type { OpenAiAwardItem } from '@/schema/awards';
+import { getRequiredEnv } from '@/utils/env';
 
-const EIGA_OSCAR_BASE_URL = 'https://eiga.com/official/oscar';
 const EIGA_FETCH_TIMEOUT_MS = 30000;
 
 /** eiga.comページと対応する部門のマッピング */
@@ -60,10 +60,11 @@ export interface ExtractedNominee {
 export async function fetchEigaOscarAwards(
   ceremonyYear: number,
 ): Promise<OpenAiAwardItem[]> {
+  const baseUrl = getRequiredEnv('EIGA_OSCAR_BASE_URL');
   const allItems: OpenAiAwardItem[] = [];
 
   for (const page of EIGA_OSCAR_PAGES) {
-    const url = `${EIGA_OSCAR_BASE_URL}/${ceremonyYear}/${page.path}`;
+    const url = `${baseUrl}/${ceremonyYear}/${page.path}`;
     let html: string;
     try {
       html = await fetchHtml(url);

--- a/src/lib/wikipedia/fetchArticle.test.ts
+++ b/src/lib/wikipedia/fetchArticle.test.ts
@@ -36,6 +36,11 @@ function createWikitextResponse(wikitext: string) {
 describe('fetchWikipediaArticle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.WIKIPEDIA_API_BASE_URL = 'https://example.test/w/api.php';
+  });
+
+  afterEach(() => {
+    delete process.env.WIKIPEDIA_API_BASE_URL;
   });
 
   it('受賞セクションが見つかった場合、セクションのwikitextを返す', async () => {
@@ -178,6 +183,15 @@ describe('fetchWikipediaArticle', () => {
 
     const firstCallOptions = mockFetch.mock.calls[0][1];
     expect(firstCallOptions.headers['User-Agent']).toContain('MovieApp');
+  });
+
+  it('WIKIPEDIA_API_BASE_URL 未設定時はfetchせずnullを返す', async () => {
+    delete process.env.WIKIPEDIA_API_BASE_URL;
+
+    const result = await fetchWikipediaArticle('テスト記事');
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('sectionsがnullの場合、記事全体にフォールバックする', async () => {

--- a/src/lib/wikipedia/fetchArticle.ts
+++ b/src/lib/wikipedia/fetchArticle.ts
@@ -6,7 +6,7 @@
  * - wikitextにはテーブル構造と太字（受賞者）マークアップが保持される
  */
 
-const WIKIPEDIA_API_BASE = 'https://ja.wikipedia.org/w/api.php';
+import { getRequiredEnv } from '@/utils/env';
 
 const WIKIPEDIA_FETCH_OPTIONS: RequestInit = {
   headers: {
@@ -52,7 +52,7 @@ async function findAwardSectionIndex(title: string): Promise<number | null> {
   });
 
   const response = await fetch(
-    `${WIKIPEDIA_API_BASE}?${params.toString()}`,
+    `${getRequiredEnv('WIKIPEDIA_API_BASE_URL')}?${params.toString()}`,
     WIKIPEDIA_FETCH_OPTIONS,
   );
   if (!response.ok) return null;
@@ -87,7 +87,7 @@ async function fetchWikitextSection(
   });
 
   const response = await fetch(
-    `${WIKIPEDIA_API_BASE}?${params.toString()}`,
+    `${getRequiredEnv('WIKIPEDIA_API_BASE_URL')}?${params.toString()}`,
     WIKIPEDIA_FETCH_OPTIONS,
   );
   if (!response.ok) return null;
@@ -111,7 +111,7 @@ async function fetchFullWikitext(title: string): Promise<string | null> {
   });
 
   const response = await fetch(
-    `${WIKIPEDIA_API_BASE}?${params.toString()}`,
+    `${getRequiredEnv('WIKIPEDIA_API_BASE_URL')}?${params.toString()}`,
     WIKIPEDIA_FETCH_OPTIONS,
   );
   if (!response.ok) {

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * 環境変数ユーティリティのテスト
+ */
+
+import { getRequiredEnv } from './env';
+
+describe('getRequiredEnv', () => {
+  const TEST_KEY = 'TEST_REQUIRED_ENV_VALUE';
+
+  afterEach(() => {
+    delete process.env[TEST_KEY];
+  });
+
+  it('設定済みの環境変数を返す', () => {
+    process.env[TEST_KEY] = 'https://example.test';
+
+    expect(getRequiredEnv(TEST_KEY)).toBe('https://example.test');
+  });
+
+  it('未設定の場合はエラーを投げる', () => {
+    delete process.env[TEST_KEY];
+
+    expect(() => getRequiredEnv(TEST_KEY)).toThrow(
+      `Required environment variable "${TEST_KEY}" is not set`,
+    );
+  });
+
+  it('空文字の場合はエラーを投げる', () => {
+    process.env[TEST_KEY] = '';
+
+    expect(() => getRequiredEnv(TEST_KEY)).toThrow(TEST_KEY);
+  });
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,22 @@
+/**
+ * 環境変数ユーティリティ
+ */
+
+/**
+ * 必須の環境変数を取得する。未設定または空文字の場合は明確なエラーを投げる。
+ *
+ * 設定漏れを早期に検知するため、フォールバック値は用意しない。
+ *
+ * @param name - 取得する環境変数名
+ * @returns 環境変数の値
+ * @throws 未設定または空文字の場合
+ */
+export function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Required environment variable "${name}" is not set`);
+  }
+
+  return value;
+}


### PR DESCRIPTION
## 概要

public リポにハードコードされていたスクレイピング対象の外部 URL 3 件を環境変数に切り出しました（秘匿目的）。**実 URL は Git 追跡ファイルに一切残していません。**

| 変数 | 用途 |
|---|---|
| `EIGA_OSCAR_BASE_URL` | アカデミー賞データ取得元 |
| `EIGA_ICAL_URL` | 公開予定映画の iCal 取得元 |
| `WIKIPEDIA_API_BASE_URL` | Wikipedia 記事取得 API |

## ロードマップ

該当なし（Issue #312）

## レビューポイント

- 共通 getter `src/utils/env.ts` の `getRequiredEnv(name)`（未設定/空文字で明確にエラー throw）を新設。
- env 参照は**関数内で遅延取得**（モジュールロード時に throw しない）。これにより env 未設定でも import 系テストが壊れず、worktree に `.env.local` が無くてもユニットテストが通る（fetch/axios はモック済み）。
- `.env.local.example` / `.claude/documents/environment-variables.md` は変数名・用途のみで**実 URL 非記載**（秘匿目的を維持）。
- コード内にフォールバックのハードコード URL を残していない。

## テスト

- `npx jest --coverage`: **225 suites / 2295 tests 全 pass**（全体 91.35% / branches 86.84% / functions 86.49% / lines 92.18%、80% 以上維持）。eiga.ts 100% / fetchEigaOscarAwards.ts 98.55% / fetchArticle.ts 97.91% / env.ts 100%
- tsc pass / lint 0 errors / prettier OK
- 各対象に「env 未設定時に throw」する検証を追加

## ⚠️ デプロイ時の必須対応

env 化により、3 変数が未設定だと当該機能が**実行時に throw して動作しません**。デプロイ前に **Vercel の Environment Variables**（Production/Preview/Development）へ実 URL の設定が必要です（実 URL はリポに無いため別途安全な経路で共有された値を設定）。影響機能: アカデミー賞同期（cron `sync-award-movies`）／ eiga 同期系（iCal）／ Wikipedia 記事取得。

Closes #312
