### PR TITLE
test(e2e): theaterExperience(WebGL)のflakyを解消（SwiftShader＋明示待機）

### DIFF
--- a/e2e/theaterExperience/theaterExperience.spec.ts
+++ b/e2e/theaterExperience/theaterExperience.spec.ts
@@ -7,12 +7,64 @@
  */
 
 import { test, expect } from '../fixtures/auth';
+import type { Page } from '@playwright/test';
+
+/**
+ * WebGL2 初期化・データ取得完了の待機タイムアウト（ms）。
+ * CIのヘッドレスChromiumでの初期化遅延を吸収しつつ、
+ * expect のデフォルト（10秒）より長めに確保する。
+ */
+const READY_TIMEOUT_MS = 15000;
+
+/**
+ * WebGL2 が利用可能になるまで明示的に待機する。
+ *
+ * CIのヘッドレスChromiumではGPU無効化により WebGL2 初期化が遅延することがあり、
+ * その状態でページのゲート（isWebGL2Support）に依存すると
+ * UnsupportedBrowserNotice に落ちて期待要素が出ずタイムアウトする。
+ * ここでブラウザの WebGL2 コンテキスト生成が成功することを先に確認し、
+ * ソフトウェアレンダリング（SwiftShader）でも安定して true になることを保証する。
+ */
+async function waitForWebGL2(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      try {
+        const canvas = document.createElement('canvas');
+        return canvas.getContext('webgl2') !== null;
+      } catch {
+        return false;
+      }
+    },
+    undefined,
+    { timeout: READY_TIMEOUT_MS },
+  );
+}
+
+/**
+ * useTheater（Supabaseフェッチ）のデータ取得完了を待機する。
+ *
+ * 座席一覧（SeatA11yList）はデータ取得後に描画されるため、
+ * 座席ボタンの出現を待つことでデータ取得完了を明示的に保証する。
+ * 併せて、読み込み中インジケータが消えていることも確認する。
+ */
+async function waitForTheaterReady(page: Page): Promise<void> {
+  // 読み込み中表示が消えるまで待つ（useTheater / useWebGL2Support の判定完了）
+  await expect(page.getByText('読み込み中...')).toHaveCount(0, {
+    timeout: READY_TIMEOUT_MS,
+  });
+  // 座席一覧が描画される（= useTheater のデータ取得完了）
+  await expect(page.getByRole('button', { name: /^A列1番、/ })).toBeVisible();
+}
 
 test.describe('シアター体験ページ', () => {
   test('俯瞰ビューが表示され、座席を選択すると一人称に切り替わり、俯瞰に戻れる', async ({
     page,
   }) => {
     await page.goto('/theater-experience');
+
+    // WebGL2 初期化とデータ取得の完了を明示的に待つ（暗黙タイムアウト依存を解消）
+    await waitForWebGL2(page);
+    await waitForTheaterReady(page);
 
     // タイトルと劇場名が表示されること
     await expect(
@@ -49,6 +101,10 @@ test.describe('シアター体験ページ', () => {
 
   test('ヒートマップ表示/非表示を切り替えられる', async ({ page }) => {
     await page.goto('/theater-experience');
+
+    // WebGL2 初期化とデータ取得の完了を明示的に待つ
+    await waitForWebGL2(page);
+    await waitForTheaterReady(page);
 
     const showRadio = page.getByRole('radio', { name: 'ヒートマップを表示' });
     const hideRadio = page.getByRole('radio', { name: 'ヒートマップを非表示' });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,18 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: STORAGE_STATE,
+        // ヘッドレスChromiumでWebGL2を安定して有効化する。
+        // CI（GPUなし）では ANGLE + SwiftShader でソフトウェアレンダリングにフォールバックさせ、
+        // シアター体験ページ（three.js / WebGL2）の isWebGL2Support ゲートが
+        // 安定して true になるようにする（flaky対策）。
+        launchOptions: {
+          args: [
+            '--use-gl=angle',
+            '--use-angle=swiftshader',
+            '--enable-unsafe-swiftshader',
+            '--ignore-gpu-blocklist',
+          ],
+        },
       },
       dependencies: ['setup'],
     },


### PR DESCRIPTION
## 概要

`e2e/theaterExperience/theaterExperience.spec.ts`（three.js/WebGL）が CI のヘッドレス Chromium で不安定（flaky）に 30 秒タイムアウトする問題を解消しました。

真因: WebGL2 初期化が失敗して `isWebGL2Support` ゲートが false になると「俯瞰に戻る」ボタン等が出ず、暗黙の `toBeVisible` タイムアウトで落ちていた。

## ロードマップ

該当なし（E2E 安定化）

## レビューポイント

- **WebGL2 の CI 安定化**（`playwright.config.ts`）: chromium project の `use.launchOptions.args` に SwiftShader/ANGLE を追加（`--use-gl=angle` / `--use-angle=swiftshader` / `--enable-unsafe-swiftshader` / `--ignore-gpu-blocklist`）。GPU なし CI でもソフトウェアレンダリングで WebGL2 が安定有効。`webServer` は未変更。
- **明示的な待機**（`theaterExperience.spec.ts`）: `waitForWebGL2`（WebGL2 コンテキスト生成待ち）と `waitForTheaterReady`（「読み込み中...」消失＋座席ボタン出現で `useTheater` フェッチ完了待ち）を追加し、暗黙タイムアウト依存を解消。timeout は定数 `READY_TIMEOUT_MS`（15000）に集約。

## テスト

- theaterExperience spec を **連続 8 回**実行し全て green（各回 3 passed）。
- **全 E2E スイート 1 回**: **88 passed / 4 skipped / 0 failed**（SwiftShader 有効化による他テストへの悪影響なし）。
- `prettier --check` / `tsc --noEmit` pass、eslint クリーン。

Closes #420
