### PR TITLE
security(api): /api/csp-report に IP 単位の軽量レート制限を追加（OWASP API4・#431）

### DIFF
--- a/src/app/api/csp-report/route.test.ts
+++ b/src/app/api/csp-report/route.test.ts
@@ -176,4 +176,23 @@ describe('POST /api/csp-report', () => {
     expect(res.status).toBe(204);
     expect(errorSpy).toHaveBeenCalled();
   });
+
+  it('同一IPから大量に送ると上限超過分はログせず破棄する（204維持）', async () => {
+    // このテスト専用のユニークIP（他テストとレート制限状態を共有しない）
+    const ip = '203.0.113.77';
+    const body = JSON.stringify({
+      'csp-report': { 'blocked-uri': 'https://evil.example.com/x.js' },
+    });
+    // 上限（route の RATE_LIMIT_MAX_REQUESTS）より十分多く送る
+    const attempts = 200;
+
+    for (let i = 0; i < attempts; i++) {
+      const res = await POST(makeRequest(body, { 'x-forwarded-for': ip }));
+      expect(res.status).toBe(204);
+    }
+
+    // 上限超過分は破棄されログされないため、warn 回数は試行回数より少ない
+    expect(warnSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(warnSpy.mock.calls.length).toBeLessThan(attempts);
+  });
 });

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -15,6 +15,8 @@
 
 import { NextResponse } from 'next/server';
 
+import { createInMemoryRateLimiter } from '@/lib/rateLimit/inMemoryRateLimit';
+
 /**
  * 受信を許可する本文サイズの上限（バイト）。
  * これを超えるレポートは中身を読まずに破棄する（メモリ枯渇・DoS 対策）。
@@ -23,6 +25,29 @@ const MAX_BODY_BYTES = 16 * 1024; // 16KB
 
 /** 正常受信時のレスポンス（本文不要のため 204）。 */
 const NO_CONTENT = 204;
+
+/**
+ * IP 単位のレート制限（インメモリ）。
+ * CSP レポートは大量に届きうるため、レポート毎に DB 書き込みが発生する
+ * DB-based レート制限は逆効果。プロセス内の軽量スロットリングで濫用・ログ肥大を
+ * 抑止する（サーバーレスではインスタンス単位・コールドスタートでリセットされる
+ * best-effort）。超過分は処理・ログせず 204 のまま黙って破棄する。
+ */
+const RATE_LIMIT_MAX_REQUESTS = 60;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1分
+const rateLimiter = createInMemoryRateLimiter({
+  maxRequests: RATE_LIMIT_MAX_REQUESTS,
+  windowMs: RATE_LIMIT_WINDOW_MS,
+});
+
+/** リクエストからクライアント IP を取得する（取得不可時は 'unknown'）。 */
+function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+  return 'unknown';
+}
 
 /**
  * 単一の CSP 違反レポート本体から、ログに残す主要フィールドを抽出する。
@@ -92,6 +117,12 @@ function logReports(payload: unknown): void {
 
 export async function POST(request: Request): Promise<NextResponse> {
   try {
+    // レート制限（超過分は処理・ログせず破棄）。CSP レポートは大量に届きうるため
+    // インメモリで軽量にスロットリングする（best-effort）。204 を維持する。
+    if (!rateLimiter.check(getClientIp(request))) {
+      return new NextResponse(null, { status: NO_CONTENT });
+    }
+
     // 本文サイズ上限チェック（Content-Length が信頼できない場合も後段の
     // text() 長で二重に防ぐ）。数値化に失敗した不正な Content-Length は
     // 上限超過として扱い、中身を読まずに破棄する（防御的）。

--- a/src/lib/rateLimit/inMemoryRateLimit.test.ts
+++ b/src/lib/rateLimit/inMemoryRateLimit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * インメモリ・レート制限のテスト
+ */
+
+import { createInMemoryRateLimiter } from './inMemoryRateLimit';
+
+describe('createInMemoryRateLimiter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('上限までは許可し、超過を拒否する', () => {
+    const limiter = createInMemoryRateLimiter({
+      maxRequests: 3,
+      windowMs: 1000,
+    });
+
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(false); // 4回目は拒否
+    expect(limiter.check('ip1')).toBe(false); // 以降も拒否
+  });
+
+  it('キーごとに独立してカウントする', () => {
+    const limiter = createInMemoryRateLimiter({
+      maxRequests: 1,
+      windowMs: 1000,
+    });
+
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(false);
+    // 別キーは影響を受けない
+    expect(limiter.check('ip2')).toBe(true);
+  });
+
+  it('ウィンドウ経過後はカウントがリセットされる', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const limiter = createInMemoryRateLimiter({
+      maxRequests: 2,
+      windowMs: 1000,
+    });
+
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(true);
+    expect(limiter.check('ip1')).toBe(false);
+
+    // ウィンドウ幅ぶん進めるとリセットされ再度許可される
+    jest.advanceTimersByTime(1000);
+    expect(limiter.check('ip1')).toBe(true);
+  });
+
+  it('maxKeys 到達時、新規キー追加で期限切れのみ掃除し有効エントリは保持する', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const limiter = createInMemoryRateLimiter({
+      maxRequests: 5,
+      windowMs: 1000,
+      maxKeys: 2,
+    });
+
+    expect(limiter.check('a')).toBe(true); // t=0（a は t=1000 で期限切れ）
+    jest.advanceTimersByTime(600);
+    expect(limiter.check('b')).toBe(true); // t=600（b は t=1600 まで有効）
+
+    // t=1000: a は期限切れ、b はまだ有効
+    jest.advanceTimersByTime(400);
+
+    // maxKeys(2) 到達済み・新規キー c 追加時: 期限切れ(a)は掃除、有効(b)は保持
+    expect(limiter.check('c')).toBe(true);
+    // b はまだ有効（掃除されず）カウント継続
+    expect(limiter.check('b')).toBe(true);
+  });
+});

--- a/src/lib/rateLimit/inMemoryRateLimit.ts
+++ b/src/lib/rateLimit/inMemoryRateLimit.ts
@@ -1,0 +1,80 @@
+/**
+ * インメモリ・レート制限（軽量スロットリング）
+ *
+ * DB を介さないプロセス内カウンタによる固定ウィンドウ方式のレート制限。
+ * 高頻度・低コストで判定したいエンドポイント（例: CSP 違反レポート受信）向け。
+ * CSP レポートのようにレポート毎に DB 書き込みを行うと逆効果になるケースで使う。
+ *
+ * ⚠️ サーバーレス環境ではインスタンス単位の状態であり、複数インスタンス間で
+ * 共有されず、コールドスタートでリセットされる。厳密な制限ではなく best-effort の
+ * 濫用抑止・ログ肥大防止を目的とする。
+ */
+
+/** インメモリ・レート制限インスタンス */
+export interface InMemoryRateLimiter {
+  /**
+   * 指定キー（IP 等）のリクエストを 1 件計上し、上限内なら true を返す。
+   * 上限超過なら false（呼び出し側で破棄する）。
+   */
+  check(key: string): boolean;
+}
+
+/** {@link createInMemoryRateLimiter} のオプション */
+export interface InMemoryRateLimiterOptions {
+  /** ウィンドウあたりの最大リクエスト数 */
+  maxRequests: number;
+  /** ウィンドウ幅（ミリ秒） */
+  windowMs: number;
+  /**
+   * 保持するキー数の上限。新規キー追加時にこの数へ達していたら、期限切れ
+   * エントリを掃除する（ユニーク IP 増加によるメモリ肥大を防ぐ）。
+   */
+  maxKeys?: number;
+}
+
+interface WindowState {
+  count: number;
+  windowStart: number;
+}
+
+const DEFAULT_MAX_KEYS = 10_000;
+
+/**
+ * 固定ウィンドウ方式のインメモリ・レート制限を生成する。
+ * 独立した状態（Map）を持つため、テストでは都度新しいインスタンスを生成できる。
+ */
+export function createInMemoryRateLimiter(
+  options: InMemoryRateLimiterOptions,
+): InMemoryRateLimiter {
+  const { maxRequests, windowMs, maxKeys = DEFAULT_MAX_KEYS } = options;
+  const store = new Map<string, WindowState>();
+
+  function check(key: string): boolean {
+    const now = Date.now();
+    const entry = store.get(key);
+
+    // 未登録、またはウィンドウを跨いだら新しいウィンドウを開始
+    if (!entry || now - entry.windowStart >= windowMs) {
+      // 新規キーで上限数に達している場合は期限切れエントリを掃除
+      if (!entry && store.size >= maxKeys) {
+        for (const [k, v] of store) {
+          if (now - v.windowStart >= windowMs) {
+            store.delete(k);
+          }
+        }
+      }
+      store.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+
+    // ウィンドウ内で上限到達なら拒否
+    if (entry.count >= maxRequests) {
+      return false;
+    }
+
+    entry.count += 1;
+    return true;
+  }
+
+  return { check };
+}


### PR DESCRIPTION
## 概要

未認証・公開の CSP 違反レポート受信エンドポイント `/api/csp-report` に**レート制限が無く**、大量 POST によるログ肥大・負荷リスク（OWASP API4）があった。**IP 単位のインメモリ軽量レート制限**（固定ウィンドウ 60回/分）を追加し、超過分は **204 のまま黙って破棄**する。

Closes #431

## ロードマップ

該当なし（セキュリティ強化）

## レビューポイント

- **DB-based レート制限をあえて使わない判断**: CSP レポートは大量に届きうるため、レポート毎に DB 書き込みが発生する既存の DB-based レート制限は逆効果。プロセス内カウンタによる軽量スロットリングを採用（Issue #431 の推奨方針に準拠）
- **超過時も 204 維持・ログしない**: 攻撃者に制限を悟らせず、ブラウザ再送も誘発しない。ログ肥大も防ぐ
- **best-effort の明記**: サーバーレスではインスタンス単位・コールドスタートでリセットされる旨をコメントに記載（厳密な制限ではなく濫用抑止が目的）
- `src/lib/rateLimit/inMemoryRateLimit.ts` は再利用可能なユーティリティとして分離（メモリ肥大防止の期限切れ掃除つき）

## テスト

- ユーティリティ単体（**カバレッジ 100%**）: 上限到達で拒否 / ウィンドウ経過でリセット / キーごと独立 / maxKeys 到達時の期限切れ掃除（有効エントリは保持）
- csp-report route 統合: 同一 IP から大量送信 → 超過分はログせず破棄（204 維持）を検証
- 関連 **15 件パス**、型チェック新規エラーなし、eslint 通過
