### PR TITLE
refactor(constants): レート制限の action/閾値を rateLimit.ts に集約（ハードコード移行B）

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -17,7 +17,12 @@ import {
 import { registerApiSchema } from '@/schema/auth';
 import { AUTH_ERROR_MESSAGES, BCRYPT_COST } from '@/constants/auth';
 import { OTP_ACTION, OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
-import { HTTP_STATUS, ERROR_CODE } from '@/constants';
+import {
+  HTTP_STATUS,
+  ERROR_CODE,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
+} from '@/constants';
 import { generateOtpCode, sendOtpEmail, randomDelay } from '@/lib/otp';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 
@@ -48,9 +53,9 @@ export async function POST(request: Request) {
     const rateLimitResult = await checkRateLimit(
       supabase,
       result.data.email,
-      'register',
-      5,
-      60,
+      RATE_LIMIT_ACTION.REGISTER,
+      RATE_LIMIT_CONFIG.REGISTER.maxAttempts,
+      RATE_LIMIT_CONFIG.REGISTER.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/awards/route.ts
+++ b/src/app/api/awards/route.ts
@@ -13,6 +13,8 @@ import {
   ERROR_CODE,
   AWARD_DEFINITIONS,
   AWARDS_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
 import { AUTH_ERROR_MESSAGES } from '@/constants/auth';
 import { handleRouteError } from '@/helpers/routeError';
@@ -57,10 +59,6 @@ interface AwardMovieRow {
 /** Cache-Control: CDNで1時間キャッシュ、stale-while-revalidateで24時間 */
 const CACHE_CONTROL_VALUE =
   'public, s-maxage=3600, stale-while-revalidate=86400';
-
-/** レートリミット設定: IP単位で30回/10分 */
-const RATE_LIMIT_MAX_ATTEMPTS = 30;
-const RATE_LIMIT_WINDOW_MINUTES = 10;
 
 /** DBレコードをAwardMovie型に変換 */
 function toAwardMovie(row: {
@@ -122,9 +120,9 @@ export async function GET(request: Request) {
       const rateLimitResult = await checkRateLimit(
         serviceSupabase,
         clientIp,
-        'awards_fetch',
-        RATE_LIMIT_MAX_ATTEMPTS,
-        RATE_LIMIT_WINDOW_MINUTES,
+        RATE_LIMIT_ACTION.AWARDS_FETCH,
+        RATE_LIMIT_CONFIG.AWARDS_FETCH.maxAttempts,
+        RATE_LIMIT_CONFIG.AWARDS_FETCH.windowMinutes,
       );
 
       if (!rateLimitResult.allowed) {

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -15,6 +15,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { IN_MEMORY_RATE_LIMIT } from '@/constants';
 import { createInMemoryRateLimiter } from '@/lib/rateLimit/inMemoryRateLimit';
 
 /**
@@ -33,11 +34,9 @@ const NO_CONTENT = 204;
  * 抑止する（サーバーレスではインスタンス単位・コールドスタートでリセットされる
  * best-effort）。超過分は処理・ログせず 204 のまま黙って破棄する。
  */
-const RATE_LIMIT_MAX_REQUESTS = 60;
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1分
 const rateLimiter = createInMemoryRateLimiter({
-  maxRequests: RATE_LIMIT_MAX_REQUESTS,
-  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: IN_MEMORY_RATE_LIMIT.CSP_REPORT.maxRequests,
+  windowMs: IN_MEMORY_RATE_LIMIT.CSP_REPORT.windowMs,
 });
 
 /** リクエストからクライアント IP を取得する（取得不可時は 'unknown'）。 */

--- a/src/app/api/dismissed-movies/route.ts
+++ b/src/app/api/dismissed-movies/route.ts
@@ -12,6 +12,8 @@ import {
   ERROR_CODE,
   DISMISSED_MOVIES_ERROR_MESSAGES,
   DISMISSED_MOVIES_SUCCESS_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
 import {
   checkDuplicate,
@@ -22,10 +24,6 @@ import { parseAndValidate } from '@/helpers/requestValidation';
 import { withAuth } from '@/helpers/routeHandler';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 import { dismissedMoviesAddSchema } from '@/schema/dismissedMovies';
-
-const RATE_LIMIT_ACTION = 'write_api_dismissed_movies';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const GET = withAuth(
   async ({ session, supabase }) => {
@@ -57,9 +55,9 @@ export const POST = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_DISMISSED_MOVIES,
+      RATE_LIMIT_CONFIG.WRITE_DISMISSED_MOVIES.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_DISMISSED_MOVIES.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {
@@ -122,9 +120,9 @@ export const DELETE = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_DISMISSED_MOVIES,
+      RATE_LIMIT_CONFIG.WRITE_DISMISSED_MOVIES.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_DISMISSED_MOVIES.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/favorites/[id]/route.ts
+++ b/src/app/api/favorites/[id]/route.ts
@@ -23,11 +23,9 @@ import {
   HTTP_STATUS,
   FAVORITES_ERROR_MESSAGES,
   FAVORITES_SUCCESS_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
-
-const RATE_LIMIT_ACTION = 'write_api_favorites';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const PATCH = withAuth(
   async ({ session, supabase, request, params }) => {
@@ -35,9 +33,9 @@ export const PATCH = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_FAVORITES,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {
@@ -98,9 +96,9 @@ export const DELETE = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_FAVORITES,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -20,11 +20,9 @@ import {
   ERROR_CODE,
   FAVORITES_ERROR_MESSAGES,
   FAVORITES_SUCCESS_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
-
-const RATE_LIMIT_ACTION = 'write_api_favorites';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const GET = withAuth(
   async ({ session, supabase, request }) => {
@@ -116,9 +114,9 @@ export const POST = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_FAVORITES,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_FAVORITES.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/movies/suggest-title/route.ts
+++ b/src/app/api/movies/suggest-title/route.ts
@@ -14,15 +14,13 @@ import {
   HTTP_STATUS,
   ERROR_CODE,
   TITLE_SUGGESTION_ERROR_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
 import { AUTH_ERROR_MESSAGES } from '@/constants/auth';
 import { titleSuggestionQuerySchema } from '@/schema/titleSuggestion';
 import { fetchTitleSuggestionsFromOpenAI } from '@/lib/openai/suggestTitle';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
-
-/** レートリミット設定: ユーザー単位で10回/60分（OpenAI APIコスト保護） */
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 60;
 
 export async function GET(request: Request) {
   try {
@@ -80,9 +78,9 @@ export async function GET(request: Request) {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      'suggest_title',
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.SUGGEST_TITLE,
+      RATE_LIMIT_CONFIG.SUGGEST_TITLE.maxAttempts,
+      RATE_LIMIT_CONFIG.SUGGEST_TITLE.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/theaters/[slug]/route.ts
+++ b/src/app/api/theaters/[slug]/route.ts
@@ -21,22 +21,19 @@ import {
   THEATER_SEATS_SELECT,
   THEATER_SPEAKERS_SELECT,
   THEATER_CACHE_CONTROL,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
 import { theaterSlugSchema } from '@/schema/theaters';
-
-/** 認証ユーザー単位の読み取りレート制限: 30 回 / 1 分 */
-const RATE_LIMIT_ACTION = 'read_api_theater_detail';
-const RATE_LIMIT_MAX_ATTEMPTS = 30;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const GET = withAuth(
   async ({ session, supabase, params }) => {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.READ_THEATER_DETAIL,
+      RATE_LIMIT_CONFIG.READ_THEATER_DETAIL.maxAttempts,
+      RATE_LIMIT_CONFIG.READ_THEATER_DETAIL.windowMinutes,
     );
     if (!rateLimitResult.allowed) {
       return rateLimitExceededResponse(rateLimitResult);

--- a/src/app/api/theaters/route.ts
+++ b/src/app/api/theaters/route.ts
@@ -15,21 +15,18 @@ import {
   THEATER_MESSAGES,
   THEATERS_LIST_SELECT,
   THEATER_CACHE_CONTROL,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
-
-/** 認証ユーザー単位の読み取りレート制限: 30 回 / 1 分 */
-const RATE_LIMIT_ACTION = 'read_api_theaters';
-const RATE_LIMIT_MAX_ATTEMPTS = 30;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const GET = withAuth(
   async ({ session, supabase }) => {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.READ_THEATERS,
+      RATE_LIMIT_CONFIG.READ_THEATERS.maxAttempts,
+      RATE_LIMIT_CONFIG.READ_THEATERS.windowMinutes,
     );
     if (!rateLimitResult.allowed) {
       return rateLimitExceededResponse(rateLimitResult);

--- a/src/app/api/user/change-password/route.ts
+++ b/src/app/api/user/change-password/route.ts
@@ -13,11 +13,9 @@ import {
 } from '@/helpers/supabase';
 import { changePasswordApiSchema } from '@/schema/auth';
 import { AUTH_ERROR_MESSAGES, BCRYPT_COST } from '@/constants/auth';
-import { HTTP_STATUS, ERROR_CODE } from '@/constants';
+import { HTTP_STATUS, ERROR_CODE, RATE_LIMIT_ACTION } from '@/constants';
 import { OTP_ACTION, OTP_CONFIG, OTP_ERROR_MESSAGES } from '@/constants/otp';
 import { checkRateLimit, resetRateLimit } from '@/lib/rateLimit/rateLimit';
-
-const RATE_LIMIT_ACTION = 'change_password';
 
 export async function POST(request: Request) {
   try {
@@ -33,7 +31,7 @@ export async function POST(request: Request) {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
+      RATE_LIMIT_ACTION.CHANGE_PASSWORD,
     );
 
     if (!rateLimitResult.allowed) {
@@ -175,7 +173,11 @@ export async function POST(request: Request) {
     }
 
     // レート制限リセット（成功時）
-    await resetRateLimit(supabase, session.user.id, RATE_LIMIT_ACTION);
+    await resetRateLimit(
+      supabase,
+      session.user.id,
+      RATE_LIMIT_ACTION.CHANGE_PASSWORD,
+    );
 
     return NextResponse.json(
       {

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -19,11 +19,9 @@ import {
   PROFILE_ERROR_MESSAGES,
   PROFILE_SUCCESS_MESSAGES,
   API_ERROR_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
-
-const RATE_LIMIT_ACTION = 'write_api_profile';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export async function PUT(request: Request) {
   try {
@@ -39,9 +37,9 @@ export async function PUT(request: Request) {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_PROFILE,
+      RATE_LIMIT_CONFIG.WRITE_PROFILE.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_PROFILE.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -23,11 +23,9 @@ import {
   SETTINGS_SUCCESS_MESSAGES,
   API_ERROR_MESSAGES,
   THEME_DEFAULTS,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
-
-const RATE_LIMIT_ACTION = 'write_api_settings';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 /** デフォルトのユーザー設定 */
 const DEFAULT_SETTINGS: UserSettings = {
@@ -107,9 +105,9 @@ export async function PUT(request: Request) {
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_SETTINGS,
+      RATE_LIMIT_CONFIG.WRITE_SETTINGS.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_SETTINGS.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -11,6 +11,8 @@ import {
   ERROR_CODE,
   WATCHLIST_ERROR_MESSAGES,
   WATCHLIST_SUCCESS_MESSAGES,
+  RATE_LIMIT_ACTION,
+  RATE_LIMIT_CONFIG,
 } from '@/constants';
 import {
   checkDuplicate,
@@ -22,10 +24,6 @@ import { withAuth } from '@/helpers/routeHandler';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 import type { WatchlistItem } from '@/lib/api/watchlist/watchlist';
 import { watchlistQuerySchema, watchlistAddSchema } from '@/schema/watchlist';
-
-const RATE_LIMIT_ACTION = 'write_api_watchlist';
-const RATE_LIMIT_MAX_ATTEMPTS = 10;
-const RATE_LIMIT_WINDOW_MINUTES = 1;
 
 export const GET = withAuth(
   async ({ session, supabase, request }) => {
@@ -155,9 +153,9 @@ export const POST = withAuth(
     const rateLimitResult = await checkRateLimit(
       supabase,
       session.user.id,
-      RATE_LIMIT_ACTION,
-      RATE_LIMIT_MAX_ATTEMPTS,
-      RATE_LIMIT_WINDOW_MINUTES,
+      RATE_LIMIT_ACTION.WRITE_WATCHLIST,
+      RATE_LIMIT_CONFIG.WRITE_WATCHLIST.maxAttempts,
+      RATE_LIMIT_CONFIG.WRITE_WATCHLIST.windowMinutes,
     );
 
     if (!rateLimitResult.allowed) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -32,3 +32,4 @@ export * from './external';
 export * from './queryParams';
 export * from './defaults';
 export * from './theaters';
+export * from './rateLimit';

--- a/src/constants/rateLimit.ts
+++ b/src/constants/rateLimit.ts
@@ -1,0 +1,60 @@
+/**
+ * レート制限の定数
+ *
+ * 各ルートに散在していた action 種別・閾値を集約する。
+ */
+
+/**
+ * DB-based レート制限のアクション種別（`rate_limits.action_type` の値）。
+ *
+ * ⚠️ これらは DB に保存されるキーのため、値を変更しないこと（変更すると既存の
+ * レート制限レコードと不整合になる）。OTP 系（registration / login / password_change 等）は
+ * `OTP_ACTION`（otp.ts）を参照。
+ */
+export const RATE_LIMIT_ACTION = {
+  WRITE_FAVORITES: 'write_api_favorites',
+  WRITE_WATCHLIST: 'write_api_watchlist',
+  WRITE_DISMISSED_MOVIES: 'write_api_dismissed_movies',
+  WRITE_PROFILE: 'write_api_profile',
+  WRITE_SETTINGS: 'write_api_settings',
+  READ_THEATERS: 'read_api_theaters',
+  READ_THEATER_DETAIL: 'read_api_theater_detail',
+  AWARDS_FETCH: 'awards_fetch',
+  SUGGEST_TITLE: 'suggest_title',
+  REGISTER: 'register',
+  CHANGE_PASSWORD: 'change_password',
+} as const;
+
+/**
+ * DB-based レート制限の閾値プリセット（maxAttempts 回 / windowMinutes 分）。
+ * checkRateLimit(supabase, id, action, maxAttempts, windowMinutes) に渡す。
+ */
+export const RATE_LIMIT_CONFIG = {
+  WRITE_FAVORITES: { maxAttempts: 10, windowMinutes: 1 },
+  WRITE_WATCHLIST: { maxAttempts: 10, windowMinutes: 1 },
+  WRITE_DISMISSED_MOVIES: { maxAttempts: 10, windowMinutes: 1 },
+  WRITE_PROFILE: { maxAttempts: 10, windowMinutes: 1 },
+  WRITE_SETTINGS: { maxAttempts: 10, windowMinutes: 1 },
+  READ_THEATERS: { maxAttempts: 30, windowMinutes: 1 },
+  READ_THEATER_DETAIL: { maxAttempts: 30, windowMinutes: 1 },
+  AWARDS_FETCH: { maxAttempts: 30, windowMinutes: 10 },
+  SUGGEST_TITLE: { maxAttempts: 10, windowMinutes: 60 },
+  REGISTER: { maxAttempts: 5, windowMinutes: 60 },
+} as const;
+
+/**
+ * checkRateLimit のデフォルト閾値（呼び出しで maxAttempts/windowMinutes を
+ * 省略した場合に適用。change-password はこのデフォルトを利用）。
+ */
+export const RATE_LIMIT_DEFAULT = {
+  MAX_ATTEMPTS: 3,
+  WINDOW_MINUTES: 30,
+} as const;
+
+/**
+ * インメモリ・レート制限（DB を使わない軽量制限）の設定。
+ * CSP レポート受信など高頻度・低コストで判定したいエンドポイント向け。
+ */
+export const IN_MEMORY_RATE_LIMIT = {
+  CSP_REPORT: { maxRequests: 60, windowMs: 60 * 1000 },
+} as const;

--- a/src/lib/rateLimit/rateLimit.ts
+++ b/src/lib/rateLimit/rateLimit.ts
@@ -4,7 +4,7 @@
 
 import { SupabaseClient } from '@supabase/supabase-js';
 
-import { SUPABASE_ERROR_CODE } from '@/constants';
+import { RATE_LIMIT_DEFAULT, SUPABASE_ERROR_CODE } from '@/constants';
 
 /**
  * レート制限チェック結果
@@ -28,8 +28,8 @@ export async function checkRateLimit(
   supabase: SupabaseClient,
   identifier: string,
   actionType: string,
-  maxAttempts: number = 3,
-  windowMinutes: number = 30,
+  maxAttempts: number = RATE_LIMIT_DEFAULT.MAX_ATTEMPTS,
+  windowMinutes: number = RATE_LIMIT_DEFAULT.WINDOW_MINUTES,
 ): Promise<RateLimitResult> {
   const { data, error } = await supabase
     .from('rate_limits')


### PR DESCRIPTION
## 概要

各APIルートに散在していたレート制限のローカル定数（`RATE_LIMIT_ACTION` / `RATE_LIMIT_MAX_ATTEMPTS` / `RATE_LIMIT_WINDOW_MINUTES`）、`checkRateLimit` のデフォルト(3/30)、csp-report のインメモリ設定を、**新規 `src/constants/rateLimit.ts`** に集約します。ハードコード→constants 移行の**第2弾（カテゴリB: レート制限の集約）**。

## ロードマップ

該当なし（リファクタ／設定集約・セキュリティ整合性向上）

## レビューポイント

- **`action_type` は `rate_limits` テーブルのDBキー**のため、値を1文字も変えていません（**挙動不変**）。閾値もすべて現状維持
- 新規 `rateLimit.ts`: `RATE_LIMIT_ACTION`（action種別）/ `RATE_LIMIT_CONFIG`（閾値プリセット）/ `RATE_LIMIT_DEFAULT`（3/30）/ `IN_MEMORY_RATE_LIMIT`（csp-report）
- 13ルートのローカル定数を削除し共有定数を参照。`register` の直接インライン(5/60)や `awards`(30/10) 等も集約
- OTP系（otp/send・verify）は既に `OTP_CONFIG` 使用済みのため対象外

## テスト

- `api` 配下 **30 スイート / 351 テスト パス**（`awards/route.test.ts` の `'awards_fetch', 30, 10` assertion 維持を含む）
- 全体 `tsc --noEmit` **0 エラー**、eslint 通過
- 検証: ルートにローカル再定義**0件**、全 action_type 値が定数側に保持されていることを grep で確認済み
