### PR TITLE
fix(security): postcss を ^8.5.10 に override（CVE-2026-41305・Dependabot #76）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10020,9 +10020,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10719,9 +10719,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10738,9 +10738,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "follow-redirects": "^1.16.0",
     "nodemailer": "^8.0.5",
     "flatted": "^3.4.2",
+    "postcss": "^8.5.10",
     "picomatch@<2.3.2": "2.3.2",
     "picomatch@>=4.0.0 <4.0.4": "4.0.4",
     "brace-expansion@1": "1.1.13",


### PR DESCRIPTION
## 概要

Dependabot [#76](https://github.com/Fn-front/movie-app/security/dependabot/76)（postcss の XSS 脆弱性 **CVE-2026-41305 / GHSA-qx2v-qp2m-jg93**, medium / CVSS 6.1）に対応します。`next` が固定する `postcss@8.4.31` を、既存の `overrides` 方針で `^8.5.10` に引き上げます（実解決: **8.5.19**）。マージ後に Dependabot #76 は自動解消されます。

## ロードマップ

該当なし（セキュリティ依存更新）

## レビューポイント

- `package.json` の `overrides` に `"postcss": "^8.5.10"` を **1行追加**（既存の `follow-redirects` / `nodemailer` / `flatted` 等と同じ流儀）
- `package-lock.json` の変更は **postcss（8.4.31→8.5.19）** と、その推移的依存 **nanoid（3.3.11→3.3.16）** の 2 つのみ
- 実影響: postcss は**ビルド時の CSS 処理でのみ**使用。ランタイムでユーザー投稿 CSS を解析して `<style>` に埋め込む処理は無いため、この脆弱性の攻撃条件は満たさず**実行時の攻撃面は限定的**。アラート解消・衛生目的

## テスト

- `npm run build` **成功**（postcss 8.5.19 で Next.js の CSS パイプライン正常動作を確認）
- CI の Next.js Build / TypeScript / ESLint / Jest / E2E で最終検証
