### PR TITLE
feat(csp): 段階2 CSP値の単一ソース化＋/api/csp-reportで違反レポート収集

### DIFF
--- a/.claude/documents/architecture.md
+++ b/.claude/documents/architecture.md
@@ -324,21 +324,24 @@ UI Re-render
 | `X-DNS-Prefetch-Control` | `on` | DNSプリフェッチ有効化 |
 | `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | HTTPS強制（2年間） |
 
-### Content-Security-Policy（nonce ベース）
+### Content-Security-Policy（unsafe-inline 許容・静的配信）
 
-CSP はページと API で付与方法を分離している。
+CSP はページと API で付与方法を分離し、いずれも `next.config.mjs` の `headers()` で静的付与する。
 
 | 対象 | 付与元 | 値 |
 |------|--------|----|
-| HTMLページ | `src/middleware.ts`（リクエスト毎に動的生成） | nonce ベース CSP（`script-src` は `'self' 'nonce-<...>' 'strict-dynamic'`、本番は `'unsafe-eval'` 除去・開発時のみ保持） |
-| `/api/*` | `next.config.mjs`（静的） | `default-src 'none'; frame-ancestors 'none'` |
+| HTMLページ（`/(.*)`） | `next.config.mjs`（静的） | `script-src 'self' 'unsafe-inline'`（開発時のみ `'unsafe-eval'` を追加）＋ `report-to` / `report-uri`。ほか `default-src 'self'` 等 |
+| `/api/*` | `next.config.mjs`（静的・後勝ちで上書き） | `default-src 'none'; frame-ancestors 'none'` |
 
-**nonce ベース CSP の仕組み（`src/lib/security/csp.ts` / `src/middleware.ts` / `src/app/layout.tsx`）:**
-- middleware がリクエスト毎に nonce を生成し、CSP ヘッダを組み立てる（`buildCspHeader` / `generateNonce`）
-- nonce は `x-nonce` リクエストヘッダに載せ、`layout.tsx`（Server Component）がテーマ初期化のインラインスクリプトに付与
-- CSP はリクエスト・レスポンス双方に設定（Next.js が自身のスクリプトへ nonce を付与するにはリクエスト側の CSP が必要）
-- `script-src` から `'unsafe-inline'` を除去。`'strict-dynamic'` 併用で nonce 付きスクリプトが読み込む chunk 等を信頼
-- `style-src` は各種ライブラリのインラインスタイル依存のため `'unsafe-inline'` を維持（今回のスコープ外）
-- `/api/*` は middleware の matcher 対象外のため、`next.config.mjs` で最も制限的な CSP を静的付与（多層防御）
+**CSP 値の単一ソース化（`src/lib/security/cspDirectives.mjs`）:**
+- CSP ディレクティブ定義はプレーン ESM の `cspDirectives.mjs` に集約する。`next.config.mjs`（Node ESM・TS トランスパイル前）は TypeScript を直接 import できないため、値の二重定義（同期漏れ）を避ける目的で共有モジュール化している。
+- `next.config.mjs` は `buildCspHeaderValue` / `buildReportingEndpointsValue` を import してヘッダ値を組み立てる。
+- `src/lib/security/csp.ts`（`buildCspHeader`）は同モジュールの薄いラッパで、テスト・将来の再利用向けに公開する。
+- `script-src` に `'unsafe-inline'` を許容することで静的プリレンダ（`○ Static`）を維持する。nonce / `'strict-dynamic'` は hydration mismatch を招くため採用しない。
+- `style-src` は各種ライブラリのインラインスタイル依存のため `'unsafe-inline'` を維持。
+- `/api/*` は最も制限的な CSP を静的付与し、多層防御を維持する。
 
-**副作用:** per-request nonce を用いるため、全ページが動的レンダリング（`ƒ`）になる。
+**CSP 違反レポートの自前収集（`src/app/api/csp-report/route.ts`）:**
+- enforce CSP に `report-to csp-endpoint`（＋後方互換の `report-uri /api/csp-report`）を付与し、`Reporting-Endpoints: csp-endpoint="/api/csp-report"` ヘッダで受信先を宣言する。
+- `/api/csp-report` は POST で違反レポートを受信し、違反ディレクティブ・blocked-uri 等を構造化ログ（`console.warn('[csp-report]', ...)`）に出力する。report-uri 形式（`application/csp-report`）と Reporting API 形式（`application/reports+json`）の双方に対応。
+- 認証不要（ブラウザが未認証で送信するため）。大量送信・悪用対策として本文サイズ上限（16KB）を設け、解析失敗時も含め常に `204` を返す（ブラウザの再送・利用者体験に影響させない）。

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,14 @@
 /* eslint-disable no-undef */
 import withBundleAnalyzer from '@next/bundle-analyzer';
 
+// CSP の値は src/lib/security/csp.ts と共有（単一ソース化）。
+// next.config.mjs（Node ESM）は TS を直接 import できないため、プレーン
+// ESM の共有モジュールを双方から import して値の二重定義を防ぐ。
+import {
+  buildCspHeaderValue,
+  buildReportingEndpointsValue,
+} from './src/lib/security/cspDirectives.mjs';
+
 const withAnalyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -11,21 +19,12 @@ const isDev = process.env.NODE_ENV === 'development';
  * HTML ページ向け CSP。
  * script-src に 'unsafe-inline' を許容することで静的プリレンダ（nonce 不要）を維持する。
  * dev は Next.js 開発ツールが eval を利用するため 'unsafe-eval' も付与する。
- * 値は src/lib/security/csp.ts の buildCspHeader と同期させること。
+ * 違反監視のため report-to / report-uri を付与する（自前 /api/csp-report で収集）。
  */
-const cspHeaderValue = [
-  "default-src 'self'",
-  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' https://image.tmdb.org data: blob:",
-  "font-src 'self' data:",
-  "connect-src 'self' https://*.supabase.co",
-  'frame-src https://www.youtube.com',
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "object-src 'none'",
-].join('; ');
+const cspHeaderValue = buildCspHeaderValue({ isDev, withReporting: true });
+
+// Reporting API のエンドポイント定義。CSP の report-to グループ名と対応させる。
+const reportingEndpointsValue = buildReportingEndpointsValue();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -111,6 +110,12 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value: cspHeaderValue,
+          },
+          // report-to（CSP）が参照する Reporting API のエンドポイント定義。
+          // 違反レポートは /api/csp-report が受信する。
+          {
+            key: 'Reporting-Endpoints',
+            value: reportingEndpointsValue,
           },
         ],
       },

--- a/src/app/api/csp-report/route.test.ts
+++ b/src/app/api/csp-report/route.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * CSP 違反レポート受信 API Route テスト
+ */
+
+import { POST } from './route';
+
+/** テスト用に Request を組み立てる。 */
+function makeRequest(
+  body: string,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request('http://localhost/api/csp-report', {
+    method: 'POST',
+    headers: { 'content-type': 'application/csp-report', ...headers },
+    body,
+  });
+}
+
+describe('POST /api/csp-report', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('report-uri 形式（csp-report）を受信しログ出力し 204 を返す', async () => {
+    const body = JSON.stringify({
+      'csp-report': {
+        'document-uri': 'https://example.com/page',
+        'violated-directive': "script-src 'self'",
+        'effective-directive': 'script-src',
+        'blocked-uri': 'https://evil.example.com/x.js',
+        'source-file': 'https://example.com/page',
+        'line-number': 10,
+        'column-number': 5,
+        disposition: 'enforce',
+      },
+    });
+
+    const res = await POST(makeRequest(body));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [, violation] = warnSpy.mock.calls[0];
+    expect(violation).toMatchObject({
+      documentUri: 'https://example.com/page',
+      violatedDirective: "script-src 'self'",
+      blockedUri: 'https://evil.example.com/x.js',
+    });
+  });
+
+  it('Reporting API 形式（reports+json 配列）を受信しログ出力する', async () => {
+    const body = JSON.stringify([
+      {
+        type: 'csp-violation',
+        body: {
+          documentURL: 'https://example.com/a',
+          effectiveDirective: 'img-src',
+          blockedURL: 'https://evil.example.com/pixel.png',
+          disposition: 'enforce',
+        },
+      },
+      {
+        type: 'csp-violation',
+        body: {
+          documentURL: 'https://example.com/b',
+          effectiveDirective: 'style-src',
+          blockedURL: 'inline',
+        },
+      },
+    ]);
+
+    const res = await POST(
+      makeRequest(body, { 'content-type': 'application/reports+json' }),
+    );
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0][1]).toMatchObject({
+      documentUri: 'https://example.com/a',
+      blockedUri: 'https://evil.example.com/pixel.png',
+    });
+  });
+
+  it('Reporting API 形式で csp-violation 以外の type は無視する', async () => {
+    const body = JSON.stringify([
+      { type: 'deprecation', body: { message: 'x' } },
+      { type: 'csp-violation', body: { blockedURL: 'https://evil/x.js' } },
+    ]);
+
+    const res = await POST(
+      makeRequest(body, { 'content-type': 'application/reports+json' }),
+    );
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('不正な JSON でも 204 を返しログしない', async () => {
+    const res = await POST(makeRequest('{not-json'));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('空の本文は 204 を返しログしない', async () => {
+    const res = await POST(makeRequest(''));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('Content-Length が上限超過の場合は本文を読まず 204 を返す', async () => {
+    const res = await POST(
+      makeRequest('{}', { 'content-length': String(17 * 1024) }),
+    );
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('Content-Length が不正値（NaN）の場合は本文を読まず 204 を返す', async () => {
+    const brokenRequest = {
+      headers: { get: () => 'not-a-number' },
+      text: jest.fn(),
+    } as unknown as Request & { text: jest.Mock };
+
+    const res = await POST(brokenRequest);
+
+    expect(res.status).toBe(204);
+    // 本文を読まずに弾くこと
+    expect(
+      (brokenRequest as unknown as { text: jest.Mock }).text,
+    ).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('本文サイズが上限超過の場合は破棄して 204 を返す', async () => {
+    // Content-Length を付けず、実本文長で上限判定させる
+    const huge = JSON.stringify({
+      'csp-report': { pad: 'x'.repeat(17 * 1024) },
+    });
+    const res = await POST(makeRequest(huge));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('未知の形状（オブジェクト単体）はログせず 204 を返す', async () => {
+    const res = await POST(makeRequest(JSON.stringify({ foo: 'bar' })));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('本文読み取りが失敗しても 204 を返す（best-effort）', async () => {
+    // text() が例外を投げる Request を模擬
+    const brokenRequest = {
+      headers: { get: () => '0' },
+      text: () => Promise.reject(new Error('stream error')),
+    } as unknown as Request;
+
+    const res = await POST(brokenRequest);
+
+    expect(res.status).toBe(204);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,124 @@
+/**
+ * CSP 違反レポート受信 API
+ * POST /api/csp-report
+ *
+ * ブラウザが送信する CSP 違反レポートを受信し、構造化ログとして出力する。
+ * - report-uri 形式: `Content-Type: application/csp-report`
+ *   （`{ "csp-report": { ... } }`）
+ * - Reporting API (report-to) 形式: `Content-Type: application/reports+json`
+ *   （`[{ "type": "csp-violation", "body": { ... } }, ...]`）
+ *
+ * 認証は不要（ブラウザが未認証で送信するため）。
+ * 大量送信・悪用対策として本文サイズに上限を設け、解析失敗時も含めて
+ * 常に 204 を返す（ブラウザにエラーを返しても再送・利用者への影響がないため）。
+ */
+
+import { NextResponse } from 'next/server';
+
+/**
+ * 受信を許可する本文サイズの上限（バイト）。
+ * これを超えるレポートは中身を読まずに破棄する（メモリ枯渇・DoS 対策）。
+ */
+const MAX_BODY_BYTES = 16 * 1024; // 16KB
+
+/** 正常受信時のレスポンス（本文不要のため 204）。 */
+const NO_CONTENT = 204;
+
+/**
+ * 単一の CSP 違反レポート本体から、ログに残す主要フィールドを抽出する。
+ * report-uri 形式（ハイフン区切り）と Reporting API 形式（キャメル/スネーク）の
+ * 双方のキーに対応する。
+ */
+function extractViolation(body: Record<string, unknown>): {
+  documentUri?: unknown;
+  violatedDirective?: unknown;
+  effectiveDirective?: unknown;
+  blockedUri?: unknown;
+  sourceFile?: unknown;
+  lineNumber?: unknown;
+  columnNumber?: unknown;
+  disposition?: unknown;
+} {
+  return {
+    documentUri: body['document-uri'] ?? body.documentURL,
+    violatedDirective: body['violated-directive'] ?? body.violatedDirective,
+    effectiveDirective: body['effective-directive'] ?? body.effectiveDirective,
+    blockedUri: body['blocked-uri'] ?? body.blockedURL,
+    sourceFile: body['source-file'] ?? body.sourceFile,
+    lineNumber: body['line-number'] ?? body.lineNumber,
+    columnNumber: body['column-number'] ?? body.columnNumber,
+    disposition: body.disposition,
+  };
+}
+
+/**
+ * パース済みの JSON からレポート本体の配列を取り出して構造化ログに出力する。
+ * 未知の形状は無視し、既知の 2 形式のみログする。
+ */
+function logReports(payload: unknown): void {
+  // report-uri 形式: { "csp-report": {...} }
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'csp-report' in payload &&
+    typeof (payload as Record<string, unknown>)['csp-report'] === 'object' &&
+    (payload as Record<string, unknown>)['csp-report'] !== null
+  ) {
+    const report = (payload as Record<string, Record<string, unknown>>)[
+      'csp-report'
+    ];
+    console.warn('[csp-report]', extractViolation(report));
+    return;
+  }
+
+  // Reporting API 形式: [{ type: 'csp-violation', body: {...} }, ...]
+  if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        entry.type === 'csp-violation' &&
+        entry.body &&
+        typeof entry.body === 'object'
+      ) {
+        console.warn(
+          '[csp-report]',
+          extractViolation(entry.body as Record<string, unknown>),
+        );
+      }
+    }
+  }
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    // 本文サイズ上限チェック（Content-Length が信頼できない場合も後段の
+    // text() 長で二重に防ぐ）。数値化に失敗した不正な Content-Length は
+    // 上限超過として扱い、中身を読まずに破棄する（防御的）。
+    const contentLength = Number(request.headers.get('content-length') ?? '0');
+    if (!Number.isFinite(contentLength) || contentLength > MAX_BODY_BYTES) {
+      return new NextResponse(null, { status: NO_CONTENT });
+    }
+
+    const raw = await request.text();
+    if (raw.length === 0 || raw.length > MAX_BODY_BYTES) {
+      return new NextResponse(null, { status: NO_CONTENT });
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      // 不正な JSON は破棄（悪用・誤送信対策）。
+      return new NextResponse(null, { status: NO_CONTENT });
+    }
+
+    logReports(payload);
+  } catch (error) {
+    // レポート収集は best-effort。失敗しても常に成功扱いで返す
+    // （ブラウザの再送やユーザー体験に影響させない）。
+    console.error('[csp-report] failed to process report:', error);
+  }
+
+  return new NextResponse(null, { status: NO_CONTENT });
+}

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -32,6 +32,11 @@ describe('buildCspHeader', () => {
       expect(header).toContain("object-src 'none'");
     });
 
+    it('違反監視用の report-to / report-uri を含む', () => {
+      expect(header).toContain('report-to csp-endpoint');
+      expect(header).toContain('report-uri /api/csp-report');
+    });
+
     it('既存の他ディレクティブを維持する', () => {
       expect(header).toContain("default-src 'self'");
       expect(header).toContain("frame-ancestors 'none'");

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -4,41 +4,25 @@
  * `script-src` に `'unsafe-inline'` を許容することで、静的プリレンダ
  * （nonce 不要）を維持したまま CSP を配信できるようにする。
  * nonce / strict-dynamic による全ページ動的化は hydration mismatch を
- * 引き起こしたため採用しない（XSS 多層防御は後続段階で report / Trusted
- * Types により補う）。
+ * 引き起こしたため採用しない（XSS 多層防御は report / Trusted Types で補う）。
  *
- * unsafe-inline を許容するため CSP は nonce に依存せず、next.config.mjs で
- * 全パスへ静的ヘッダとして配信する。
+ * CSP の値そのものは `next.config.mjs`（Node ESM）と共有するため、プレーン
+ * ESM の共有モジュール `cspDirectives.mjs` に単一ソース化している。本ファイル
+ * はその共有ロジックへの薄いラッパであり、値を重複定義しない。
  */
+
+import { buildCspHeaderValue } from './cspDirectives.mjs';
 
 /**
  * CSP ヘッダ値を生成する。
+ *
+ * 違反レポート用ディレクティブ（`report-to` / `report-uri`）を含む enforce CSP
+ * を返す。dev では `script-src` に `'unsafe-eval'` を付与する。
  *
  * @param isDev 開発環境かどうか。開発時のみ `script-src` に `'unsafe-eval'` を付与する
  *   （Next.js の開発ツールが eval を利用するため）。本番では付与しない。
  * @returns 1 行に整形した CSP ヘッダ値
  */
 export function buildCspHeader(isDev: boolean): string {
-  const directives = [
-    "default-src 'self'",
-    // 静的プリレンダを維持するため 'unsafe-inline' を許容する。
-    // dev は Next.js 開発ツールが eval を利用するため 'unsafe-eval' も付与する。
-    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
-    // style-src は Next.js / 各種ライブラリのインラインスタイルに依存するため
-    // 'unsafe-inline' を維持する。
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' https://image.tmdb.org data: blob:",
-    // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
-    // base64エンコードした data: URI で読み込むために必要
-    "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co",
-    'frame-src https://www.youtube.com',
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    // プラグイン（<object>/<embed>）を全面禁止し、埋め込みベクタを塞ぐ
-    "object-src 'none'",
-  ];
-
-  return directives.join('; ');
+  return buildCspHeaderValue({ isDev, withReporting: true });
 }

--- a/src/lib/security/cspDirectives.mjs
+++ b/src/lib/security/cspDirectives.mjs
@@ -1,0 +1,95 @@
+/**
+ * Content Security Policy (CSP) ディレクティブの単一ソース。
+ *
+ * `next.config.mjs`（Node ESM・TS トランスパイル前）からは TypeScript の
+ * `csp.ts` を直接 import できないため、CSP の定義そのものはプレーン ESM
+ * である本モジュールに集約する。`csp.ts` と `next.config.mjs` の双方が
+ * ここを import することで、値の二重定義（同期漏れ）を防ぐ。
+ *
+ * 方針（段階1 から継続）:
+ * - `script-src` に `'unsafe-inline'` を許容し、静的プリレンダ（nonce 不要）
+ *   を維持する。nonce / strict-dynamic は hydration mismatch を招くため不採用。
+ * - dev のみ `script-src` に `'unsafe-eval'` を付与する（Next.js 開発ツールが
+ *   eval を利用するため）。
+ *
+ * 段階2 で追加:
+ * - CSP 違反を自前収集するため `report-to` / `report-uri` を付与する
+ *   （enforce CSP に付与し、通常運用での違反を監視する）。
+ */
+
+/**
+ * CSP 違反レポートの受信エンドポイント（自前 API Route）。
+ * `report-uri`（後方互換）と `Reporting-Endpoints` の URL に共通で用いる。
+ */
+export const CSP_REPORT_PATH = '/api/csp-report';
+
+/**
+ * `report-to` で参照する Reporting API のエンドポイント名（グループ名）。
+ * `Reporting-Endpoints` ヘッダのキーと一致させること。
+ */
+export const CSP_REPORT_GROUP = 'csp-endpoint';
+
+/**
+ * CSP ディレクティブ配列を生成する。
+ *
+ * @param {object} [options] 生成オプション
+ * @param {boolean} [options.isDev=false] 開発環境かどうか。
+ *   true の場合のみ `script-src` に `'unsafe-eval'` を付与する。
+ * @param {boolean} [options.withReporting=false] 違反レポート用ディレクティブ
+ *   （`report-to` / `report-uri`）を付与するかどうか。
+ * @returns {string[]} CSP ディレクティブの配列（"; " で連結して利用する）
+ */
+export function getCspDirectives({
+  isDev = false,
+  withReporting = false,
+} = {}) {
+  const directives = [
+    "default-src 'self'",
+    // 静的プリレンダを維持するため 'unsafe-inline' を許容する。
+    // dev は Next.js 開発ツールが eval を利用するため 'unsafe-eval' も付与する。
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+    // style-src は Next.js / 各種ライブラリのインラインスタイルに依存するため
+    // 'unsafe-inline' を維持する。
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' https://image.tmdb.org data: blob:",
+    // data: は @fullcalendar/core が内部でアイコンフォント(fcicons)を
+    // base64エンコードした data: URI で読み込むために必要
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co",
+    'frame-src https://www.youtube.com',
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    // プラグイン（<object>/<embed>）を全面禁止し、埋め込みベクタを塞ぐ
+    "object-src 'none'",
+  ];
+
+  if (withReporting) {
+    // report-to は Reporting API（Reporting-Endpoints ヘッダのグループ名を参照）。
+    // report-uri は report-to 未対応ブラウザ向けの後方互換。
+    directives.push(`report-to ${CSP_REPORT_GROUP}`);
+    directives.push(`report-uri ${CSP_REPORT_PATH}`);
+  }
+
+  return directives;
+}
+
+/**
+ * CSP ヘッダ値（1 行文字列）を生成する。
+ *
+ * @param {object} [options] {@link getCspDirectives} と同じオプション
+ * @returns {string} "; " で連結した CSP ヘッダ値
+ */
+export function buildCspHeaderValue(options) {
+  return getCspDirectives(options).join('; ');
+}
+
+/**
+ * `Reporting-Endpoints` ヘッダ値を生成する。
+ * report-to のグループ名（{@link CSP_REPORT_GROUP}）と受信 URL を対応づける。
+ *
+ * @returns {string} 例: `csp-endpoint="/api/csp-report"`
+ */
+export function buildReportingEndpointsValue() {
+  return `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"`;
+}

--- a/src/lib/security/cspDirectives.test.ts
+++ b/src/lib/security/cspDirectives.test.ts
@@ -1,0 +1,78 @@
+/**
+ * CSP ディレクティブ共有モジュール（単一ソース）のテスト
+ */
+
+import {
+  CSP_REPORT_GROUP,
+  CSP_REPORT_PATH,
+  buildCspHeaderValue,
+  buildReportingEndpointsValue,
+  getCspDirectives,
+} from './cspDirectives.mjs';
+
+describe('getCspDirectives', () => {
+  it('デフォルト（引数なし）は本番相当・レポートなし', () => {
+    const directives = getCspDirectives();
+    const scriptSrc = directives.find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toBe("script-src 'self' 'unsafe-inline'");
+    expect(directives.some((d) => d.startsWith('report-to'))).toBe(false);
+    expect(directives.some((d) => d.startsWith('report-uri'))).toBe(false);
+  });
+
+  it("isDev=true で script-src に 'unsafe-eval' を付与する", () => {
+    const directives = getCspDirectives({ isDev: true });
+    const scriptSrc = directives.find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toBe("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
+  });
+
+  it("isDev=false で 'unsafe-eval' を付与しない", () => {
+    const directives = getCspDirectives({ isDev: false });
+    const scriptSrc = directives.find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+  });
+
+  it('withReporting=true で report-to / report-uri を末尾に付与する', () => {
+    const directives = getCspDirectives({ withReporting: true });
+    expect(directives).toContain(`report-to ${CSP_REPORT_GROUP}`);
+    expect(directives).toContain(`report-uri ${CSP_REPORT_PATH}`);
+  });
+
+  it('既存の主要ディレクティブを維持する', () => {
+    const directives = getCspDirectives();
+    expect(directives).toContain("default-src 'self'");
+    expect(directives).toContain("style-src 'self' 'unsafe-inline'");
+    expect(directives).toContain(
+      "img-src 'self' https://image.tmdb.org data: blob:",
+    );
+    expect(directives).toContain("font-src 'self' data:");
+    expect(directives).toContain("connect-src 'self' https://*.supabase.co");
+    expect(directives).toContain('frame-src https://www.youtube.com');
+    expect(directives).toContain("frame-ancestors 'none'");
+    expect(directives).toContain("base-uri 'self'");
+    expect(directives).toContain("form-action 'self'");
+    expect(directives).toContain("object-src 'none'");
+  });
+});
+
+describe('buildCspHeaderValue', () => {
+  it('ディレクティブを "; " で 1 行連結する', () => {
+    const header = buildCspHeaderValue({ isDev: false, withReporting: true });
+    expect(header).not.toContain('\n');
+    expect(header).toContain("default-src 'self'; ");
+    expect(header).toContain('report-uri /api/csp-report');
+  });
+
+  it('引数なしでも動作する（デフォルト適用）', () => {
+    const header = buildCspHeaderValue();
+    expect(header).toContain("default-src 'self'");
+    expect(header).not.toContain('report-to');
+  });
+});
+
+describe('buildReportingEndpointsValue', () => {
+  it('report-to グループ名と受信 URL を対応づける', () => {
+    expect(buildReportingEndpointsValue()).toBe(
+      `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"`,
+    );
+  });
+});


### PR DESCRIPTION
## 概要

CSP 対応の**段階2**。段階1（`unsafe-inline` 許容＋静的維持）の上に、(1) CSP 値の**単一ソース化**、(2) CSP 違反レポートの**自前収集**を追加します。

## ロードマップ

該当なし（CSP 多層防御の段階的強化・段階2）

## レビューポイント

- **単一ソース化**: `src/lib/security/cspDirectives.mjs`（プレーン ESM）に CSP ディレクティブ定義を集約。`next.config.mjs`（Node ESM・TS を直接 import 不可）と `csp.ts` の**双方から import** して二重定義・同期ズレを解消（`getCspDirectives`/`buildCspHeaderValue`/`buildReportingEndpointsValue`、dev/prod と reporting をオプション化）。`csp.ts` は薄いラッパに。
- **`/api/csp-report`**（`src/app/api/csp-report/route.ts`, POST・認証不要）: `application/csp-report`（report-uri 形式）と `application/reports+json`（Reporting API 形式）の両対応、`violated-directive`/`blocked-uri` 等を構造化ログ。**本文 16KB 上限**（Content-Length と実長で二重チェック、不正 Content-Length も破棄）、**不正/空/超過でも常に 204**（best-effort）。
- **CSP ヘッダ**: enforce CSP に `report-to csp-endpoint` ＋互換の `report-uri /api/csp-report`、全パスに `Reporting-Endpoints: csp-endpoint="/api/csp-report"`。段階1 の `unsafe-inline` 許容・静的維持はそのまま。
- ⚠️ **既知の残課題**: `/api/csp-report` にレート制限が未実装（api-route ルール／OWASP API4）。別 Issue 化して対応予定。

## テスト

- `npm run build` 成功、**静的ページ維持**（公開ページは `○ Static` のまま）。
- `npx jest` 全 **2330 テスト pass**、新規/変更ファイル（`route.ts`/`cspDirectives.mjs`/`csp.ts`）**カバレッジ 100%**。`tsc`/`lint`/`prettier` pass。
- 追加テスト: `cspDirectives.test.ts`、`csp.test.ts`（report-to/report-uri）、`csp-report/route.test.ts`（両形式受信/不正JSON/空/上限超過/NaN/未知形状）。
- hydration 0・CSP 違反 0 は agent が chrome-devtools 隔離コンテキストで、コーディネーターが既存 `default` セッションでそれぞれ確認。ライブなヘッダ/実違反の最終確認は **CI の E2E** に委ねる。
- `architecture.md` の CSP 節を現行仕様に更新。
