### PR TITLE
docs(database): award_movies に person_name カラムを追記

### DIFF
--- a/.claude/documents/database-schema.md
+++ b/.claude/documents/database-schema.md
@@ -414,6 +414,7 @@ OpenAI APIによるレコメンド映画を管理（日次Cronで全件入れ替
 | release_date | DATE | NULL | - | 公開日 |
 | vote_average | NUMERIC(3,1) | NULL | - | TMDb評価 |
 | genre_ids | INTEGER[] | NULL | - | ジャンルID配列 |
+| person_name | VARCHAR(255) | NULL | - | 人名（監督賞・演技賞などで使用） |
 | award_name | VARCHAR(100) | NOT NULL | - | 賞名キー（academy_awards等） |
 | award_year | INTEGER | NOT NULL | - | 授賞年度 |
 | category | VARCHAR(100) | NOT NULL | - | 部門キー（best_picture等） |


### PR DESCRIPTION
## 概要

`award_movies` テーブルの `person_name` カラムが `.claude/documents/database-schema.md` に未反映だったため追記します（マイグレーション `20260323000000_add_person_name_to_award_movies.sql` で追加済み・API/型では使用済み）。

Closes #306

## ロードマップ

該当なし（ドキュメント整備）

## レビューポイント

- **ドキュメントのみ**の変更（コード変更なし）
- `person_name` を `genre_ids` と `award_name` の間に追記（`awards/route.ts` の `AWARD_MOVIES_SELECT` のカラム順に一致）

## テスト

- ドキュメントのみのため対象外