### PR TITLE
perf(awards): availableYears を RPC(get_award_years) で DB 側 DISTINCT 化

### DIFF
--- a/src/app/api/awards/route.test.ts
+++ b/src/app/api/awards/route.test.ts
@@ -9,10 +9,11 @@
 // --- Mocks ---
 
 const mockAnonFrom = jest.fn();
+const mockAnonRpc = jest.fn();
 const mockServiceFrom = jest.fn();
 
 jest.mock('@/helpers/supabase', () => ({
-  createAnonClient: jest.fn(() => ({ from: mockAnonFrom })),
+  createAnonClient: jest.fn(() => ({ from: mockAnonFrom, rpc: mockAnonRpc })),
   createServiceRoleClient: jest.fn(() => ({ from: mockServiceFrom })),
   dbConnectionErrorResponse: jest.fn(
     () => new Response(JSON.stringify({ success: false }), { status: 500 }),
@@ -49,15 +50,8 @@ function createRequest(yearParam?: string, ip?: string): Request {
 }
 
 function mockYearQuery(years: number[]) {
-  mockAnonFrom.mockReturnValueOnce({
-    select: () => ({
-      order: () =>
-        Promise.resolve({
-          data: years.map((y) => ({ award_year: y })),
-          error: null,
-        }),
-    }),
-  });
+  // 年度一覧は RPC get_award_years（DB 側で DISTINCT・降順）で取得する
+  mockAnonRpc.mockResolvedValueOnce({ data: years, error: null });
 }
 
 function mockAwardDataQuery(rows: Record<string, unknown>[]) {
@@ -243,9 +237,9 @@ describe('GET /api/awards', () => {
     expect(categories[1].category).toBe('best_director');
   });
 
-  it('availableYearsが重複なしで返される', async () => {
-    // 同じ年度が複数レコードに存在する場合
-    mockYearQuery([2026, 2026, 2025, 2025, 2024]);
+  it('availableYearsはRPC(get_award_years)の結果をそのまま返す', async () => {
+    // 重複排除・降順ソートは DB 側（RPC）で実施されるため、返り値をそのまま返す
+    mockYearQuery([2026, 2025, 2024]);
     mockAwardDataQuery([]);
 
     const response = await GET(createRequest('2026'));
@@ -262,15 +256,10 @@ describe('GET /api/awards', () => {
     expect(response.status).toBe(500);
   });
 
-  it('年度一覧取得でDBエラーの場合500を返す', async () => {
-    mockAnonFrom.mockReturnValueOnce({
-      select: () => ({
-        order: () =>
-          Promise.resolve({
-            data: null,
-            error: { message: 'DB error', code: 'INTERNAL' },
-          }),
-      }),
+  it('年度一覧取得(RPC)でDBエラーの場合500を返す', async () => {
+    mockAnonRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'DB error', code: 'INTERNAL' },
     });
 
     const response = await GET(createRequest('2026'));

--- a/src/app/api/awards/route.ts
+++ b/src/app/api/awards/route.ts
@@ -153,21 +153,13 @@ export async function GET(request: Request) {
     const supabase = createAnonClient();
     if (!supabase) return dbConnectionErrorResponse();
 
-    // 利用可能な年度一覧を取得
-    const { data: yearRows, error: yearError } = await supabase
-      .from('award_movies')
-      .select('award_year')
-      .order('award_year', { ascending: false });
+    // 利用可能な年度一覧を取得（DB 側で DISTINCT・降順ソート）
+    const { data: availableYears, error: yearError } =
+      await supabase.rpc('get_award_years');
 
     if (yearError) {
       throw yearError;
     }
-
-    const availableYears = [
-      ...new Set(
-        (yearRows ?? []).map((r: { award_year: number }) => r.award_year),
-      ),
-    ];
 
     // 指定年度の受賞作品データを取得（必要カラムのみ）
     const { data: rawAwardRows, error: awardError } = await supabase
@@ -223,7 +215,7 @@ export async function GET(request: Request) {
 
     const responseData: AwardsResponseData = {
       year,
-      availableYears,
+      availableYears: availableYears ?? [],
       awards,
     };
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -12,6 +12,31 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: '14.1';
   };
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       accounts: {
@@ -868,6 +893,7 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      get_award_years: { Args: never; Returns: number[] };
       get_watchlist_by_proximity: {
         Args: { p_limit: number; p_offset?: number; p_user_id: string };
         Returns: {
@@ -1012,6 +1038,9 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },

--- a/supabase/migrations/20260718103227_add_get_award_years_rpc.sql
+++ b/supabase/migrations/20260718103227_add_get_award_years_rpc.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- get_award_years RPC 関数
+-- ============================================
+-- 受賞作品の「利用可能な年度」を DB 側で DISTINCT・降順ソートして返す。
+-- 従来は全行の award_year を取得し JS 側（Set）で重複排除していたが、データ量
+-- 増加に伴う転送量・メモリ増を避けるため DB 側で集約する。
+-- 公開データ（anon が SELECT 可能な award_movies）を読むだけのため SECURITY INVOKER。
+
+CREATE OR REPLACE FUNCTION public.get_award_years()
+RETURNS integer[]
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    array_agg(DISTINCT award_year ORDER BY award_year DESC),
+    ARRAY[]::integer[]
+  )
+  FROM public.award_movies;
+$$;
+
+-- Data API（RPC / supabase-js）から呼び出せるよう EXECUTE を付与する。
+-- awards の年度取得は anon クライアントで実行されるため anon にも付与する。
+GRANT EXECUTE ON FUNCTION public.get_award_years() TO anon, authenticated, service_role;


### PR DESCRIPTION
## 概要

`/api/awards` の「利用可能年度」取得を、**全行 `award_year` 取得 → JS(`Set`)で重複排除**から、**DB 側で DISTINCT・降順集約する RPC `get_award_years()`** に変更します。データ量増加に伴う転送量・メモリを削減します。

Closes #310

## ロードマップ

該当なし（パフォーマンス最適化）

## レビューポイント

- **RPC 方式を採用**（Issue #310 の第1候補）。`get_award_years()` は `SECURITY INVOKER`（公開データ `award_movies` を読むだけ）、`anon / authenticated / service_role` に `EXECUTE` 付与
- route は anon クライアントで `.rpc('get_award_years')` を呼び、結果をそのまま返す（重複排除・ソートは DB 側）
- **本番 DB へ適用済み**（`supabase db push`）。未適用は本 migration 1 件のみであることを `migration list` で確認してから push
- `database.types.ts` は `supabase gen types` で再生成後 `prettier --write` を適用（差分は `get_award_years` と `graphql_public` スキーマブロックのみ＝正味 +少数行）

## テスト

- **本番 RPC を anon キーで実呼び出し検証済み**: `isArray=true` / `[2026, 2025]`（DISTINCT・降順で返ることを確認）
- awards route テスト **16 件パス**（年度取得を RPC モックに更新／dedup は DB 側前提に調整）
- 全体 `tsc --noEmit` **0 エラー**、eslint・prettier check 通過
