### PR TITLE
refactor(constants): 既存定数があるのに直値の箇所を集約（ハードコード移行A）

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -16,7 +16,7 @@ import {
 } from '@/helpers/supabase';
 import { registerApiSchema } from '@/schema/auth';
 import { AUTH_ERROR_MESSAGES, BCRYPT_COST } from '@/constants/auth';
-import { OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
+import { OTP_ACTION, OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
 import { HTTP_STATUS, ERROR_CODE } from '@/constants';
 import { generateOtpCode, sendOtpEmail, randomDelay } from '@/lib/otp';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
@@ -128,7 +128,7 @@ export async function POST(request: Request) {
     const { error: otpInsertError } = await supabase.from('otp_codes').insert({
       email,
       code,
-      action_type: 'registration',
+      action_type: OTP_ACTION.REGISTRATION,
       expires_at: expiresAt.toISOString(),
     });
 

--- a/src/app/api/user/change-password/route.ts
+++ b/src/app/api/user/change-password/route.ts
@@ -14,7 +14,7 @@ import {
 import { changePasswordApiSchema } from '@/schema/auth';
 import { AUTH_ERROR_MESSAGES, BCRYPT_COST } from '@/constants/auth';
 import { HTTP_STATUS, ERROR_CODE } from '@/constants';
-import { OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
+import { OTP_ACTION, OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
 import { checkRateLimit, resetRateLimit } from '@/lib/rateLimit/rateLimit';
 
 const RATE_LIMIT_ACTION = 'change_password';
@@ -95,7 +95,7 @@ export async function POST(request: Request) {
       .from('otp_codes')
       .select('id, verified_at')
       .eq('email', user.email)
-      .eq('action_type', 'password_change')
+      .eq('action_type', OTP_ACTION.PASSWORD_CHANGE)
       .not('verified_at', 'is', null)
       .order('verified_at', { ascending: false })
       .limit(1)

--- a/src/components/ui/toast/toast.tsx
+++ b/src/components/ui/toast/toast.tsx
@@ -7,7 +7,7 @@
 import { type ReactNode, memo, useCallback } from 'react';
 import * as ToastPrimitive from '@radix-ui/react-toast';
 
-import { ARIA_LABELS } from '@/constants';
+import { ANIMATION, ARIA_LABELS } from '@/constants';
 import { cn } from '@/utils/cn';
 
 import styles from './toast.module.scss';
@@ -64,7 +64,7 @@ export interface ToastProviderProps {
 export const ToastProvider = memo<ToastProviderProps>(function ToastProvider({
   children,
   swipeDirection = 'right',
-  duration = 5000,
+  duration = ANIMATION.TOAST_DURATION,
 }) {
   return (
     <ToastPrimitive.Provider
@@ -99,7 +99,7 @@ export const Toast = memo<ToastProps>(function Toast({
   title,
   description,
   variant = 'info',
-  duration = 5000,
+  duration = ANIMATION.TOAST_DURATION,
   action,
   className,
 }) {

--- a/src/features/auth/otpVerification/otpVerification.tsx
+++ b/src/features/auth/otpVerification/otpVerification.tsx
@@ -12,7 +12,12 @@ import { Input } from '@/components/ui/input/input';
 import { Button } from '@/components/ui/button/button';
 import { Heading } from '@/components/ui/heading/heading';
 import { otpFormSchema, type OtpFormData } from '@/schema/otp';
-import { ARIA_LABELS, BUTTON_LABELS, OTP_MESSAGES } from '@/constants';
+import {
+  ARIA_LABELS,
+  BUTTON_LABELS,
+  OTP_CONFIG,
+  OTP_MESSAGES,
+} from '@/constants';
 import type { OtpAction } from '@/constants/otp';
 
 import { useOtpVerification } from './hooks/useOtpVerification';
@@ -76,8 +81,8 @@ export const OtpVerification = memo<OtpVerificationProps>(
             <Input
               type='text'
               inputMode='numeric'
-              maxLength={6}
-              pattern='[0-9]{6}'
+              maxLength={OTP_CONFIG.CODE_LENGTH}
+              pattern={`[0-9]{${OTP_CONFIG.CODE_LENGTH}}`}
               placeholder='123456'
               autoFocus
               autoComplete='one-time-code'

--- a/src/lib/api/auth/auth.ts
+++ b/src/lib/api/auth/auth.ts
@@ -2,6 +2,7 @@
  * 認証API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 
 /**
@@ -65,7 +66,7 @@ export interface SendOtpResponse {
  */
 export async function sendOtp(data: SendOtpRequest): Promise<SendOtpResponse> {
   const response = await axiosInstance.post<SendOtpResponse>(
-    '/api/auth/otp/send',
+    API_ENDPOINTS.OTP_SEND,
     data,
   );
   return response.data;

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -9,8 +9,13 @@ import GitHub from 'next-auth/providers/github';
 import { createClient } from '@supabase/supabase-js';
 import bcrypt from 'bcryptjs';
 
-import { AUTH_ERROR_MESSAGES, SESSION_CONFIG, ROUTES } from '@/constants';
-import { OTP_CONFIG } from '@/constants/otp';
+import {
+  AUTH_ERROR_MESSAGES,
+  SESSION_CONFIG,
+  ROUTES,
+  SUPABASE_ERROR_CODE,
+} from '@/constants';
+import { OTP_ACTION, OTP_CONFIG } from '@/constants/otp';
 import { isSessionExpired } from '@/lib/auth/sessionExpiry';
 import { checkRateLimit, resetRateLimit } from '@/lib/rateLimit/rateLimit';
 
@@ -55,7 +60,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const loginMethod = (credentials.loginMethod as string) || 'password';
 
         // レート制限チェック（emailベース: 3回失敗で30分ロック）
-        const rateLimitResult = await checkRateLimit(supabase, email, 'login');
+        const rateLimitResult = await checkRateLimit(
+          supabase,
+          email,
+          OTP_ACTION.LOGIN,
+        );
 
         if (!rateLimitResult.allowed) {
           throw new Error(AUTH_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
@@ -83,7 +92,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             .from('otp_codes')
             .select('id, verified_at')
             .eq('email', email)
-            .eq('action_type', 'login')
+            .eq('action_type', OTP_ACTION.LOGIN)
             .not('verified_at', 'is', null)
             .order('verified_at', { ascending: false })
             .limit(1)
@@ -135,7 +144,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         }
 
         // 認証成功 — レート制限リセット
-        await resetRateLimit(supabase, email, 'login');
+        await resetRateLimit(supabase, email, OTP_ACTION.LOGIN);
 
         return {
           id: user.id,
@@ -211,7 +220,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         .single();
 
       // DBエラー（"not found"以外）は失敗とする
-      if (findError && findError.code !== 'PGRST116') {
+      if (findError && findError.code !== SUPABASE_ERROR_CODE.NOT_FOUND) {
         return false;
       }
 

--- a/src/lib/eiga/fetchEigaOscarAwards.ts
+++ b/src/lib/eiga/fetchEigaOscarAwards.ts
@@ -7,10 +7,9 @@
 
 import axios from 'axios';
 
+import { EIGA_FETCH_TIMEOUT_MS } from '@/constants';
 import type { OpenAiAwardItem } from '@/schema/awards';
 import { getRequiredEnv } from '@/utils/env';
-
-const EIGA_FETCH_TIMEOUT_MS = 30000;
 
 /** eiga.comページと対応する部門のマッピング */
 interface EigaPageConfig {


### PR DESCRIPTION
## 概要

既存の共有定数が存在するのに**直値／同名ローカル再定義**になっていた箇所を、既存定数の参照へ統一します（**値は同一・挙動不変**）。ハードコード→constants 移行の**第1弾（カテゴリA: 既存定数の未使用是正）**です。

## ロードマップ

該当なし（リファクタ／重複解消）

## レビューポイント

すべて「既存定数の値と一致することを確認済み」の置換です（挙動不変）:

| 箇所 | Before → After |
|---|---|
| toast.tsx（2箇所） | `5000` → `ANIMATION.TOAST_DURATION` |
| otpVerification.tsx | `6` / `[0-9]{6}` → `OTP_CONFIG.CODE_LENGTH` |
| eiga/fetchEigaOscarAwards.ts | 同名ローカル `const ...=30000` を削除し `EIGA_FETCH_TIMEOUT_MS` を import |
| lib/auth/auth.ts | `'login'`（3箇所）→ `OTP_ACTION.LOGIN` ／ `'PGRST116'` → `SUPABASE_ERROR_CODE.NOT_FOUND` |
| lib/api/auth/auth.ts | `'/api/auth/otp/send'` → `API_ENDPOINTS.OTP_SEND` |
| register/route.ts | `'registration'` → `OTP_ACTION.REGISTRATION` |
| change-password/route.ts | `'password_change'` → `OTP_ACTION.PASSWORD_CHANGE` |

※ `lib/auth/auth.ts` の `'password'` / `'otp'`（ログイン**方式**）は別概念のため対象外（後続Eで検討）。

**後続PR予定**: B（レート制限の集約 / 新規 rateLimit.ts）／ C+D（Cache-Control・SELECT 文字列）／ E（その他の設定値）

## テスト

- 関連 **13 スイート 152 件パス**、全体 `tsc --noEmit` **0 エラー**、eslint 通過
