### PR TITLE
fix(title-suggestion): LLMの件数オーバーシュートで原題候補がゼロになる不具合を修正

### DIFF
--- a/src/constants/titleSuggestion.ts
+++ b/src/constants/titleSuggestion.ts
@@ -24,6 +24,8 @@ export const TITLE_SUGGESTION = {
   STALE_TIME: 24 * 60 * 60 * 1000,
   /** sessionStorageキー: 提案クリック時に提案リストを保持 */
   STORAGE_KEY: 'title_suggestions',
+  /** 原題候補の最大件数（LLMが超過して返した場合は切り詰める） */
+  MAX_SUGGESTIONS: 5,
 } as const;
 
 /**

--- a/src/lib/openai/suggestTitle.test.ts
+++ b/src/lib/openai/suggestTitle.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * 原題提案ロジック テスト
+ */
+
+import { TITLE_SUGGESTION } from '@/constants';
+
+// --- Mocks ---
+
+const mockCreate = jest.fn();
+jest.mock('./client', () => ({
+  createOpenAIClient: jest.fn(() => ({
+    responses: { create: mockCreate },
+  })),
+  getOpenAIModel: jest.fn(() => 'gpt-4o-mini'),
+}));
+
+import { fetchTitleSuggestionsFromOpenAI } from './suggestTitle';
+
+// --- Tests ---
+
+describe('fetchTitleSuggestionsFromOpenAI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('正常なレスポンスをパースして返す', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: JSON.stringify({
+        suggestions: ['The Shawshank Redemption'],
+      }),
+    });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('ショーシャンク');
+
+    expect(result).toEqual(['The Shawshank Redemption']);
+  });
+
+  it('上限を超える候補が返っても、[]にせず先頭MAX件に切り詰めて返す', async () => {
+    // LLMは上限件数を厳密に守らず超過して返すことがある。
+    // 以前は上限超過でzod検証に失敗し[]を返し、候補ゼロになっていた。
+    const over = Array.from(
+      { length: TITLE_SUGGESTION.MAX_SUGGESTIONS + 3 },
+      (_, i) => `Movie ${i + 1}`,
+    );
+    mockCreate.mockResolvedValue({
+      output_text: JSON.stringify({ suggestions: over }),
+    });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toHaveLength(TITLE_SUGGESTION.MAX_SUGGESTIONS);
+    expect(result[0]).toBe('Movie 1');
+  });
+
+  it('空配列レスポンスはそのまま空配列を返す', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: JSON.stringify({ suggestions: [] }),
+    });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('Inception');
+
+    expect(result).toEqual([]);
+  });
+
+  it('プロンプトに上限件数が反映される', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: JSON.stringify({ suggestions: [] }),
+    });
+
+    await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    const instructions = mockCreate.mock.calls[0][0].instructions;
+    expect(instructions).toContain(`上限${TITLE_SUGGESTION.MAX_SUGGESTIONS}件`);
+  });
+
+  it('OpenAIクライアントがnullの場合、[]を返す', async () => {
+    const { createOpenAIClient } = await import('./client');
+    (createOpenAIClient as jest.Mock).mockReturnValueOnce(null);
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toEqual([]);
+  });
+
+  it('output_textが空の場合、[]を返す', async () => {
+    mockCreate.mockResolvedValue({ output_text: '' });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toEqual([]);
+  });
+
+  it('不正なJSONレスポンスの場合、[]を返す', async () => {
+    mockCreate.mockResolvedValue({ output_text: 'not json' });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toEqual([]);
+  });
+
+  it('空文字を含む不正な候補の場合、[]を返す', async () => {
+    mockCreate.mockResolvedValue({
+      output_text: JSON.stringify({ suggestions: [''] }),
+    });
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toEqual([]);
+  });
+
+  it('API呼び出し失敗の場合、[]を返す', async () => {
+    mockCreate.mockRejectedValue(new Error('API error'));
+
+    const result = await fetchTitleSuggestionsFromOpenAI('テスト');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/openai/suggestTitle.ts
+++ b/src/lib/openai/suggestTitle.ts
@@ -2,7 +2,7 @@
  * OpenAI Responses APIを使用した原題提案ロジック（Web検索付き）
  */
 
-import { OPENAI_CONFIG } from '@/constants';
+import { OPENAI_CONFIG, TITLE_SUGGESTION } from '@/constants';
 import { openAiTitleSuggestionsResponseSchema } from '@/schema/titleSuggestion';
 
 import { createOpenAIClient, getOpenAIModel } from './client';
@@ -26,7 +26,7 @@ function buildSystemPrompt(): string {
 - 入力が既に原題（英語）の場合は空配列を返すこと
 - 邦題として正式に知られている映画を最優先で含めること（最新の映画も含む）
 - キーワードから推測できる関連映画も候補に含めること
-- 思いつく候補をすべて返すこと（上限5件）
+- 思いつく候補をすべて返すこと（上限${TITLE_SUGGESTION.MAX_SUGGESTIONS}件）
 - 最も可能性が高い順に並べること
 - 候補は必ず「映画作品」のタイトルに限定すること（ゲーム・テレビ番組・書籍など映画以外の作品は含めない）
 - 映画と全く関連がないと判断できる場合のみ空配列を返すこと

--- a/src/schema/titleSuggestion.test.ts
+++ b/src/schema/titleSuggestion.test.ts
@@ -58,11 +58,24 @@ describe('openAiTitleSuggestionsResponseSchema', () => {
     expect(result.data?.suggestions).toEqual([]);
   });
 
-  it('5件を超える候補を拒否する', () => {
+  it('5件ちょうどはそのまま通る（上限）', () => {
     const result = openAiTitleSuggestionsResponseSchema.safeParse({
-      suggestions: ['a', 'b', 'c', 'd', 'e', 'f'],
+      suggestions: ['a', 'b', 'c', 'd', 'e'],
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.suggestions).toEqual(['a', 'b', 'c', 'd', 'e']);
+    }
+  });
+
+  it('5件を超える候補は拒否せず先頭5件に切り詰める（順序維持）', () => {
+    const result = openAiTitleSuggestionsResponseSchema.safeParse({
+      suggestions: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.suggestions).toEqual(['a', 'b', 'c', 'd', 'e']);
+    }
   });
 
   it('空文字列を含む候補を拒否する', () => {

--- a/src/schema/titleSuggestion.ts
+++ b/src/schema/titleSuggestion.ts
@@ -4,6 +4,8 @@
 
 import { z } from 'zod';
 
+import { TITLE_SUGGESTION } from '@/constants';
+
 /**
  * 原題提案APIクエリパラメータスキーマ
  */
@@ -13,9 +15,19 @@ export const titleSuggestionQuerySchema = z.object({
 
 /**
  * OpenAIレスポンススキーマ（複数候補）
+ *
+ * LLMは上限件数を超えて返すことがある。上限超過を弾かず、検証前に上限件数へ
+ * 切り詰める（超過分は破棄）。原題提案は下流で件数制御しないため slice が実効上限。
+ * 空配列は許容（入力が既に原題／映画と無関係の場合に返る）。
  */
 export const openAiTitleSuggestionsResponseSchema = z.object({
-  suggestions: z.array(z.string().min(1)).max(5),
+  suggestions: z.preprocess(
+    (value) =>
+      Array.isArray(value)
+        ? value.slice(0, TITLE_SUGGESTION.MAX_SUGGESTIONS)
+        : value,
+    z.array(z.string().min(1)),
+  ),
 });
 
 /**


### PR DESCRIPTION
## 概要

原題提案（`fetchTitleSuggestionsFromOpenAI`）で OpenAI が上限（5件）を超えて返すと、zod の `.max(5)` でレスポンス全体が reject され、`safeParse` 失敗時に `[]` を返して**候補ゼロ**になる不具合を修正します。#434 と同一クラスのバグ。上限超過はエラーにせず、検証前に上限件数へ切り詰める方式（`z.preprocess`）に変更します。

Closes #436

## ロードマップ

該当なし（本番稼働中のバグ修正）

## レビューポイント

- `src/schema/titleSuggestion.ts`: `.max(5)`（reject）→ `z.preprocess` で検証前に先頭 5 件へ切り詰め。**空配列は許容のまま**（入力が既に英語／映画と無関係の場合に返る正常値）
- 件数上限を `TITLE_SUGGESTION.MAX_SUGGESTIONS` に**定数化**し、スキーマとプロンプト（`suggestTitle.ts`）で一元管理（drift 防止）
- #435（#434）と同じ切り詰め方針を踏襲

## テスト

- スキーマ単体: 上限ちょうど（5件）→全件、超過（8件）→先頭5件に切り詰め・順序維持
- **`suggestTitle` の fetch 回帰テストを新規作成**（従来テストゼロ）: 8件→`[]`でなく5件、正常系／空配列／null クライアント／空 output／不正 JSON／不正項目／API 失敗／プロンプト件数反映
- title/suggest 関連 **3 スイート 24 件パス**、型チェック新規エラーなし、eslint 通過
