### PR TITLE
feat(security): 段階3 Trusted TypesをReport-Onlyで導入（DOM XSS補完）

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ import withBundleAnalyzer from '@next/bundle-analyzer';
 import {
   buildCspHeaderValue,
   buildReportingEndpointsValue,
+  buildTrustedTypesReportOnlyHeaderValue,
 } from './src/lib/security/cspDirectives.mjs';
 
 const withAnalyzer = withBundleAnalyzer({
@@ -25,6 +26,15 @@ const cspHeaderValue = buildCspHeaderValue({ isDev, withReporting: true });
 
 // Reporting API のエンドポイント定義。CSP の report-to グループ名と対応させる。
 const reportingEndpointsValue = buildReportingEndpointsValue();
+
+/**
+ * Trusted Types 導入の Report-Only CSP（段階3）。
+ * enforce CSP（unsafe-inline）はそのまま維持しつつ、別ヘッダで
+ * `require-trusted-types-for 'script'` / `trusted-types <policy>` を Report-Only
+ * 配信する。違反はブロックされず /api/csp-report に収集され、DOM-based XSS の
+ * sink を安全に洗い出す。enforce への昇格は段階4 で行う。
+ */
+const trustedTypesReportOnlyValue = buildTrustedTypesReportOnlyHeaderValue();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -110,6 +120,12 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value: cspHeaderValue,
+          },
+          // 段階3: Trusted Types を Report-Only で導入する。enforce CSP とは
+          // 別ヘッダのため既存機能は壊れず、違反は /api/csp-report に収集される。
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: trustedTypesReportOnlyValue,
           },
           // report-to（CSP）が参照する Reporting API のエンドポイント定義。
           // 違反レポートは /api/csp-report が受信する。

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.4.12",
         "ical.js": "^2.2.1",
         "next": "^16.2.6",
         "next-auth": "^5.0.0-beta.30",
@@ -4390,6 +4391,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
@@ -6202,6 +6210,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bcryptjs": "^3.0.3",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.12",
     "ical.js": "^2.2.1",
     "next": "^16.2.6",
     "next-auth": "^5.0.0-beta.30",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,16 @@ export default function RootLayout({
       <head>
         {/* ストレージキーは STORAGE_KEYS.THEME ('movie-app:theme') と同期すること */}
         {/* CSP は script-src 'unsafe-inline' を許容するため nonce は付与しない */}
+        {/*
+          Trusted Types（段階3, Report-Only）について:
+          この <script> は SSR で静的にドキュメントへ埋め込まれる「インラインスクリプト」であり、
+          DOM 注入 sink（innerHTML / script.text 代入 / eval 等）ではない。よって
+          `require-trusted-types-for 'script'` の対象外で、Report-Only でも enforce でも
+          違反にならない（挙動は script-src 'unsafe-inline' 側で許可される）。
+          そのため named ポリシー経由へ書き換える必要はなく、固定文字列のまま維持する。
+          ランタイム注入が必要になった場合に備えたポリシーは
+          src/lib/security/trustedTypes.ts（theme-init）に用意している。
+        */}
         <script
           dangerouslySetInnerHTML={{
             __html:

--- a/src/lib/security/cspDirectives.mjs
+++ b/src/lib/security/cspDirectives.mjs
@@ -15,6 +15,14 @@
  * 段階2 で追加:
  * - CSP 違反を自前収集するため `report-to` / `report-uri` を付与する
  *   （enforce CSP に付与し、通常運用での違反を監視する）。
+ *
+ * 段階3 で追加:
+ * - DOM-based XSS を型レベルで封じるため Trusted Types を導入する。まずは
+ *   `Content-Security-Policy-Report-Only` に `require-trusted-types-for 'script'`
+ *   と `trusted-types <policy>` を付与し、違反を `/api/csp-report` に収集する
+ *   （enforce CSP＝unsafe-inline はそのまま維持し、既存機能を壊さない）。
+ * - Report-Only 段階で違反が出ないことを確認してから、段階4 で enforce CSP へ
+ *   `require-trusted-types-for 'script'` を昇格させる。
  */
 
 /**
@@ -28,6 +36,26 @@ export const CSP_REPORT_PATH = '/api/csp-report';
  * `Reporting-Endpoints` ヘッダのキーと一致させること。
  */
 export const CSP_REPORT_GROUP = 'csp-endpoint';
+
+/**
+ * Trusted Types のポリシー名（許可リスト）。
+ * `trusted-types` ディレクティブに列挙する名前と、クライアント側で
+ * `trustedTypes.createPolicy(...)` に渡す名前を一致させるため単一ソース化する。
+ *
+ * - `sanitize-html`: DOMPurify で sanitize する汎用 HTML ポリシー（アプリ用）。
+ * - `theme-init`: `layout.tsx` のテーマ初期化インラインスクリプト（固定文字列）を
+ *   enforce 昇格後も動作させるための named ポリシー。
+ * - `dompurify`: DOMPurify が内部で生成し得るデフォルトポリシー名。明示的に
+ *   許可リストへ含めておく（内部ポリシー利用時に enforce でブロックされないため）。
+ * - `nextjs`: Next.js（App Router のスクリプト注入等）が利用し得るポリシー名。
+ *   Report-Only 段階で違反を観測し、enforce 昇格時の許可要否を判断する。
+ */
+export const TRUSTED_TYPES_POLICIES = Object.freeze([
+  'sanitize-html',
+  'theme-init',
+  'dompurify',
+  'nextjs',
+]);
 
 /**
  * CSP ディレクティブ配列を生成する。
@@ -92,4 +120,38 @@ export function buildCspHeaderValue(options) {
  */
 export function buildReportingEndpointsValue() {
   return `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"`;
+}
+
+/**
+ * Trusted Types 用の Report-Only CSP ディレクティブ配列を生成する（段階3）。
+ *
+ * enforce CSP（{@link getCspDirectives}）とは独立した
+ * `Content-Security-Policy-Report-Only` ヘッダに載せる。Report-Only なので
+ * 違反はブロックされず `/api/csp-report` に収集されるのみ。これにより
+ * `unsafe-inline` を維持したまま DOM-based XSS の sink を安全に洗い出せる。
+ *
+ * - `require-trusted-types-for 'script'`: DOM sink（innerHTML 等）へ生文字列を
+ *   渡す操作を TrustedHTML 必須にする。
+ * - `trusted-types <policy...>`: 許可するポリシー名の列挙。
+ *   ここに無い名前で `createPolicy` すると（enforce 時に）失敗する。
+ * - `report-to` / `report-uri`: 違反を既存の収集エンドポイントへ送る。
+ *
+ * @returns {string[]} Report-Only CSP ディレクティブの配列
+ */
+export function getTrustedTypesReportOnlyDirectives() {
+  return [
+    "require-trusted-types-for 'script'",
+    `trusted-types ${TRUSTED_TYPES_POLICIES.join(' ')}`,
+    `report-to ${CSP_REPORT_GROUP}`,
+    `report-uri ${CSP_REPORT_PATH}`,
+  ];
+}
+
+/**
+ * Trusted Types 用の Report-Only CSP ヘッダ値（1 行文字列）を生成する。
+ *
+ * @returns {string} `Content-Security-Policy-Report-Only` に設定する値
+ */
+export function buildTrustedTypesReportOnlyHeaderValue() {
+  return getTrustedTypesReportOnlyDirectives().join('; ');
 }

--- a/src/lib/security/cspDirectives.test.ts
+++ b/src/lib/security/cspDirectives.test.ts
@@ -5,9 +5,12 @@
 import {
   CSP_REPORT_GROUP,
   CSP_REPORT_PATH,
+  TRUSTED_TYPES_POLICIES,
   buildCspHeaderValue,
   buildReportingEndpointsValue,
+  buildTrustedTypesReportOnlyHeaderValue,
   getCspDirectives,
+  getTrustedTypesReportOnlyDirectives,
 } from './cspDirectives.mjs';
 
 describe('getCspDirectives', () => {
@@ -74,5 +77,59 @@ describe('buildReportingEndpointsValue', () => {
     expect(buildReportingEndpointsValue()).toBe(
       `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"`,
     );
+  });
+});
+
+describe('TRUSTED_TYPES_POLICIES', () => {
+  it('sanitize-html / theme-init を許可リストに含む', () => {
+    expect(TRUSTED_TYPES_POLICIES).toContain('sanitize-html');
+    expect(TRUSTED_TYPES_POLICIES).toContain('theme-init');
+  });
+
+  it('DOMPurify / Next.js の内部ポリシー名も許可する', () => {
+    expect(TRUSTED_TYPES_POLICIES).toContain('dompurify');
+    expect(TRUSTED_TYPES_POLICIES).toContain('nextjs');
+  });
+
+  it('凍結（不変）されている', () => {
+    expect(Object.isFrozen(TRUSTED_TYPES_POLICIES)).toBe(true);
+  });
+});
+
+describe('getTrustedTypesReportOnlyDirectives（段階3）', () => {
+  const directives = getTrustedTypesReportOnlyDirectives();
+
+  it("require-trusted-types-for 'script' を含む", () => {
+    expect(directives).toContain("require-trusted-types-for 'script'");
+  });
+
+  it('trusted-types に許可ポリシー名を列挙する', () => {
+    expect(directives).toContain(
+      `trusted-types ${TRUSTED_TYPES_POLICIES.join(' ')}`,
+    );
+  });
+
+  it('既存の /api/csp-report へ違反を送る（report-to / report-uri）', () => {
+    expect(directives).toContain(`report-to ${CSP_REPORT_GROUP}`);
+    expect(directives).toContain(`report-uri ${CSP_REPORT_PATH}`);
+  });
+
+  it('enforce CSP には trusted-types 系を混ぜない（Report-Only 専用）', () => {
+    const enforce = getCspDirectives({ withReporting: true });
+    expect(enforce.some((d) => d.startsWith('require-trusted-types-for'))).toBe(
+      false,
+    );
+    expect(enforce.some((d) => d.startsWith('trusted-types'))).toBe(false);
+  });
+});
+
+describe('buildTrustedTypesReportOnlyHeaderValue（段階3）', () => {
+  const header = buildTrustedTypesReportOnlyHeaderValue();
+
+  it('ディレクティブを "; " で 1 行連結する', () => {
+    expect(header).not.toContain('\n');
+    expect(header).toContain("require-trusted-types-for 'script'; ");
+    expect(header).toContain('trusted-types sanitize-html');
+    expect(header).toContain('report-uri /api/csp-report');
   });
 });

--- a/src/lib/security/trustedTypes.test.ts
+++ b/src/lib/security/trustedTypes.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Trusted Types ポリシー（段階3）のテスト
+ *
+ * jsdom には `window.trustedTypes` が無いため、対応環境の挙動は
+ * `createPolicy` をモックした factory を注入して検証する。非対応環境は
+ * `window.trustedTypes` が undefined のまま（既定）で検証する。
+ *
+ * モジュール内でポリシーをキャッシュするため、各テストで
+ * `jest.resetModules()` + 動的 import して状態をリセットする。
+ */
+
+/** 元の window.trustedTypes を退避し、各テスト後に復元する。 */
+const originalTrustedTypes = (window as unknown as { trustedTypes?: unknown })
+  .trustedTypes;
+
+afterEach(() => {
+  if (originalTrustedTypes === undefined) {
+    delete (window as unknown as { trustedTypes?: unknown }).trustedTypes;
+  } else {
+    (window as unknown as { trustedTypes?: unknown }).trustedTypes =
+      originalTrustedTypes;
+  }
+  jest.resetModules();
+});
+
+/**
+ * createPolicy を記録するモック factory を window に注入する。
+ * ポリシーは createHTML / createScript ともに恒等関数（値を検証しやすくする）。
+ */
+function installTrustedTypesMock(): { createPolicy: jest.Mock } {
+  const createPolicy = jest.fn(
+    (
+      name: string,
+      options: {
+        createHTML?: (s: string) => string;
+        createScript?: (s: string) => string;
+      },
+    ) => ({
+      name,
+      createHTML: (input: string) => options.createHTML?.(input) ?? input,
+      createScript: (input: string) => options.createScript?.(input) ?? input,
+    }),
+  );
+  (window as unknown as { trustedTypes?: unknown }).trustedTypes = {
+    createPolicy,
+  };
+  return { createPolicy };
+}
+
+function removeTrustedTypes(): void {
+  delete (window as unknown as { trustedTypes?: unknown }).trustedTypes;
+}
+
+describe('ポリシー名の単一ソース整合性', () => {
+  it('公開する名前が CSP 許可リスト（TRUSTED_TYPES_POLICIES）に含まれる', async () => {
+    const mod = await import('./trustedTypes');
+    const { TRUSTED_TYPES_POLICIES } = await import('./cspDirectives.mjs');
+    expect(TRUSTED_TYPES_POLICIES).toContain(mod.SANITIZE_HTML_POLICY_NAME);
+    expect(TRUSTED_TYPES_POLICIES).toContain(mod.THEME_INIT_POLICY_NAME);
+  });
+});
+
+describe('isTrustedTypesSupported', () => {
+  it('window.trustedTypes.createPolicy があれば true', async () => {
+    installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    expect(mod.isTrustedTypesSupported()).toBe(true);
+  });
+
+  it('window.trustedTypes が無ければ false', async () => {
+    removeTrustedTypes();
+    const mod = await import('./trustedTypes');
+    expect(mod.isTrustedTypesSupported()).toBe(false);
+  });
+});
+
+describe('getSanitizeHtmlPolicy', () => {
+  it('対応環境では sanitize-html ポリシーを生成する', async () => {
+    const { createPolicy } = installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    const policy = mod.getSanitizeHtmlPolicy();
+    expect(policy).not.toBeNull();
+    expect(createPolicy).toHaveBeenCalledWith(
+      'sanitize-html',
+      expect.objectContaining({ createHTML: expect.any(Function) }),
+    );
+  });
+
+  it('同一ポリシーをキャッシュして再生成しない', async () => {
+    const { createPolicy } = installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    mod.getSanitizeHtmlPolicy();
+    mod.getSanitizeHtmlPolicy();
+    expect(createPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it('非対応環境では null を返す', async () => {
+    removeTrustedTypes();
+    const mod = await import('./trustedTypes');
+    expect(mod.getSanitizeHtmlPolicy()).toBeNull();
+  });
+
+  it('createHTML は DOMPurify でサニタイズする（危険なタグを除去）', async () => {
+    installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    const policy = mod.getSanitizeHtmlPolicy();
+    const result = policy!.createHTML(
+      '<img src=x onerror=alert(1)><b>ok</b>',
+    ) as unknown as string;
+    expect(result).toContain('<b>ok</b>');
+    expect(result).not.toContain('onerror');
+  });
+});
+
+describe('sanitizeHtml', () => {
+  it('対応環境ではポリシー経由でサニタイズした値を返す', async () => {
+    installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    const result = mod.sanitizeHtml(
+      '<script>alert(1)</script><p>hi</p>',
+    ) as unknown as string;
+    expect(result).toContain('<p>hi</p>');
+    expect(result).not.toContain('<script>');
+  });
+
+  it('非対応環境でも DOMPurify でサニタイズした文字列を返す', async () => {
+    removeTrustedTypes();
+    const mod = await import('./trustedTypes');
+    const result = mod.sanitizeHtml(
+      '<a href="javascript:alert(1)">x</a><span>safe</span>',
+    ) as unknown as string;
+    expect(result).toContain('<span>safe</span>');
+    expect(result).not.toContain('javascript:');
+  });
+});
+
+describe('getThemeInitPolicy', () => {
+  it('対応環境では theme-init ポリシーを生成する', async () => {
+    const { createPolicy } = installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    const policy = mod.getThemeInitPolicy();
+    expect(policy).not.toBeNull();
+    expect(createPolicy).toHaveBeenCalledWith(
+      'theme-init',
+      expect.objectContaining({ createScript: expect.any(Function) }),
+    );
+  });
+
+  it('createScript は入力をそのまま返す（固定スクリプト用）', async () => {
+    installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    const policy = mod.getThemeInitPolicy();
+    const script = '(function(){})()';
+    expect(policy!.createScript(script) as unknown as string).toBe(script);
+  });
+
+  it('キャッシュして再生成しない', async () => {
+    const { createPolicy } = installTrustedTypesMock();
+    const mod = await import('./trustedTypes');
+    mod.getThemeInitPolicy();
+    mod.getThemeInitPolicy();
+    expect(createPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it('非対応環境では null を返す', async () => {
+    removeTrustedTypes();
+    const mod = await import('./trustedTypes');
+    expect(mod.getThemeInitPolicy()).toBeNull();
+  });
+});

--- a/src/lib/security/trustedTypes.ts
+++ b/src/lib/security/trustedTypes.ts
@@ -1,0 +1,155 @@
+/**
+ * Trusted Types ポリシー（段階3）
+ *
+ * `unsafe-inline` 許容の弱点である DOM-based XSS を型レベルで封じるため、
+ * Trusted Types のポリシーを定義する。DOM sink（`innerHTML` /
+ * `dangerouslySetInnerHTML` など）へは、これらのポリシーが生成した
+ * `TrustedHTML` / `TrustedScript` のみを渡すようにする。
+ *
+ * 段階3 は `Content-Security-Policy-Report-Only` での導入のため、ポリシー未使用の
+ * 生文字列 sink があっても「ブロックされず」`/api/csp-report` に収集されるだけ。
+ * 段階4（enforce）を見据え、既知の sink はここで生成したポリシー経由へ移行する。
+ *
+ * ブラウザ未対応（`window.trustedTypes` が無い）環境や SSR ではポリシーを
+ * 生成できないため、feature-test でグレースフルにフォールバックする
+ * （その場合はサニタイズ結果の文字列をそのまま返す）。
+ */
+
+import DOMPurify from 'dompurify';
+
+import { TRUSTED_TYPES_POLICIES } from './cspDirectives.mjs';
+
+/**
+ * `createPolicy` の戻り値型。`@types/trusted-types` は渡した options のキーだけを
+ * 持つ `Pick<...>` を返すため、`createHTML` のみ / `createScript` のみのポリシーを
+ * それぞれ表現する（グローバルの `TrustedTypePolicy` は全メソッド必須で不一致になる）。
+ */
+type HtmlPolicy = Pick<TrustedTypePolicy, 'name' | 'createHTML'>;
+type ScriptPolicy = Pick<TrustedTypePolicy, 'name' | 'createScript'>;
+
+/**
+ * `trusted-types` 許可リストと一致させるポリシー名。
+ *
+ * CSP 側の許可リスト（`cspDirectives.mjs` の {@link TRUSTED_TYPES_POLICIES}）を
+ * 単一ソースとし、そこから取り出すことで手動同期の乖離を防ぐ。許可リストに
+ * 名前が無い状態で `createPolicy` すると enforce 昇格時にポリシー生成が失敗する
+ * ため、存在しなければ即座に失敗させる。
+ *
+ * @param name 許可リストに含まれているべきポリシー名
+ * @returns 許可リストで検証済みのポリシー名
+ */
+function requireAllowedPolicyName(name: string): string {
+  if (!TRUSTED_TYPES_POLICIES.includes(name)) {
+    throw new Error(
+      `Trusted Types policy "${name}" is not in TRUSTED_TYPES_POLICIES (cspDirectives.mjs). ` +
+        'CSP の trusted-types 許可リストへ追加すること。',
+    );
+  }
+  return name;
+}
+
+export const SANITIZE_HTML_POLICY_NAME =
+  requireAllowedPolicyName('sanitize-html');
+export const THEME_INIT_POLICY_NAME = requireAllowedPolicyName('theme-init');
+
+/**
+ * ブラウザが Trusted Types に対応しているか（＝`createPolicy` が使えるか）を
+ * feature-test する。SSR（`window` 無し）や非対応ブラウザでは false。
+ */
+export function isTrustedTypesSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.trustedTypes !== 'undefined' &&
+    typeof window.trustedTypes.createPolicy === 'function'
+  );
+}
+
+/**
+ * 生成済みの sanitize-html ポリシー（多重生成を避けるためモジュール内でキャッシュ）。
+ * 同名ポリシーの再生成は enforce 時に例外となるため、必ず使い回す。
+ */
+let cachedSanitizePolicy: HtmlPolicy | null = null;
+
+/**
+ * DOMPurify を裏に持つ `sanitize-html` Trusted Types ポリシーを取得する。
+ *
+ * `createHTML` は「通常の文字列」を返す必要があるため、DOMPurify は
+ * `RETURN_TRUSTED_TYPE: false` で呼ぶ（内部で TrustedHTML を作らせない）。
+ * また DOMPurify 独自の内部ポリシー（`dompurify`）を無効化することで、
+ * 本ポリシーとの二重ラップ・無限再帰を避ける（`TRUSTED_TYPES_POLICY: null`）。
+ *
+ * 非対応環境では null を返す（呼び出し側は {@link sanitizeHtml} を使う）。
+ */
+export function getSanitizeHtmlPolicy(): HtmlPolicy | null {
+  if (!isTrustedTypesSupported()) {
+    return null;
+  }
+  if (cachedSanitizePolicy) {
+    return cachedSanitizePolicy;
+  }
+  cachedSanitizePolicy = window.trustedTypes!.createPolicy(
+    SANITIZE_HTML_POLICY_NAME,
+    {
+      createHTML: (input: string): string =>
+        DOMPurify.sanitize(input, {
+          RETURN_TRUSTED_TYPE: false,
+          TRUSTED_TYPES_POLICY: null,
+        }) as unknown as string,
+    },
+  );
+  return cachedSanitizePolicy;
+}
+
+/**
+ * 任意の HTML 文字列をサニタイズして sink へ安全に渡せる値を返す。
+ *
+ * - Trusted Types 対応環境: `sanitize-html` ポリシーで `TrustedHTML` を返す
+ *   （enforce 時でも `innerHTML` へ代入できる）。
+ * - 非対応環境 / SSR: DOMPurify でサニタイズした文字列を返す（型は string）。
+ *
+ * 戻り値は `innerHTML` / `dangerouslySetInnerHTML.__html` にそのまま渡せる。
+ *
+ * @param dirty サニタイズ対象の生 HTML 文字列
+ * @returns TrustedHTML（対応時）またはサニタイズ済み文字列（非対応時）
+ */
+export function sanitizeHtml(dirty: string): TrustedHTML | string {
+  const policy = getSanitizeHtmlPolicy();
+  if (policy) {
+    return policy.createHTML(dirty);
+  }
+  // 非対応環境でも DOM-based XSS を防ぐため、必ずサニタイズして返す。
+  return DOMPurify.sanitize(dirty, {
+    RETURN_TRUSTED_TYPE: false,
+    TRUSTED_TYPES_POLICY: null,
+  }) as unknown as string;
+}
+
+/**
+ * 生成済みの theme-init ポリシー（同上、モジュール内キャッシュ）。
+ */
+let cachedThemeInitPolicy: ScriptPolicy | null = null;
+
+/**
+ * テーマ初期化の固定インラインスクリプト（`layout.tsx`）を enforce 昇格後も
+ * 動作させるための named ポリシー。入力は固定文字列のみを想定しており、
+ * `createScript` はそのまま返す（外部入力を混ぜないこと）。
+ *
+ * 非対応環境では null を返す（この場合フォールバックは呼び出し側で不要＝
+ * Report-Only 段階では素の文字列がそのまま実行される）。
+ */
+export function getThemeInitPolicy(): ScriptPolicy | null {
+  if (!isTrustedTypesSupported()) {
+    return null;
+  }
+  if (cachedThemeInitPolicy) {
+    return cachedThemeInitPolicy;
+  }
+  cachedThemeInitPolicy = window.trustedTypes!.createPolicy(
+    THEME_INIT_POLICY_NAME,
+    {
+      // 入力は固定スクリプト文字列のみ。外部入力は渡さない前提で恒等関数とする。
+      createScript: (input: string): string => input,
+    },
+  );
+  return cachedThemeInitPolicy;
+}


### PR DESCRIPTION
## 概要

CSP 対応の**段階3**。`unsafe-inline` 許容の弱点である **DOM-based XSS を Trusted Types で型レベルに封じる**補完を、まず **Report-Only** で導入します（enforce は段階4）。

## ロードマップ

該当なし（CSP 多層防御の段階的強化・段階3）

## レビューポイント

- **DOMPurify＋Trusted Types**: `dompurify@3.4.12`（v3 は型同梱）。`src/lib/security/trustedTypes.ts` に `sanitize-html` ポリシー（`createHTML` で `DOMPurify.sanitize`、`RETURN_TRUSTED_TYPE:false`＋`TRUSTED_TYPES_POLICY:null` で二重ラップ/無限再帰を回避）、`theme-init` ポリシー、`isTrustedTypesSupported()` の feature-test ＋未対応/SSR フォールバック、ポリシーのキャッシュ。
- **sink 対応**: プロジェクトの DOM sink は `layout.tsx` のテーマ初期化スクリプト 1 箇所のみ。これは **SSR で静的に埋め込むインラインスクリプトで DOM 注入 sink ではない**ため `require-trusted-types-for 'script'` の対象外（Report-Only/enforce いずれでも違反にならない）。理由をコメント明記。
- **Report-Only ヘッダ**: `cspDirectives.mjs`（単一ソース）に追加し `next.config.mjs` から配信。`Content-Security-Policy-Report-Only: require-trusted-types-for 'script'; trusted-types sanitize-html theme-init dompurify nextjs; report-to csp-endpoint; report-uri /api/csp-report`。**enforce CSP（unsafe-inline）・静的維持はそのまま**。違反は既存 `/api/csp-report` が受信。
- ポリシー名は `TRUSTED_TYPES_POLICIES` を単一ソース化し、`trustedTypes.ts` が import して検証（許可外は throw）＋整合性テスト。

## テスト

- `npm run build` 成功、**静的プリレンダ維持**（Report-Only 追加で動的化なし）。`tsc`/`eslint`/`prettier`/`jest`（**2351 tests pass**、security 新規 38 tests・カバレッジ 96-100%）すべて pass。
- hydration / CSP / Trusted Types 違反 0 を、agent は独立コンテキストで、コーディネーターは既存 `default` セッションで確認。実 Trusted Types 違反のライブ確認は **CI の E2E** に委ねる。
- **Report-Only のため既存機能は壊れない**設計（テーマ切替等）。

## 段階4（enforce）へ

本番で Report-Only の違反を `/api/csp-report` で監視 → 想定外 sink や不要ポリシーが無いことを確認後、`require-trusted-types-for`/`trusted-types` を enforce CSP へ昇格（別 PR）。
