### PR TITLE
perf(favorites): カウントクエリを select('*') から select('id') に変更

### DIFF
--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -53,10 +53,10 @@ export const GET = withAuth(
 
     const { sort_by, sort_order, page, limit } = queryResult.data;
 
-    // 件数取得
+    // 件数取得（カウントのみのため id 列だけ指定して転送量を削減）
     const { count, error: countError } = await supabase
       .from('favorites')
-      .select('*', { count: 'exact', head: true })
+      .select('id', { count: 'exact', head: true })
       .eq('user_id', session.user.id)
       .is('deleted_at', null);
 


### PR DESCRIPTION
## 概要

`/api/favorites` の件数取得クエリ（`head: true` のカウント専用）で `select('*')` を `select('id')` に変更し、不要なカラム転送を削減します。

Closes #324

## ロードマップ

該当なし（パフォーマンス最適化）

## レビューポイント

- `src/app/api/favorites/route.ts` のカウントクエリのみ変更（`head: true` のため実データは返らないが、列指定を最小化）
- 横断確認: `select('*', { count })` の同種箇所は本ファイルのみで他になし

## テスト

- favorites route テスト **15 件パス**（挙動不変・回帰なし）