### PR TITLE
feat(scripts): 画面修正PR用ビジュアル証跡ヘルパー(Release Assets方式)を追加

### DIFF
--- a/.claude/rules/visual-evidence.md
+++ b/.claude/rules/visual-evidence.md
@@ -1,0 +1,50 @@
+# 画面修正 PR のビジュアル証跡ルール
+
+## 【必須】画面修正時の添付
+
+見た目に変化がある UI/画面の修正は、PR に以下を必ず添付する:
+
+- **修正前（Before）/ 修正後（After）のスクリーンショット**
+- **動作保証の動画**（主要操作の一連の流れ）
+
+対象外: ロジックのみ・非 UI（API/型/テスト等）の変更。
+
+## 取得方法（agent-browser）
+
+ヘルパースクリプト `scripts/pr-visual.mjs` を使う（内部で agent-browser を呼ぶ）。dev サーバー起動が前提。
+
+```bash
+# 1) 修正前: main で dev 起動 → Before を撮影
+node scripts/pr-visual.mjs shot http://localhost:3000/<path> docs/tmp/<feature>-before.png
+
+# 2) 修正後: 修正ブランチで dev 起動 → After 撮影 + 動作動画
+node scripts/pr-visual.mjs shot   http://localhost:3000/<path> docs/tmp/<feature>-after.png
+node scripts/pr-visual.mjs record http://localhost:3000/<path> docs/tmp/<feature>-demo.webm 10
+```
+
+## アップロード・埋め込み（GitHub Release Assets 方式）
+
+画像/動画を **prerelease の Release Assets** としてアップし、出力された markdown を PR 本文に貼る。
+
+```bash
+# Before/After 比較表 + 動画をまとめてアップし markdown 出力（tag は一意に。PR 番号やブランチ名など）
+node scripts/pr-visual.mjs beforeafter pr-visual-<feature> \
+  docs/tmp/<feature>-before.png docs/tmp/<feature>-after.png docs/tmp/<feature>-demo.webm
+
+# マージ後の後片付け（prerelease とタグを削除）
+node scripts/pr-visual.mjs cleanup pr-visual-<feature>
+```
+
+- **既存の `gh auth`（PAT）だけで動作**し、session cookie 不要・CI でも動く。画像は inline 表示、動画はリンクで開ける。
+- `--prerelease` で作成するためリリース一覧を汚さない。**マージ後は `cleanup` で削除**する。
+- **リポ本体に画像/動画をコミットしない**（Release Assets に置くため履歴が肥大化しない）。
+
+### なぜ gh-image を使わないか
+
+GitHub の画像添付エンドポイント（user-attachments）は**ブラウザの `user_session` cookie 専用**で、`gh` の PAT/OAuth では利用できない（公式に "not planned"）。gh-image はブラウザセッションを再現する仕組みで CLI 完結・CI 化ができないため、本プロジェクトでは Release Assets 方式を採用する。
+
+## 既存運用との棲み分け
+
+- **E2E シナリオ結果**のスクショは従来どおり `docs/e2e-screenshots/` に**コミット**し、コミット SHA 固定の raw URL permalink で PR に埋め込む（`.claude/CLAUDE.md` 参照）。安定した回帰用証跡はリポに残す。
+- **画面修正の Before/After ＋デモ動画**は **Release Assets 方式**を使い、リポにコミットしない（重い画像/動画でリポを肥大化させないため）。
+- 一時ファイルは `docs/tmp/`（`.gitignore` 対象）に置き、アップロード後は残さない。

--- a/.claude/rules/visual-evidence.md
+++ b/.claude/rules/visual-evidence.md
@@ -22,29 +22,31 @@ node scripts/pr-visual.mjs shot   http://localhost:3000/<path> docs/tmp/<feature
 node scripts/pr-visual.mjs record http://localhost:3000/<path> docs/tmp/<feature>-demo.webm 10
 ```
 
-## アップロード・埋め込み（GitHub Release Assets 方式）
+## アップロード・埋め込み（gh-image / user-attachments）
 
-画像/動画を **prerelease の Release Assets** としてアップし、出力された markdown を PR 本文に貼る。
+`gh-image`（drogers0/gh-image）で GitHub の **user-attachments** にアップし、出力された markdown を PR 本文に貼る。**動画は user-attachments だと `<video>` でインライン再生される**（Release Assets のリンク止まりと違う）。
 
 ```bash
-# Before/After 比較表 + 動画をまとめてアップし markdown 出力（tag は一意に。PR 番号やブランチ名など）
-node scripts/pr-visual.mjs beforeafter pr-visual-<feature> \
+# Before/After 比較表 + 動画（インライン再生）をまとめて出力
+node scripts/pr-visual.mjs beforeafter \
   docs/tmp/<feature>-before.png docs/tmp/<feature>-after.png docs/tmp/<feature>-demo.webm
-
-# マージ後の後片付け（prerelease とタグを削除）
-node scripts/pr-visual.mjs cleanup pr-visual-<feature>
 ```
 
-- **既存の `gh auth`（PAT）だけで動作**し、session cookie 不要・CI でも動く。画像は inline 表示、動画はリンクで開ける。
-- `--prerelease` で作成するためリリース一覧を汚さない。**マージ後は `cleanup` で削除**する。
-- **リポ本体に画像/動画をコミットしない**（Release Assets に置くため履歴が肥大化しない）。
+- 画像は `![](url)`、**動画は生 URL を単独行**で貼る（GitHub が自動で動画プレーヤーに変換）。
+- **リポ本体に画像/動画をコミットしない**（user-attachments に置くため履歴が肥大化しない）。アップ後は削除不要（リポを汚さない）。
 
-### なぜ gh-image を使わないか
+### 認証（session token）
 
-GitHub の画像添付エンドポイント（user-attachments）は**ブラウザの `user_session` cookie 専用**で、`gh` の PAT/OAuth では利用できない（公式に "not planned"）。gh-image はブラウザセッションを再現する仕組みで CLI 完結・CI 化ができないため、本プロジェクトでは Release Assets 方式を採用する。
+user-attachments のアップロードは GitHub の **web セッション cookie（`user_session`）** を使う（PAT/OAuth 不可＝ GitHub 仕様）。次のいずれかで用意する:
+
+1. **対応ブラウザ（Chrome/Safari/Firefox/Edge/Brave/Opera）で github.com にログイン済み** → gh-image が cookie から自動取得。`gh image check-token` で `Token is valid` を確認。
+2. CI/headless では `.env.local` に `GH_SESSION_TOKEN=<user_session>` を設定（`gh image extract-token` で取得した値）。
+
+- token は一度用意すれば期限切れまで使い回せる（毎回ログイン不要）。
+- ⚠️ `user_session` は**アカウント全権限**の cookie。パスワード同様に厳重管理し、リポ・ログに出さない。CI で使うなら**専用 bot アカウント**を推奨。
 
 ## 既存運用との棲み分け
 
 - **E2E シナリオ結果**のスクショは従来どおり `docs/e2e-screenshots/` に**コミット**し、コミット SHA 固定の raw URL permalink で PR に埋め込む（`.claude/CLAUDE.md` 参照）。安定した回帰用証跡はリポに残す。
-- **画面修正の Before/After ＋デモ動画**は **Release Assets 方式**を使い、リポにコミットしない（重い画像/動画でリポを肥大化させないため）。
+- **画面修正の Before/After ＋デモ動画**は **gh-image（user-attachments）**を使い、リポにコミットしない（動画インライン再生・リポ肥大化回避のため）。
 - 一時ファイルは `docs/tmp/`（`.gitignore` 対象）に置き、アップロード後は残さない。

--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,7 @@ Thumbs.db
 
 # AI review cache (pre-commit hook output)
 .cache/
+
+# PR ビジュアル証跡の一時ファイル（Release Assets へアップ後は残さない）
+/docs/tmp/
 # Cache refresh 1769994937

--- a/scripts/pr-visual.mjs
+++ b/scripts/pr-visual.mjs
@@ -1,43 +1,44 @@
 #!/usr/bin/env node
 /**
- * PR 用ビジュアル証跡ヘルパー（Release Assets 方式）
+ * PR 用ビジュアル証跡ヘルパー（gh-image 方式）
  *
  * 画面修正 PR に「修正前/後スクリーンショット」と「動作保証の動画」を添付するための補助ツール。
- * agent-browser でスクショ/録画し、GitHub Release Assets（--prerelease）としてアップロードして、
- * PR 本文にそのまま貼れる markdown を出力する。
+ * agent-browser でスクショ/録画し、gh-image（drogers0/gh-image）で GitHub の user-attachments に
+ * アップロードして、PR 本文にそのまま貼れる markdown を出力する。
  *
- * なぜ Release Assets 方式か:
- *   GitHub の画像添付エンドポイント（user-attachments）はブラウザの user_session cookie 専用で、
- *   gh の PAT/OAuth では利用できない（公式に "not planned"）。Release Assets なら既存の `gh auth`
- *   だけで CLI 完結・CI 対応でアップでき、リポ本体に画像/動画をコミットせずに済む。
+ * なぜ gh-image / user-attachments か:
+ *   user-attachments にアップした動画は GitHub が <video> としてインライン再生する
+ *   （Release Assets 方式ではリンク止まりで再生されない）。画像もそのまま inline 表示される。
  *
  * 前提:
  *   - dev サーバー起動（例: npm run dev → http://localhost:3000）
  *   - agent-browser CLI 導入済み
- *   - gh CLI 認証済み（対象リポへの write 権限）
+ *   - gh CLI 認証済み（対象リポへの write 権限。リポ ID 参照に使う）
+ *   - gh-image 導入済み（gh extension install drogers0/gh-image）
+ *   - GitHub の session token が用意されていること。次のいずれか:
+ *       (a) 対応ブラウザ（Chrome/Safari/Firefox/Edge/Brave/Opera）で github.com にログイン済み
+ *           → gh-image が cookie から自動取得（`gh image check-token` で確認）
+ *       (b) `.env.local` などに `GH_SESSION_TOKEN=<user_session>` を設定（CI/headless 向け）
+ *     ※ user_session は「アカウント全権限」の cookie。パスワード同様に厳重に扱う。
  *
  * 使い方:
  *   node scripts/pr-visual.mjs shot        <url> <out.png>              指定 URL のスクショ（全画面）
  *   node scripts/pr-visual.mjs record      <url> <out.webm> [sec]       指定 URL を sec 秒録画（既定 8）
- *   node scripts/pr-visual.mjs upload      <tag> <file...>              Release にアップし markdown 出力
- *   node scripts/pr-visual.mjs beforeafter <tag> <before.png> <after.png>  Before/After 比較表を出力
- *   node scripts/pr-visual.mjs cleanup     <tag>                        実演用 prerelease を削除
+ *   node scripts/pr-visual.mjs upload      <file...>                    user-attachments にアップし markdown 出力
+ *   node scripts/pr-visual.mjs beforeafter <before.png> <after.png> [demo.webm...]  比較表＋動画を出力
  *
  * 例:
- *   # main で before、修正ブランチで after + 動画
- *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/nowshowing-before.png
- *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/nowshowing-after.png
- *   node scripts/pr-visual.mjs record http://localhost:3000/movies/now-showing docs/tmp/nowshowing-demo.webm 10
- *   # Release にアップして PR 本文へ（tag は PR 番号やブランチ名などで一意に）
- *   node scripts/pr-visual.mjs beforeafter pr-visual-nowshowing docs/tmp/nowshowing-before.png docs/tmp/nowshowing-after.png
- *   node scripts/pr-visual.mjs upload      pr-visual-nowshowing docs/tmp/nowshowing-demo.webm
+ *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/ns-before.png
+ *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/ns-after.png
+ *   node scripts/pr-visual.mjs record http://localhost:3000/movies/now-showing docs/tmp/ns-demo.webm 10
+ *   node scripts/pr-visual.mjs beforeafter docs/tmp/ns-before.png docs/tmp/ns-after.png docs/tmp/ns-demo.webm
  */
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, basename } from 'node:path';
 
-const SESSION = 'pr-visual';
+const SESSION = process.env.AGENT_BROWSER_SESSION || 'pr-visual';
 const IMAGE_RE = /\.(png|jpe?g|gif|webp)$/i;
 
 function sh(bin, args) {
@@ -56,9 +57,10 @@ function sleep(ms) {
 function shot(url, out) {
   if (!url || !out) throw new Error('shot: <url> <out.png> が必要です');
   ensureDir(out);
-  sh('agent-browser', ['open', url, '--headed', '--session', SESSION]);
+  // 既存セッションがあれば再利用される（毎回新規起動はしない）
+  sh('agent-browser', ['open', url, '--session', SESSION]);
   sleep(1500);
-  sh('agent-browser', ['screenshot', '--full', out, '--session', SESSION]);
+  sh('agent-browser', ['screenshot', '--full', '--session', SESSION, out]);
   console.log(`✓ スクショ保存: ${out}`);
 }
 
@@ -72,71 +74,60 @@ function record(url, out, sec = '8') {
   console.log(`✓ 録画保存: ${out}`);
 }
 
-/** prerelease を用意（無ければ作成）してファイルをアップし、name→ダウンロードURL を返す */
-function uploadAssets(tag, files) {
-  if (!tag) throw new Error('tag が必要です');
+/**
+ * gh image で user-attachments にアップロードし、ファイルごとの markdown 参照を返す。
+ * gh image は画像を `![name](url)`、動画などは生 URL で出力する（1 ファイル 1 行）。
+ * 返り値: Map<filePath, { url, raw }>（raw は gh image が出力した行そのもの）
+ */
+function ghImageUpload(files) {
   if (!files.length) throw new Error('アップロードするファイルがありません');
   for (const f of files) {
     if (!existsSync(f)) throw new Error(`ファイルが見つかりません: ${f}`);
   }
-  try {
-    sh('gh', ['release', 'view', tag]);
-  } catch {
-    sh('gh', [
-      'release',
-      'create',
-      tag,
-      '--prerelease',
-      '--title',
-      `PR visual assets: ${tag}`,
-      '--notes',
-      'PR 用ビジュアル証跡（自動生成の prerelease。マージ後に削除して構いません）',
-    ]);
-    console.log(`✓ prerelease 作成: ${tag}`);
+  const lines = sh('gh', ['image', ...files])
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  if (lines.length !== files.length) {
+    throw new Error(`gh image の出力行数(${lines.length})がファイル数(${files.length})と一致しません`);
   }
-  sh('gh', ['release', 'upload', tag, ...files, '--clobber']);
-  const rel = JSON.parse(sh('gh', ['release', 'view', tag, '--json', 'assets']));
   const map = new Map();
-  for (const a of rel.assets) map.set(a.name, a.url);
+  files.forEach((f, i) => {
+    const raw = lines[i].trim();
+    const m = raw.match(/\((https?:\/\/[^)]+)\)/) || raw.match(/(https?:\/\/\S+)/);
+    map.set(f, { url: m ? m[1] : raw, raw });
+  });
   return map;
 }
 
+/** 画像は `![](url)`、動画（user-attachments）はインライン再生されるよう生 URL を単独行で。 */
 function mdRef(file, url) {
-  const name = basename(file);
-  return IMAGE_RE.test(name) ? `![${name}](${url})` : `[🎬 ${name}](${url})`;
+  return IMAGE_RE.test(basename(file)) ? `![${basename(file)}](${url})` : url;
 }
 
-function upload(tag, files) {
-  const map = uploadAssets(tag, files);
-  const lines = files.map((f) => mdRef(f, map.get(basename(f))));
+function upload(files) {
+  const map = ghImageUpload(files);
   console.log('\n--- PR 本文に貼り付け ---\n');
-  console.log(lines.join('\n'));
+  console.log(files.map((f) => mdRef(f, map.get(f).url)).join('\n'));
 }
 
-function beforeafter(tag, before, after, ...restFiles) {
-  if (!before || !after) throw new Error('beforeafter: <tag> <before.png> <after.png> が必要です');
-  const files = [before, after, ...restFiles];
-  const map = uploadAssets(tag, files);
+function beforeafter(before, after, ...videos) {
+  if (!before || !after) throw new Error('beforeafter: <before.png> <after.png> [demo.webm...] が必要です');
+  const map = ghImageUpload([before, after, ...videos]);
   const out = [
     '## スクリーンショット',
     '',
     '| Before | After |',
     '| --- | --- |',
-    `| ${mdRef(before, map.get(basename(before)))} | ${mdRef(after, map.get(basename(after)))} |`,
+    `| ${mdRef(before, map.get(before).url)} | ${mdRef(after, map.get(after).url)} |`,
   ];
-  if (restFiles.length) {
+  if (videos.length) {
     out.push('', '## 動作動画', '');
-    for (const f of restFiles) out.push(mdRef(f, map.get(basename(f))));
+    // 動画は生 URL を単独行で置くと GitHub が <video> でインライン再生する
+    for (const v of videos) out.push(map.get(v).url, '');
   }
-  out.push('');
   console.log('\n--- PR 本文に貼り付け ---\n');
   console.log(out.join('\n'));
-}
-
-function cleanup(tag) {
-  if (!tag) throw new Error('cleanup: <tag> が必要です');
-  sh('gh', ['release', 'delete', tag, '--yes', '--cleanup-tag']);
-  console.log(`✓ prerelease 削除: ${tag}`);
 }
 
 const [cmd, ...rest] = process.argv.slice(2);
@@ -149,24 +140,20 @@ try {
       record(rest[0], rest[1], rest[2]);
       break;
     case 'upload':
-      upload(rest[0], rest.slice(1));
+      upload(rest);
       break;
     case 'beforeafter':
-      beforeafter(rest[0], rest[1], rest[2], ...rest.slice(3));
-      break;
-    case 'cleanup':
-      cleanup(rest[0]);
+      beforeafter(rest[0], rest[1], ...rest.slice(2));
       break;
     default:
       console.log(
         [
-          'PR 用ビジュアル証跡ヘルパー（Release Assets 方式）',
+          'PR 用ビジュアル証跡ヘルパー（gh-image 方式）',
           '',
           '  node scripts/pr-visual.mjs shot        <url> <out.png>',
           '  node scripts/pr-visual.mjs record      <url> <out.webm> [sec]',
-          '  node scripts/pr-visual.mjs upload      <tag> <file...>',
-          '  node scripts/pr-visual.mjs beforeafter <tag> <before.png> <after.png> [demo.webm...]',
-          '  node scripts/pr-visual.mjs cleanup     <tag>',
+          '  node scripts/pr-visual.mjs upload      <file...>',
+          '  node scripts/pr-visual.mjs beforeafter <before.png> <after.png> [demo.webm...]',
         ].join('\n')
       );
       process.exit(cmd ? 1 : 0);

--- a/scripts/pr-visual.mjs
+++ b/scripts/pr-visual.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * PR 用ビジュアル証跡ヘルパー（Release Assets 方式）
+ *
+ * 画面修正 PR に「修正前/後スクリーンショット」と「動作保証の動画」を添付するための補助ツール。
+ * agent-browser でスクショ/録画し、GitHub Release Assets（--prerelease）としてアップロードして、
+ * PR 本文にそのまま貼れる markdown を出力する。
+ *
+ * なぜ Release Assets 方式か:
+ *   GitHub の画像添付エンドポイント（user-attachments）はブラウザの user_session cookie 専用で、
+ *   gh の PAT/OAuth では利用できない（公式に "not planned"）。Release Assets なら既存の `gh auth`
+ *   だけで CLI 完結・CI 対応でアップでき、リポ本体に画像/動画をコミットせずに済む。
+ *
+ * 前提:
+ *   - dev サーバー起動（例: npm run dev → http://localhost:3000）
+ *   - agent-browser CLI 導入済み
+ *   - gh CLI 認証済み（対象リポへの write 権限）
+ *
+ * 使い方:
+ *   node scripts/pr-visual.mjs shot        <url> <out.png>              指定 URL のスクショ（全画面）
+ *   node scripts/pr-visual.mjs record      <url> <out.webm> [sec]       指定 URL を sec 秒録画（既定 8）
+ *   node scripts/pr-visual.mjs upload      <tag> <file...>              Release にアップし markdown 出力
+ *   node scripts/pr-visual.mjs beforeafter <tag> <before.png> <after.png>  Before/After 比較表を出力
+ *   node scripts/pr-visual.mjs cleanup     <tag>                        実演用 prerelease を削除
+ *
+ * 例:
+ *   # main で before、修正ブランチで after + 動画
+ *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/nowshowing-before.png
+ *   node scripts/pr-visual.mjs shot   http://localhost:3000/movies/now-showing docs/tmp/nowshowing-after.png
+ *   node scripts/pr-visual.mjs record http://localhost:3000/movies/now-showing docs/tmp/nowshowing-demo.webm 10
+ *   # Release にアップして PR 本文へ（tag は PR 番号やブランチ名などで一意に）
+ *   node scripts/pr-visual.mjs beforeafter pr-visual-nowshowing docs/tmp/nowshowing-before.png docs/tmp/nowshowing-after.png
+ *   node scripts/pr-visual.mjs upload      pr-visual-nowshowing docs/tmp/nowshowing-demo.webm
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, basename } from 'node:path';
+
+const SESSION = 'pr-visual';
+const IMAGE_RE = /\.(png|jpe?g|gif|webp)$/i;
+
+function sh(bin, args) {
+  return execFileSync(bin, args, { encoding: 'utf8' });
+}
+
+function ensureDir(file) {
+  const dir = dirname(file);
+  if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function sleep(ms) {
+  execFileSync('sleep', [String(ms / 1000)]);
+}
+
+function shot(url, out) {
+  if (!url || !out) throw new Error('shot: <url> <out.png> が必要です');
+  ensureDir(out);
+  sh('agent-browser', ['open', url, '--headed', '--session', SESSION]);
+  sleep(1500);
+  sh('agent-browser', ['screenshot', '--full', out, '--session', SESSION]);
+  console.log(`✓ スクショ保存: ${out}`);
+}
+
+function record(url, out, sec = '8') {
+  if (!url || !out) throw new Error('record: <url> <out.webm> [sec] が必要です');
+  ensureDir(out);
+  sh('agent-browser', ['record', 'start', out, url, '--session', SESSION]);
+  console.log(`● 録画開始（${sec}秒）: ${out}`);
+  sleep(Number(sec) * 1000);
+  sh('agent-browser', ['record', 'stop', '--session', SESSION]);
+  console.log(`✓ 録画保存: ${out}`);
+}
+
+/** prerelease を用意（無ければ作成）してファイルをアップし、name→ダウンロードURL を返す */
+function uploadAssets(tag, files) {
+  if (!tag) throw new Error('tag が必要です');
+  if (!files.length) throw new Error('アップロードするファイルがありません');
+  for (const f of files) {
+    if (!existsSync(f)) throw new Error(`ファイルが見つかりません: ${f}`);
+  }
+  try {
+    sh('gh', ['release', 'view', tag]);
+  } catch {
+    sh('gh', [
+      'release',
+      'create',
+      tag,
+      '--prerelease',
+      '--title',
+      `PR visual assets: ${tag}`,
+      '--notes',
+      'PR 用ビジュアル証跡（自動生成の prerelease。マージ後に削除して構いません）',
+    ]);
+    console.log(`✓ prerelease 作成: ${tag}`);
+  }
+  sh('gh', ['release', 'upload', tag, ...files, '--clobber']);
+  const rel = JSON.parse(sh('gh', ['release', 'view', tag, '--json', 'assets']));
+  const map = new Map();
+  for (const a of rel.assets) map.set(a.name, a.url);
+  return map;
+}
+
+function mdRef(file, url) {
+  const name = basename(file);
+  return IMAGE_RE.test(name) ? `![${name}](${url})` : `[🎬 ${name}](${url})`;
+}
+
+function upload(tag, files) {
+  const map = uploadAssets(tag, files);
+  const lines = files.map((f) => mdRef(f, map.get(basename(f))));
+  console.log('\n--- PR 本文に貼り付け ---\n');
+  console.log(lines.join('\n'));
+}
+
+function beforeafter(tag, before, after, ...restFiles) {
+  if (!before || !after) throw new Error('beforeafter: <tag> <before.png> <after.png> が必要です');
+  const files = [before, after, ...restFiles];
+  const map = uploadAssets(tag, files);
+  const out = [
+    '## スクリーンショット',
+    '',
+    '| Before | After |',
+    '| --- | --- |',
+    `| ${mdRef(before, map.get(basename(before)))} | ${mdRef(after, map.get(basename(after)))} |`,
+  ];
+  if (restFiles.length) {
+    out.push('', '## 動作動画', '');
+    for (const f of restFiles) out.push(mdRef(f, map.get(basename(f))));
+  }
+  out.push('');
+  console.log('\n--- PR 本文に貼り付け ---\n');
+  console.log(out.join('\n'));
+}
+
+function cleanup(tag) {
+  if (!tag) throw new Error('cleanup: <tag> が必要です');
+  sh('gh', ['release', 'delete', tag, '--yes', '--cleanup-tag']);
+  console.log(`✓ prerelease 削除: ${tag}`);
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+try {
+  switch (cmd) {
+    case 'shot':
+      shot(rest[0], rest[1]);
+      break;
+    case 'record':
+      record(rest[0], rest[1], rest[2]);
+      break;
+    case 'upload':
+      upload(rest[0], rest.slice(1));
+      break;
+    case 'beforeafter':
+      beforeafter(rest[0], rest[1], rest[2], ...rest.slice(3));
+      break;
+    case 'cleanup':
+      cleanup(rest[0]);
+      break;
+    default:
+      console.log(
+        [
+          'PR 用ビジュアル証跡ヘルパー（Release Assets 方式）',
+          '',
+          '  node scripts/pr-visual.mjs shot        <url> <out.png>',
+          '  node scripts/pr-visual.mjs record      <url> <out.webm> [sec]',
+          '  node scripts/pr-visual.mjs upload      <tag> <file...>',
+          '  node scripts/pr-visual.mjs beforeafter <tag> <before.png> <after.png> [demo.webm...]',
+          '  node scripts/pr-visual.mjs cleanup     <tag>',
+        ].join('\n')
+      );
+      process.exit(cmd ? 1 : 0);
+  }
+} catch (err) {
+  console.error(`エラー: ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/pr-visual.mjs
+++ b/scripts/pr-visual.mjs
@@ -71,7 +71,24 @@ function record(url, out, sec = '8') {
   console.log(`● 録画開始（${sec}秒）: ${out}`);
   sleep(Number(sec) * 1000);
   sh('agent-browser', ['record', 'stop', '--session', SESSION]);
+  remuxDuration(out);
   console.log(`✓ 録画保存: ${out}`);
+}
+
+/**
+ * agent-browser の WebM はコンテナの duration メタデータが欠落しがちで、
+ * GitHub のプレーヤーが「0 秒」と表示してしまう。ffmpeg で remux して補正する（あれば）。
+ */
+function remuxDuration(out) {
+  try {
+    sh('ffmpeg', ['-version']);
+  } catch {
+    console.warn('⚠ ffmpeg 未導入のため duration 補正をスキップ（GitHub で長さが 0 表示になる場合あり。brew install ffmpeg 推奨）');
+    return;
+  }
+  const tmp = `${out}.fixed.webm`;
+  sh('ffmpeg', ['-y', '-i', out, '-c', 'copy', tmp]);
+  sh('mv', [tmp, out]);
 }
 
 /**

--- a/scripts/pr-visual.mjs
+++ b/scripts/pr-visual.mjs
@@ -65,7 +65,8 @@ function shot(url, out) {
 }
 
 function record(url, out, sec = '8') {
-  if (!url || !out) throw new Error('record: <url> <out.webm> [sec] が必要です');
+  if (!url || !out)
+    throw new Error('record: <url> <out.webm> [sec] が必要です');
   ensureDir(out);
   sh('agent-browser', ['record', 'start', out, url, '--session', SESSION]);
   console.log(`● 録画開始（${sec}秒）: ${out}`);
@@ -83,7 +84,9 @@ function remuxDuration(out) {
   try {
     sh('ffmpeg', ['-version']);
   } catch {
-    console.warn('⚠ ffmpeg 未導入のため duration 補正をスキップ（GitHub で長さが 0 表示になる場合あり。brew install ffmpeg 推奨）');
+    console.warn(
+      '⚠ ffmpeg 未導入のため duration 補正をスキップ（GitHub で長さが 0 表示になる場合あり。brew install ffmpeg 推奨）',
+    );
     return;
   }
   const tmp = `${out}.fixed.webm`;
@@ -106,12 +109,15 @@ function ghImageUpload(files) {
     .split('\n')
     .filter(Boolean);
   if (lines.length !== files.length) {
-    throw new Error(`gh image の出力行数(${lines.length})がファイル数(${files.length})と一致しません`);
+    throw new Error(
+      `gh image の出力行数(${lines.length})がファイル数(${files.length})と一致しません`,
+    );
   }
   const map = new Map();
   files.forEach((f, i) => {
     const raw = lines[i].trim();
-    const m = raw.match(/\((https?:\/\/[^)]+)\)/) || raw.match(/(https?:\/\/\S+)/);
+    const m =
+      raw.match(/\((https?:\/\/[^)]+)\)/) || raw.match(/(https?:\/\/\S+)/);
     map.set(f, { url: m ? m[1] : raw, raw });
   });
   return map;
@@ -129,7 +135,10 @@ function upload(files) {
 }
 
 function beforeafter(before, after, ...videos) {
-  if (!before || !after) throw new Error('beforeafter: <before.png> <after.png> [demo.webm...] が必要です');
+  if (!before || !after)
+    throw new Error(
+      'beforeafter: <before.png> <after.png> [demo.webm...] が必要です',
+    );
   const map = ghImageUpload([before, after, ...videos]);
   const out = [
     '## スクリーンショット',
@@ -171,7 +180,7 @@ try {
           '  node scripts/pr-visual.mjs record      <url> <out.webm> [sec]',
           '  node scripts/pr-visual.mjs upload      <file...>',
           '  node scripts/pr-visual.mjs beforeafter <before.png> <after.png> [demo.webm...]',
-        ].join('\n')
+        ].join('\n'),
       );
       process.exit(cmd ? 1 : 0);
   }


### PR DESCRIPTION
## 概要

画面修正 PR に **修正前/後スクリーンショット**と**動作保証の動画**を添付するための仕組みを追加しました。

- `scripts/pr-visual.mjs`: agent-browser でスクショ/録画し、**gh-image（user-attachments）**へアップして PR 本文に貼れる markdown を出力するヘルパー。**動画は GitHub が `<video>` でインライン再生**する。
- `.claude/rules/visual-evidence.md`: 運用ルール（取得・アップ・認証・既存 E2E スクショ運用との棲み分け）。
- `.gitignore`: 一時ファイル置き場 `/docs/tmp/` を追加。

## ロードマップ

該当なし（開発ワークフロー整備）

## レビューポイント

- **gh-image / user-attachments 方式を採用した理由**: user-attachments にアップした動画は GitHub が `<video>` でインライン再生する（Release Assets 方式はリンク止まり）。
- **認証**: user-attachments は GitHub の web セッション cookie（`user_session`）が必須（PAT/OAuth 不可＝ GitHub 仕様）。対応ブラウザで github.com ログイン済みなら gh-image が cookie 自動取得、CI では `GH_SESSION_TOKEN` を使用。token は一度用意すれば使い回せる。
- スクリプトのコマンド: `shot` / `record` / `upload` / `beforeafter`。既存セッション再利用（毎回 headed で開き直さない）。
- 既存の E2E スクショ運用（`docs/e2e-screenshots/` にコミット→ raw URL）との棲み分けをルールに明記。

## テスト

スクリプトを実際に実行して動作実証しました（Before=未ログイン / After=ログインの状態差でヘルパー動作を実証。※ UI 修正 PR ではないため状態差で例示）。下記はヘルパーで撮影 → gh-image でアップしたものです。

## スクリーンショット

| Before | After |
| --- | --- |
| ![home-before.png](https://github.com/user-attachments/assets/3e6f689e-ee89-4d87-bd95-3c5f08f5fca1) | ![home-after.png](https://github.com/user-attachments/assets/96baec43-550a-4a85-bbc6-e9c8246f96cf) |

## 動作動画

https://github.com/user-attachments/assets/ac5ab273-cc52-45dc-abaf-56cc8797f273
