### PR TITLE
fix(csp): unsafe-inline許容+静的維持でhydration error/本番CSP違反/全動的化を解消（#418回帰）

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,28 @@ const withAnalyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const isDev = process.env.NODE_ENV === 'development';
+
+/**
+ * HTML ページ向け CSP。
+ * script-src に 'unsafe-inline' を許容することで静的プリレンダ（nonce 不要）を維持する。
+ * dev は Next.js 開発ツールが eval を利用するため 'unsafe-eval' も付与する。
+ * 値は src/lib/security/csp.ts の buildCspHeader と同期させること。
+ */
+const cspHeaderValue = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' https://image.tmdb.org data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.supabase.co",
+  'frame-src https://www.youtube.com',
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // React Strict Mode有効化（開発環境でEffect二重実行による潜在バグを検出）
@@ -84,16 +106,18 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
-          // HTML ページ向けの Content-Security-Policy は nonce ベースへ移行したため
-          // src/middleware.ts でリクエストごとに動的生成する。
-          // ここで静的に定義すると二重定義になるため、あえて設定しない。
-          // （CSP 以外のセキュリティヘッダは静的でよいため本ファイルで維持）
+          // CSP は unsafe-inline を許容し nonce 非依存のため、全パスへ静的に配信する。
+          // これにより静的プリレンダ（○ Static）を維持できる。
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeaderValue,
+          },
         ],
       },
       {
-        // /api/* は middleware の matcher 対象外（nonce CSP が付与されない）。
-        // JSON API はスクリプト実行やフレーム化を一切必要としないため、
-        // 最も制限的な CSP を静的に付与して多層防御を維持する。
+        // /api/* は JSON API のためスクリプト実行やフレーム化を一切必要としない。
+        // 最も制限的な CSP で上書きし、多層防御を維持する
+        // （後勝ちで /(.*) の CSP を上書きする）。
         source: '/api/(.*)',
         headers: [
           {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { headers } from 'next/headers';
 import { Noto_Sans_JP } from 'next/font/google';
 
 import { AppQueryProvider } from '@/components/providers/queryProvider';
@@ -19,21 +18,17 @@ export const metadata: Metadata = {
   description: '映画ウォッチリスト管理アプリケーション',
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // CSP nonce を middleware が設定した x-nonce ヘッダから取得し、
-  // インライン初期化スクリプトに付与する（'unsafe-inline' 除去のため）。
-  const nonce = (await headers()).get('x-nonce') ?? undefined;
-
   return (
     <html lang='ja' suppressHydrationWarning>
       <head>
         {/* ストレージキーは STORAGE_KEYS.THEME ('movie-app:theme') と同期すること */}
+        {/* CSP は script-src 'unsafe-inline' を許容するため nonce は付与しない */}
         <script
-          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html:
               "(function(){try{var t=localStorage.getItem('movie-app:theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark')}catch(e){}})()",

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -2,49 +2,23 @@
  * CSP ヘッダ生成ロジックのテスト
  */
 
-import { buildCspHeader, generateNonce } from './csp';
-
-describe('generateNonce', () => {
-  it('base64 文字列を返す', () => {
-    const nonce = generateNonce();
-    // base64 として復元できることを確認
-    expect(nonce).toMatch(/^[A-Za-z0-9+/]+=*$/);
-    expect(nonce.length).toBeGreaterThan(0);
-  });
-
-  it('呼び出しごとに異なる値を生成する', () => {
-    const a = generateNonce();
-    const b = generateNonce();
-    expect(a).not.toBe(b);
-  });
-
-  it('復元すると UUID 形式になる', () => {
-    const nonce = generateNonce();
-    const decoded = Buffer.from(nonce, 'base64').toString('utf8');
-    expect(decoded).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
-  });
-});
+import { buildCspHeader } from './csp';
 
 describe('buildCspHeader', () => {
-  const nonce = 'test-nonce-value';
-
   describe('本番環境（isDev=false）', () => {
-    const header = buildCspHeader(nonce, false);
+    const header = buildCspHeader(false);
 
-    it("script-src に nonce と 'strict-dynamic' を含む", () => {
-      expect(header).toContain(
-        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
-      );
+    it("script-src に 'self' と 'unsafe-inline' を含む（静的プリレンダ維持）", () => {
+      expect(header).toContain("script-src 'self' 'unsafe-inline'");
     });
 
-    it("script-src から 'unsafe-inline' が除去されている", () => {
+    it("script-src に nonce / 'strict-dynamic' を含まない", () => {
       const scriptSrc = header
         .split('; ')
         .find((d) => d.startsWith('script-src'));
       expect(scriptSrc).toBeDefined();
-      expect(scriptSrc).not.toContain("'unsafe-inline'");
+      expect(scriptSrc).not.toContain('nonce-');
+      expect(scriptSrc).not.toContain("'strict-dynamic'");
     });
 
     it("本番では script-src に 'unsafe-eval' を含まない", () => {
@@ -52,6 +26,10 @@ describe('buildCspHeader', () => {
         .split('; ')
         .find((d) => d.startsWith('script-src'));
       expect(scriptSrc).not.toContain("'unsafe-eval'");
+    });
+
+    it("object-src 'none' を含む", () => {
+      expect(header).toContain("object-src 'none'");
     });
 
     it('既存の他ディレクティブを維持する', () => {
@@ -65,7 +43,6 @@ describe('buildCspHeader', () => {
         "img-src 'self' https://image.tmdb.org data: blob:",
       );
       expect(header).toContain("font-src 'self' data:");
-      // style-src は今回のスコープ外のため 'unsafe-inline' を維持
       expect(header).toContain("style-src 'self' 'unsafe-inline'");
     });
 
@@ -76,7 +53,7 @@ describe('buildCspHeader', () => {
   });
 
   describe('開発環境（isDev=true）', () => {
-    const header = buildCspHeader(nonce, true);
+    const header = buildCspHeader(true);
 
     it("script-src に 'unsafe-eval' を含む（Next.js 開発ツール向け）", () => {
       const scriptSrc = header
@@ -85,16 +62,11 @@ describe('buildCspHeader', () => {
       expect(scriptSrc).toContain("'unsafe-eval'");
     });
 
-    it("開発でも 'unsafe-inline' は含まない", () => {
+    it("開発でも 'unsafe-inline' を含む", () => {
       const scriptSrc = header
         .split('; ')
         .find((d) => d.startsWith('script-src'));
-      expect(scriptSrc).not.toContain("'unsafe-inline'");
+      expect(scriptSrc).toContain("'unsafe-inline'");
     });
-  });
-
-  it('nonce の値がヘッダに反映される', () => {
-    const header = buildCspHeader('another-nonce', false);
-    expect(header).toContain("'nonce-another-nonce'");
   });
 });

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,37 +1,31 @@
 /**
  * Content Security Policy (CSP) ヘッダ生成ロジック
  *
- * nonce ベースの CSP を採用し、`script-src` から `'unsafe-inline'` を除去する。
- * インラインスクリプト（layout.tsx のテーマ初期化）にはリクエストごとに生成した
- * nonce を付与することで実行を許可する。
+ * `script-src` に `'unsafe-inline'` を許容することで、静的プリレンダ
+ * （nonce 不要）を維持したまま CSP を配信できるようにする。
+ * nonce / strict-dynamic による全ページ動的化は hydration mismatch を
+ * 引き起こしたため採用しない（XSS 多層防御は後続段階で report / Trusted
+ * Types により補う）。
  *
- * `'strict-dynamic'` を併用することで、nonce 付きスクリプトが動的に読み込む
- * スクリプト（Next.js の chunk 等）を信頼し、明示的なホワイトリスト維持を不要にする。
+ * unsafe-inline を許容するため CSP は nonce に依存せず、next.config.mjs で
+ * 全パスへ静的ヘッダとして配信する。
  */
-
-/** リクエストごとに一意な nonce を生成する（base64 エンコードした UUID） */
-export function generateNonce(): string {
-  return Buffer.from(crypto.randomUUID()).toString('base64');
-}
 
 /**
  * CSP ヘッダ値を生成する。
  *
- * @param nonce リクエストごとの nonce
  * @param isDev 開発環境かどうか。開発時のみ `script-src` に `'unsafe-eval'` を付与する
  *   （Next.js の開発ツールが eval を利用するため）。本番では付与しない。
  * @returns 1 行に整形した CSP ヘッダ値
  */
-export function buildCspHeader(nonce: string, isDev: boolean): string {
+export function buildCspHeader(isDev: boolean): string {
   const directives = [
     "default-src 'self'",
-    // nonce + strict-dynamic により 'unsafe-inline' を除去。
-    // 本番では 'unsafe-eval' を付与しない（多層防御の強化）。
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${
-      isDev ? " 'unsafe-eval'" : ''
-    }`,
+    // 静的プリレンダを維持するため 'unsafe-inline' を許容する。
+    // dev は Next.js 開発ツールが eval を利用するため 'unsafe-eval' も付与する。
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
     // style-src は Next.js / 各種ライブラリのインラインスタイルに依存するため
-    // 'unsafe-inline' を維持する（今回の対応スコープ外）。
+    // 'unsafe-inline' を維持する。
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' https://image.tmdb.org data: blob:",
     // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
@@ -42,6 +36,8 @@ export function buildCspHeader(nonce: string, isDev: boolean): string {
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",
+    // プラグイン（<object>/<embed>）を全面禁止し、埋め込みベクタを塞ぐ
+    "object-src 'none'",
   ];
 
   return directives.join('; ');

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -3,8 +3,7 @@
  */
 
 // next/serverをモック
-// mockNextResponseNext は NextResponse.next() に渡される init 引数
-// （{ request: { headers } }）を記録し、リクエストヘッダへの nonce/CSP 伝播を検証する。
+// mockNextResponseNext は NextResponse.next() の呼び出しを記録する。
 const mockNextResponseNext = jest.fn();
 const mockNextResponseRedirect = jest.fn();
 const mockCookiesDelete = jest.fn();
@@ -180,58 +179,8 @@ describe('middleware', () => {
     });
   });
 
-  describe('CSP nonce / ヘッダ付与', () => {
-    it('通常応答に Content-Security-Policy ヘッダが付与される', () => {
-      const req = createMockRequest({
-        pathname: '/movies/now-showing',
-        auth: mockAuth,
-        hasSessionCookie: true,
-      });
-
-      const response = middleware(req);
-      const csp = response.headers.get('content-security-policy');
-
-      expect(csp).not.toBeNull();
-      expect(csp).toContain("script-src 'self' 'nonce-");
-      expect(csp).toContain("'strict-dynamic'");
-      // 多層防御強化: 'unsafe-inline' は script-src から除去されている
-      const scriptSrc = csp
-        ?.split('; ')
-        .find((d) => d.startsWith('script-src'));
-      expect(scriptSrc).not.toContain("'unsafe-inline'");
-    });
-
-    it('リダイレクト応答にも Content-Security-Policy ヘッダが付与される', () => {
-      const req = createMockRequest({
-        pathname: '/watchlist',
-        auth: null,
-        hasSessionCookie: false,
-      });
-
-      const response = middleware(req);
-
-      expect(response.headers.get('content-security-policy')).not.toBeNull();
-    });
-
-    it('リクエストごとに異なる nonce を生成する', () => {
-      const req1 = createMockRequest({
-        pathname: '/movies/now-showing',
-        auth: mockAuth,
-        hasSessionCookie: true,
-      });
-      const req2 = createMockRequest({
-        pathname: '/movies/now-showing',
-        auth: mockAuth,
-        hasSessionCookie: true,
-      });
-
-      const csp1 = middleware(req1).headers.get('content-security-policy');
-      const csp2 = middleware(req2).headers.get('content-security-policy');
-
-      expect(csp1).not.toBe(csp2);
-    });
-
-    it('x-nonce と CSP がリクエストヘッダに伝播する（Server Component / Next.js 参照用）', () => {
+  describe('CSP / nonce を付与しない（静的配信へ移行）', () => {
+    it('通常応答に Content-Security-Policy ヘッダを設定しない（next.config で静的配信）', () => {
       const req = createMockRequest({
         pathname: '/movies/now-showing',
         auth: mockAuth,
@@ -240,22 +189,21 @@ describe('middleware', () => {
 
       const response = middleware(req);
 
-      // NextResponse.next() に渡された init から伝播先のリクエストヘッダを取得
-      const init = mockNextResponseNext.mock.calls[0][0] as {
-        request?: { headers?: Headers };
-      };
-      const requestHeaders = init?.request?.headers;
-      expect(requestHeaders).toBeInstanceOf(Headers);
+      expect(response.headers.get('content-security-policy')).toBeNull();
+    });
 
-      const nonceHeader = requestHeaders?.get('x-nonce');
-      const requestCsp = requestHeaders?.get('content-security-policy');
-      const responseCsp = response.headers.get('content-security-policy');
+    it('NextResponse.next() に x-nonce/CSP を載せたリクエストヘッダを渡さない', () => {
+      const req = createMockRequest({
+        pathname: '/movies/now-showing',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
 
-      // x-nonce が設定され、レスポンス CSP の nonce 値と一致する
-      expect(nonceHeader).toBeTruthy();
-      expect(responseCsp).toContain(`'nonce-${nonceHeader}'`);
-      // リクエストヘッダにも同一の CSP が伝播している
-      expect(requestCsp).toBe(responseCsp);
+      middleware(req);
+
+      // 認証のみのため init（{ request: { headers } }）は渡されない
+      const init = mockNextResponseNext.mock.calls[0][0];
+      expect(init).toBeUndefined();
     });
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,14 @@
 /**
- * Next.js Middleware - 認証保護 + CSP nonce 付与
+ * Next.js Middleware - 認証保護
+ *
+ * CSP は static prerender を維持するため next.config.mjs で静的配信する
+ * （script-src 'unsafe-inline' 許容により nonce 不要）。ここでは認証保護のみを担う。
  */
 
 import { NextResponse } from 'next/server';
 
 import { auth } from '@/lib/auth/auth';
 import { ROUTES, AUTH_REQUIRED_ROUTES } from '@/constants/common';
-import { buildCspHeader, generateNonce } from '@/lib/security/csp';
 
 /** セッションcookie名（環境に応じて切り替え） */
 const SESSION_COOKIE_NAME =
@@ -23,34 +25,6 @@ const authPaths = [ROUTES.LOGIN, ROUTES.REGISTER];
 export default auth((req) => {
   const { nextUrl } = req;
   const isAuthenticated = !!req.auth;
-
-  // --- CSP nonce の生成とヘッダ準備 ---
-  // リクエストごとに nonce を生成し CSP ヘッダを組み立てる。
-  // x-nonce はリクエストヘッダに載せ、Server Component（layout.tsx）から
-  // 参照できるようにする。CSP はリクエスト/レスポンス双方に設定する
-  // （Next.js が自身のスクリプトへ nonce を付与するにはリクエスト側の CSP が必要）。
-  const nonce = generateNonce();
-  const isDev = process.env.NODE_ENV === 'development';
-  const cspHeader = buildCspHeader(nonce, isDev);
-
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.set('x-nonce', nonce);
-  requestHeaders.set('Content-Security-Policy', cspHeader);
-
-  /** 通常応答（NextResponse.next）に nonce 付きリクエストヘッダと CSP を適用する */
-  const buildNextResponse = () => {
-    const response = NextResponse.next({
-      request: { headers: requestHeaders },
-    });
-    response.headers.set('Content-Security-Policy', cspHeader);
-    return response;
-  };
-
-  /** リダイレクト応答にも CSP を付与する */
-  const withCsp = (response: NextResponse) => {
-    response.headers.set('Content-Security-Policy', cspHeader);
-    return response;
-  };
 
   const isProtectedPath = protectedPaths.some((path) =>
     nextUrl.pathname.startsWith(path),
@@ -74,23 +48,23 @@ export default auth((req) => {
 
   if (!isAuthenticated && hasSessionCookie) {
     const response = isProtectedPath
-      ? withCsp(NextResponse.redirect(buildSignInUrl()))
-      : buildNextResponse();
+      ? NextResponse.redirect(buildSignInUrl())
+      : NextResponse.next();
     response.cookies.delete(SESSION_COOKIE_NAME);
     return response;
   }
 
   // 未認証で保護されたパスにアクセス → サインインページへリダイレクト（戻り先を保持）
   if (isProtectedPath && !isAuthenticated) {
-    return withCsp(NextResponse.redirect(buildSignInUrl()));
+    return NextResponse.redirect(buildSignInUrl());
   }
 
   // 認証済みで認証ページにアクセス → ホームへリダイレクト
   if (isAuthPath && isAuthenticated) {
-    return withCsp(NextResponse.redirect(new URL(ROUTES.HOME, nextUrl)));
+    return NextResponse.redirect(new URL(ROUTES.HOME, nextUrl));
   }
 
-  return buildNextResponse();
+  return NextResponse.next();
 });
 
 // Middlewareを適用するパスを設定


### PR DESCRIPTION
## 概要

CSP を **nonce＋strict-dynamic＋force-dynamic** から **`unsafe-inline` 許容＋静的維持** に変更し、#418 が引き起こしていた 3 つの問題を解消します:
1. `layout.tsx` の手動 nonce と Next.js 自動 nonce 注入の競合による **hydration error**
2. 静的プリレンダページで nonce 未注入 → **本番で CSP 違反 31 件・アプリ hydrate 不能**
3. `await headers()` による **全ページ動的レンダリング化**（静的最適化・CDN キャッシュの喪失）

XSS 多層防御（`unsafe-inline` 除去分）は、**後続段階で Trusted Types（Report-Only→enforce）＋ CSP レポートを段階導入して補完**する方針です（別 Issue 化予定）。

## ロードマップ

該当なし（#418 回帰の修正・CSP 方針転換の段階1）

## レビューポイント

- `csp.ts`: `script-src` を本番 `'self' 'unsafe-inline'` / dev `'self' 'unsafe-inline' 'unsafe-eval'`。nonce/strict-dynamic を除去し **`object-src 'none'` を追加**。他ディレクティブ（style/img/font/connect/frame/frame-ancestors/base-uri/form-action）は維持。
- `layout.tsx`: `await headers()`・`<script nonce>` を除去（素の `dangerouslySetInnerHTML` に戻す）→ **静的復活**。
- `middleware.ts`: nonce/x-nonce/CSP 設定を除去し認証保護のみに。
- `next.config.mjs`: CSP を全パス静的配信、`/api` は最制限で上書き。
- **静的/動的（before→after）**: 全ページ動的 → **静的 11 復活**（公開 6: `/awards`・`/movies/now-showing`・`/movies/upcoming`・`/search`・`/theater-experience`・`/auth/signup`、認証 4: `/favorites`・`/watchlist`・`/settings`・`/settings/change-password`）。`/`・`/auth/signin`・`/api/*` は session 依存で動的のまま（妥当）。
- ⚠️ この段階は **`unsafe-inline` を許容**（XSS 多層防御の 1 層を一旦外す）。主防御（React 自動エスケープ＋入力検証＋`httpOnly` cookie）は維持。後続で Trusted Types 等を追加します。

## テスト

- `npm run build` 成功。本番（`next start`）と dev の両方で **hydration error 0・CSP 違反 0**（agent が独立コンテキストで検証。コーディネーターも新規セッションで hydration 0・CSP 違反 0 を再確認）。
- 既存機能動作（テーマ切替・WebGL・fullcalendar・TMDb 画像・Supabase・YouTube）。
- `npx jest` 全 2306 テスト pass。`csp.ts` 100% / `middleware.ts` 96.66%。lint/tsc/prettier pass。

Closes #427
