### PR TITLE
fix(hooks): PR自動レビューのagentフックを削除（誤発火の恒久対策）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,17 +74,6 @@
             "statusMessage": "Prettier/ESLint を実行中..."
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "agent",
-            "if": "Bash(gh pr create *)",
-            "prompt": "PR が作成されました。以下の手順でレビューしてください:\n1. `gh pr diff` で差分を確認\n2. コード品質・セキュリティ・テストカバレッジの観点でレビュー\n3. 問題があれば `gh pr comment` でPRにコメントを投稿\n4. 問題がなければ「LGTM」とコメント\n\nレビュー観点:\n- OWASP Top 10 脆弱性がないか\n- テストが十分か\n- 命名規則・コーディング規約に準拠しているか\n- パフォーマンスに問題がないか",
-            "timeout": 120
-          }
-        ]
       }
     ]
   }


### PR DESCRIPTION
## 概要

#411 のフック誤発火の**恒久対策**。`.claude/settings.json` の `PostToolUse` から **PR 自動レビューの agent フックを削除**する。

このフックは `if: "Bash(gh pr create *)"` で「PR 作成時のみ」を意図していたが、実際には **`gh pr create` 以外の無関係な Bash 実行でも発火**し、本セッション中に複数回誤起動。さらに **マージ済みの #428 に根拠の弱いレビューコメントを誤投稿**する実害が出た（#411 で懸念していた挙動が顕在化）。

PR レビューは手動 / サブエージェント（今回のワークフローで実施）で代替する。

## ロードマップ

該当なし

## レビューポイント

- 削除対象は `PostToolUse` の `matcher: "Bash"` ＋ `type: "agent"` フックのみ。
- **残すもの**: PreToolUse のカバレッジチェック（`pre-commit-coverage.sh`）、PostToolUse の `Edit|Write` lint フック（`post-edit-lint.sh`）は維持。
- 誤発火の原因は `agent` タイプフックで `if` 条件が期待通り機能せず全 Bash にマッチしていたこと。将来 PR 自動レビューを復活させる場合は、`command` フックでコマンド判定してから起動する形を推奨。

## テスト

- `.claude/settings.json` の JSON 妥当性を確認。
- 他フック（coverage / lint）の定義は不変。

Closes #411
