### PR TITLE
test(e2e): OTPレート制限のcleanup拡張でotpFlow不安定を解消（#416回帰）

### DIFF
--- a/e2e/auth/otpFlow.spec.ts
+++ b/e2e/auth/otpFlow.spec.ts
@@ -15,6 +15,7 @@ import { test, expect } from '@playwright/test';
 import {
   getLatestOtpCode,
   cleanupAuthUser,
+  cleanupOtpCodes,
   cleanupRateLimit,
   expireOtpCode,
   maxOutOtpAttempts,
@@ -39,8 +40,12 @@ test.describe('確認コード(OTP)フロー（未認証）', () => {
     await cleanupAuthUser(maxAttemptsEmail);
   });
 
-  // OTP日次送信上限（メール単位24h/5通）はCI/ローカルの繰り返し実行で累積し、
-  // 送信が RATE_LIMIT で弾かれてflakyになる。各テスト前に使用メールの制限をリセットする。
+  // OTP系レート制限（送信日次上限・検証/ログインのバースト上限など）はCI/ローカルの
+  // 繰り返し実行で rate_limits に累積し、送信/検証が弾かれてflakyになる。各テスト前に
+  // 使用メールの関連レート制限をすべてリセットする（cleanupRateLimit の既定挙動）。
+  // さらに login フローは「前回送信から60秒」の再送クールダウン（otp_codes.created_at 基準）
+  // があり、前回実行で残った login OTP が近接実行を弾く。TEST_USER の login OTP も削除して
+  // クールダウンをリセットする。
   test.beforeEach(async () => {
     await Promise.all([
       cleanupRateLimit(TEST_USER.email),
@@ -48,6 +53,7 @@ test.describe('確認コード(OTP)フロー（未認証）', () => {
       cleanupRateLimit(errEmail),
       cleanupRateLimit(expiredEmail),
       cleanupRateLimit(maxAttemptsEmail),
+      cleanupOtpCodes(TEST_USER.email, 'login'),
     ]);
   });
 

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -199,18 +199,44 @@ export async function maxOutOtpAttempts(
 }
 
 /**
+ * メール（identifier）単位で使われる認証/OTP系のレート制限 action_type 一覧。
+ * これらは rate_limits テーブルに email を identifier として蓄積されるため、
+ * CI/ローカルの繰り返し実行で累積し、近接実行する他テストと衝突して
+ * RATE_LIMIT_EXCEEDED / VERIFY_RATE_LIMIT_EXCEEDED で不安定に失敗する。
+ * - otp_send_daily: OTP日次送信上限（src/app/api/auth/otp/send/route.ts）
+ * - otp_verify:     OTP検証のバースト上限（src/app/api/auth/otp/verify/route.ts, #416）
+ * - login:          メールOTPログインの試行上限（src/lib/auth/auth.ts）
+ * - register:       新規登録の試行上限（src/app/api/auth/register/route.ts）
+ * - otp_resend:     OTP再送上限（DB制約で許可済み。将来の追従漏れを防ぐため含める）
+ * ※ change_password は identifier が user.id（メール以外）かつ DB を叩く E2E で
+ *   到達しないため、ここには含めない。
+ */
+const EMAIL_RATE_LIMIT_ACTION_TYPES = [
+  'otp_send_daily',
+  'otp_verify',
+  'login',
+  'register',
+  'otp_resend',
+] as const;
+
+/**
  * 指定識別子（メール等）のレート制限レコードを物理削除してリセットする。
- * OTP日次送信上限（action_type='otp_send_daily'）はメール単位で24h/5通のため、
- * CI/ローカルの繰り返し実行で累積し他テストと衝突する。OTP系テストの前に
- * これを呼んで自テストが累積に寄与せず・干渉されないようにする。
+ * 既定では認証/OTP系の関連 action_type をすべて（{@link EMAIL_RATE_LIMIT_ACTION_TYPES}）
+ * まとめてリセットし、テスト間の累積・残留で他テストがレート制限に到達するのを防ぐ。
+ * OTP/認証系テストの前（beforeEach 等）に呼んで、自テストが累積に寄与せず・
+ * 干渉されないようにする。
+ *
+ * @param identifier 対象の識別子（通常はメールアドレス）
+ * @param actionTypes リセット対象の action_type。未指定なら関連する全種別。
  */
 export async function cleanupRateLimit(
   identifier: string,
-  actionType = 'otp_send_daily',
+  actionTypes: readonly string[] = EMAIL_RATE_LIMIT_ACTION_TYPES,
 ): Promise<void> {
   const enc = encodeURIComponent(identifier);
+  const inList = encodeURIComponent(`(${actionTypes.join(',')})`);
   await fetch(
-    `${SUPABASE_URL}/rest/v1/rate_limits?identifier=eq.${enc}&action_type=eq.${actionType}`,
+    `${SUPABASE_URL}/rest/v1/rate_limits?identifier=eq.${enc}&action_type=in.${inList}`,
     { method: 'DELETE', headers: supabaseHeaders },
   );
 }


### PR DESCRIPTION
## 概要

OTP/認証系 E2E が「レート制限レコードのテスト間累積」で不安定に失敗する回帰（#416 のクリーンアップ追従漏れ）を、**テスト側のクリーンアップ拡張のみ**で解消しました。**本番コード（`src/`）は一切変更していません**（本番のレート制限挙動は不変）。

## ロードマップ

該当なし（E2E 安定化 / #416 回帰対応）

## レビューポイント

- `e2e/helpers/api.ts` の `cleanupRateLimit` を、単一 action_type（`otp_send_daily`）のみのリセットから、関連 action_type を PostgREST の `in.()` でまとめてリセットする実装に拡張（第2引数を `readonly string[]`、既定＝全種別）。既存呼び出しは自動的に全種リセットへ移行。
- リセット対象（email identifier 単位）: `otp_send_daily` / `otp_verify`（#416 追加）/ `login` / `register` / `otp_resend`。`change_password` は identifier が `user.id` で E2E 対象外。
- **追加要因の対処**: otpFlow の login フローには `rate_limits` とは別に「前回送信から 60 秒」の再送クールダウン（`otp_codes.created_at` 基準）があり、前回実行の残留 login OTP が近接実行を弾いていた。`otpFlow.spec.ts` の `beforeEach` に `cleanupOtpCodes(TEST_USER.email, 'login')` を追加して解消。

## テスト

- `otpFlow.spec.ts`（6 件）: **3 回連続で 6 passed**
- `otpPasswordChangeResend.spec.ts` + `changePassword.spec.ts`（12 件）: **2 回連続で 12 passed**
- `prettier --check` pass、eslint クリーン（e2e は ignore）。`src/` 未変更のため本番レート制限は不変。

Closes #423
