### PR TITLE
security(otp): テストバイパスガードを positive guard（fail-closed）化

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -112,7 +112,8 @@ export default defineConfig({
     reuseExistingServer: !isCI,
     timeout: 120000,
     // OTPフローE2E用: メール実送信をスキップ（コードはDBから取得して検証）。
+    // E2E_TEST_MODE=true は positive guard の必須シグナル（これが無いとバイパスは無効）。
     // ローカルで reuseExistingServer 時は、起動済みdevサーバーにも同フラグが必要。
-    env: { OTP_EMAIL_TEST_BYPASS: 'true' },
+    env: { E2E_TEST_MODE: 'true', OTP_EMAIL_TEST_BYPASS: 'true' },
   },
 });

--- a/src/lib/otp/sendOtpEmail.test.ts
+++ b/src/lib/otp/sendOtpEmail.test.ts
@@ -26,6 +26,10 @@ describe('sendOtpEmail', () => {
       RESEND_API_KEY: 'test_api_key',
       RESEND_FROM_EMAIL: 'test@example.com',
     };
+    // バイパス系フラグは各テストで明示設定するため baseline はクリア
+    delete process.env.E2E_TEST_MODE;
+    delete process.env.OTP_EMAIL_TEST_BYPASS;
+    delete process.env.VERCEL_ENV;
   });
 
   afterAll(() => {
@@ -89,5 +93,84 @@ describe('sendOtpEmail', () => {
         text: expect.stringContaining('654321'),
       }),
     );
+  });
+
+  describe('テストバイパスガード（positive guard / #424）', () => {
+    it('E2E_TEST_MODE=true かつ OTP_EMAIL_TEST_BYPASS=true で実送信をスキップしtrueを返す', async () => {
+      process.env.E2E_TEST_MODE = 'true';
+      process.env.OTP_EMAIL_TEST_BYPASS = 'true';
+      delete process.env.VERCEL_ENV;
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      const result = await sendOtpEmail('user@example.com', '123456');
+
+      expect(result).toBe(true);
+      // バイパス時は実送信しない
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('OTP_EMAIL_TEST_BYPASS=true 単体（E2E_TEST_MODE無し）ではバイパスしない: VERCEL_ENV=production', async () => {
+      mockSend.mockResolvedValue({ data: { id: 'x' }, error: null });
+      process.env.OTP_EMAIL_TEST_BYPASS = 'true';
+      process.env.VERCEL_ENV = 'production';
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      await sendOtpEmail('user@example.com', '123456');
+
+      // 実送信パスに入る＝バイパスしていない
+      expect(mockSend).toHaveBeenCalled();
+    });
+
+    it('OTP_EMAIL_TEST_BYPASS=true 単体ではバイパスしない: VERCEL_ENV=preview', async () => {
+      mockSend.mockResolvedValue({ data: { id: 'x' }, error: null });
+      process.env.OTP_EMAIL_TEST_BYPASS = 'true';
+      process.env.VERCEL_ENV = 'preview';
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      await sendOtpEmail('user@example.com', '123456');
+
+      expect(mockSend).toHaveBeenCalled();
+    });
+
+    it('OTP_EMAIL_TEST_BYPASS=true 単体ではバイパスしない: VERCEL_ENV 未定義', async () => {
+      mockSend.mockResolvedValue({ data: { id: 'x' }, error: null });
+      process.env.OTP_EMAIL_TEST_BYPASS = 'true';
+      delete process.env.VERCEL_ENV;
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      await sendOtpEmail('user@example.com', '123456');
+
+      expect(mockSend).toHaveBeenCalled();
+    });
+
+    it('E2E_TEST_MODE=true + OTP_EMAIL_TEST_BYPASS=true でも VERCEL_ENV=production ではバイパスしない（多層防御）', async () => {
+      mockSend.mockResolvedValue({ data: { id: 'x' }, error: null });
+      process.env.E2E_TEST_MODE = 'true';
+      process.env.OTP_EMAIL_TEST_BYPASS = 'true';
+      process.env.VERCEL_ENV = 'production';
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      await sendOtpEmail('user@example.com', '123456');
+
+      expect(mockSend).toHaveBeenCalled();
+    });
+
+    it('E2E_TEST_MODE=true でも OTP_EMAIL_TEST_BYPASS が無ければバイパスしない', async () => {
+      mockSend.mockResolvedValue({ data: { id: 'x' }, error: null });
+      process.env.E2E_TEST_MODE = 'true';
+      delete process.env.OTP_EMAIL_TEST_BYPASS;
+      delete process.env.VERCEL_ENV;
+      jest.resetModules();
+
+      const { sendOtpEmail } = await import('./sendOtpEmail');
+      await sendOtpEmail('user@example.com', '123456');
+
+      expect(mockSend).toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/otp/sendOtpEmail.ts
+++ b/src/lib/otp/sendOtpEmail.ts
@@ -26,13 +26,17 @@ export async function sendOtpEmail(
 ): Promise<boolean> {
   // E2E/テスト用バイパス: メールの実送信をスキップして成功扱いにする。
   // OTPコードはDBに保存されるため、テストはDBから取得して検証できる。
-  // デフォルトoff。CIのE2Eサーバー（npm start=本番ビルド）のみ
-  // OTP_EMAIL_TEST_BYPASS=true で有効化する。
-  // Vercel本番では VERCEL_ENV ガードにより強制無効（誤設定耐性）。
+  //
+  // positive guard（fail-closed）: 明示的な E2E_TEST_MODE=true のときのみ許可する。
+  // 旧実装は VERCEL_ENV !== 'production' の否定条件（fail-open）で、preview や
+  // VERCEL_ENV 未定義でもフラグ単体で有効化されうる問題があった（#424）。
+  // 加えて機能個別の OTP_EMAIL_TEST_BYPASS=true を要求し、Vercel 本番では
+  // VERCEL_ENV で多層に強制無効化する（万一 E2E_TEST_MODE が本番に漏れても遮断）。
   // ※ NODE_ENV は CI も production のため判別に使えない。
   if (
-    process.env.VERCEL_ENV !== 'production' &&
-    process.env.OTP_EMAIL_TEST_BYPASS === 'true'
+    process.env.E2E_TEST_MODE === 'true' &&
+    process.env.OTP_EMAIL_TEST_BYPASS === 'true' &&
+    process.env.VERCEL_ENV !== 'production'
   ) {
     console.warn(
       '[OTP_EMAIL_TEST_BYPASS] sendOtpEmail はテストモードのため実送信をスキップしました',


### PR DESCRIPTION
## 概要

テスト用バイパスフラグ `OTP_EMAIL_TEST_BYPASS` のガードが `VERCEL_ENV !== 'production'` という**否定条件（fail-open）**で、preview / `VERCEL_ENV` 未定義でもフラグ単体で有効化されうる問題（#424）を修正します。**positive guard（fail-closed）**に変更します。

Closes #424

## ロードマップ

該当なし（セキュリティ強化・多層防御）

## レビューポイント

- `src/lib/otp/sendOtpEmail.ts`: バイパス条件を **`E2E_TEST_MODE === 'true'`（明示的シグナル・必須）＋ `OTP_EMAIL_TEST_BYPASS === 'true'`（機能個別）＋ `VERCEL_ENV !== 'production'`（本番の多層遮断）** に変更。`E2E_TEST_MODE` が無い限りバイパスは無効（default off）
- `playwright.config.ts`: webServer env に `E2E_TEST_MODE: 'true'` を追加（E2E は従来どおりメール送信をスキップ）
- ⚠️ **スコープ補足**: Issue が併記する `DISABLE_RATE_LIMIT_FOR_E2E` は**コード・git 履歴に存在しません**（#423 はレート制限クリーンアップで対応し、当該フラグは追加していない）。よって本PRの対象は `OTP_EMAIL_TEST_BYPASS` のみです

## テスト

`sendOtpEmail.test.ts` に完了条件（#424）を満たすガードテストを追加（**11件パス**）:
- `E2E_TEST_MODE=true` + `OTP_EMAIL_TEST_BYPASS=true` → バイパス（実送信スキップ）
- `OTP_EMAIL_TEST_BYPASS=true` **単体**では `production` / `preview` / `VERCEL_ENV 未定義`のいずれでも**バイパスしない**
- `E2E_TEST_MODE=true` + `OTP_EMAIL_TEST_BYPASS=true` でも `VERCEL_ENV=production` では**バイパスしない**（多層防御）
- `E2E_TEST_MODE=true` でも `OTP_EMAIL_TEST_BYPASS` 無しでは**バイパスしない**

eslint / typecheck 通過。
