### PR TITLE
fix(recommendations): LLMの件数オーバーシュートで生成が丸ごと失敗する不具合を修正

### DIFF
--- a/src/lib/openai/generateRecommendations.test.ts
+++ b/src/lib/openai/generateRecommendations.test.ts
@@ -6,6 +6,10 @@
  * レコメンド生成ロジック テスト
  */
 
+import {
+  RECOMMENDATIONS_GENERATION_BUFFER,
+  RECOMMENDATIONS_MAX_COUNT,
+} from '@/constants';
 import type { OpenAiRecommendationItem } from '@/schema/recommendations';
 
 // --- Mocks ---
@@ -28,6 +32,10 @@ import {
   fetchRecommendationsFromOpenAI,
   resolveRecommendationsWithTMDb,
 } from './generateRecommendations';
+
+/** AIレスポンスとして保持される最大件数（最大表示件数＋取りこぼし用バッファ） */
+const MAX_RESPONSE_COUNT =
+  RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER;
 
 // --- Tests ---
 
@@ -205,6 +213,31 @@ describe('fetchRecommendationsFromOpenAI', () => {
 
     const systemMessage = mockCreate.mock.calls[0][0].messages[0];
     expect(systemMessage.content).toContain('3件推薦');
+  });
+
+  it('OpenAIが上限を超える件数を返しても、nullにせず上限件数に切り詰めて返す', async () => {
+    // LLMは要求件数を厳密に守らず超過して返すことがある。
+    // 以前は上限超過でzod検証に失敗しnullを返し、cronが丸ごと失敗していた。
+    const overCount = MAX_RESPONSE_COUNT + 1;
+    const mockResponse = {
+      recommendations: Array.from({ length: overCount }, (_, i) => ({
+        title: `Movie ${i + 1}`,
+        year: 2020,
+        reason: `理由${i + 1}`,
+      })),
+    };
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify(mockResponse) } }],
+    });
+
+    const result = await fetchRecommendationsFromOpenAI(
+      [{ title: 'テスト', rating: 5 }],
+      [],
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(MAX_RESPONSE_COUNT);
+    expect(result![0].title).toBe('Movie 1');
   });
 });
 

--- a/src/schema/recommendations.test.ts
+++ b/src/schema/recommendations.test.ts
@@ -138,6 +138,9 @@ describe('openAiRecommendationsResponseSchema', () => {
       recommendations: items,
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.recommendations).toHaveLength(MAX_RESPONSE_COUNT);
+    }
   });
 
   it('空配列の場合エラーになる', () => {
@@ -147,7 +150,7 @@ describe('openAiRecommendationsResponseSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('上限（最大件数＋バッファ）を超える場合エラーになる', () => {
+  it('上限（最大件数＋バッファ）を超える場合は弾かず上限件数に切り詰める', () => {
     const items = Array.from({ length: MAX_RESPONSE_COUNT + 1 }, (_, i) => ({
       ...validItem,
       title: `映画${i + 1}`,
@@ -155,7 +158,28 @@ describe('openAiRecommendationsResponseSchema', () => {
     const result = openAiRecommendationsResponseSchema.safeParse({
       recommendations: items,
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.recommendations).toHaveLength(MAX_RESPONSE_COUNT);
+    }
+  });
+
+  it('上限を大幅に超える場合も先頭から上限件数のみ残す（順序維持）', () => {
+    const items = Array.from({ length: MAX_RESPONSE_COUNT + 10 }, (_, i) => ({
+      ...validItem,
+      title: `映画${i + 1}`,
+    }));
+    const result = openAiRecommendationsResponseSchema.safeParse({
+      recommendations: items,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.recommendations).toHaveLength(MAX_RESPONSE_COUNT);
+      expect(result.data.recommendations[0].title).toBe('映画1');
+      expect(result.data.recommendations[MAX_RESPONSE_COUNT - 1].title).toBe(
+        `映画${MAX_RESPONSE_COUNT}`,
+      );
+    }
   });
 
   it('recommendationsが未指定の場合エラーになる', () => {

--- a/src/schema/recommendations.ts
+++ b/src/schema/recommendations.ts
@@ -11,8 +11,9 @@ import {
 } from '@/constants';
 
 /**
- * AIに要求しうる最大件数（最大表示件数＋取りこぼし用バッファ）
- * バッファ分多めに要求するため、レスポンス検証の上限もこれに合わせる。
+ * AIレスポンスとして保持する最大件数（最大表示件数＋取りこぼし用バッファ）。
+ * LLMは要求件数を厳密に守らず超過して返すことがあるため、超過分は
+ * バリデーションエラーにせず、この件数まで切り詰める（超過分は破棄）。
  */
 const OPENAI_RECOMMENDATIONS_MAX_RESPONSE =
   RECOMMENDATIONS_MAX_COUNT + RECOMMENDATIONS_GENERATION_BUFFER;
@@ -34,13 +35,17 @@ export const openAiRecommendationItemSchema = z.object({
  * OpenAIレスポンス全体スキーマ
  */
 export const openAiRecommendationsResponseSchema = z.object({
-  recommendations: z
-    .array(openAiRecommendationItemSchema)
-    .min(1, 'レコメンドは1件以上必要です')
-    .max(
-      OPENAI_RECOMMENDATIONS_MAX_RESPONSE,
-      `レコメンドは${OPENAI_RECOMMENDATIONS_MAX_RESPONSE}件以下にしてください`,
-    ),
+  // LLMは要求件数を超えて返すことがある。上限超過を弾かず、かつ全件を検証する
+  // 無駄（巨大配列時のコスト）を避けるため、検証前に上限件数へ切り詰める。
+  recommendations: z.preprocess(
+    (value) =>
+      Array.isArray(value)
+        ? value.slice(0, OPENAI_RECOMMENDATIONS_MAX_RESPONSE)
+        : value,
+    z
+      .array(openAiRecommendationItemSchema)
+      .min(1, 'レコメンドは1件以上必要です'),
+  ),
 });
 
 /**


### PR DESCRIPTION
## 概要

レコメンド生成で OpenAI が要求件数（15件）を超えて返すと、zod の `.max()` でレスポンス全体が reject され、**該当ユーザーのレコメンドが0件になりリトライも打ち切られる**不具合を修正します。下流の `resolveRecommendationsWithTMDb` で件数は既に丸めているため、上限超過はエラーにせず切り詰める方式に変更し、cron（`/api/cron/generate-recommendations`）と手動更新（`/api/recommendations/refresh`）の両経路を救済します。

Closes #434

## ロードマップ

該当なし（本番稼働中のバグ修正）

## レビューポイント

- `src/schema/recommendations.ts`: 配列の `.max()`（reject）を `z.preprocess` による**検証前の切り詰め**に変更。事前スライスにより上限超過を弾かず、かつ巨大配列時に全件検証する無駄も回避（pre-commit AIレビュー指摘に対応）。`.min(1)` は維持（空レスポンスは従来どおりエラー）
- 「上限超過＝エラー」から「上限超過＝切り詰め」へ倒した設計判断（下流で件数制御済みのため機能面の影響なし・堅牢化のみ）

## テスト

- スキーマ単体テスト: 上限超過→切り詰め・順序維持、空配列→エラー維持を追加/更新
- `fetchRecommendationsFromOpenAI` 回帰テスト: 16件返却時に `null` ではなく15件を返すことを検証（本番エラーの直接再現）
- 既存の「上限超過でエラー」テストを新挙動（切り詰め）に更新
- 関連3ファイル **81 件パス** / 型チェック（recommendations 関連）新規エラーなし / eslint 通過
