### PR TITLE
refactor(constants): Cache-Control と SELECT カラムを定数に集約（ハードコード移行C+D）

### DIFF
--- a/src/app/api/awards/route.ts
+++ b/src/app/api/awards/route.ts
@@ -15,6 +15,7 @@ import {
   AWARDS_MESSAGES,
   RATE_LIMIT_ACTION,
   RATE_LIMIT_CONFIG,
+  CACHE_CONTROL,
 } from '@/constants';
 import { AUTH_ERROR_MESSAGES } from '@/constants/auth';
 import { handleRouteError } from '@/helpers/routeError';
@@ -55,10 +56,6 @@ interface AwardMovieRow {
   is_winner: boolean;
   display_order: number;
 }
-
-/** Cache-Control: CDNで1時間キャッシュ、stale-while-revalidateで24時間 */
-const CACHE_CONTROL_VALUE =
-  'public, s-maxage=3600, stale-while-revalidate=86400';
 
 /** DBレコードをAwardMovie型に変換 */
 function toAwardMovie(row: {
@@ -140,7 +137,7 @@ export async function GET(request: Request) {
               ...(rateLimitResult.retryAfter
                 ? { 'Retry-After': String(rateLimitResult.retryAfter) }
                 : {}),
-              'Cache-Control': 'no-store',
+              'Cache-Control': CACHE_CONTROL.NO_STORE,
             },
           },
         );
@@ -221,7 +218,7 @@ export async function GET(request: Request) {
       { success: true, data: responseData },
       {
         status: HTTP_STATUS.OK,
-        headers: { 'Cache-Control': CACHE_CONTROL_VALUE },
+        headers: { 'Cache-Control': CACHE_CONTROL.PUBLIC_1H_SWR_24H },
       },
     );
   } catch (error) {

--- a/src/app/api/dismissed-movies/route.ts
+++ b/src/app/api/dismissed-movies/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from 'next/server';
 import {
   HTTP_STATUS,
   ERROR_CODE,
+  DISMISSED_MOVIES_SELECT,
   DISMISSED_MOVIES_ERROR_MESSAGES,
   DISMISSED_MOVIES_SUCCESS_MESSAGES,
   RATE_LIMIT_ACTION,
@@ -29,7 +30,7 @@ export const GET = withAuth(
   async ({ session, supabase }) => {
     const { data, error } = await supabase
       .from('dismissed_movies')
-      .select('id, tmdb_movie_id, title, poster_path, genre_ids, created_at')
+      .select(DISMISSED_MOVIES_SELECT)
       .eq('user_id', session.user.id)
       .is('deleted_at', null)
       .order('created_at', { ascending: false });
@@ -92,7 +93,7 @@ export const POST = withAuth(
         poster_path: parsed.data.poster_path ?? null,
         genre_ids: parsed.data.genre_ids ?? null,
       })
-      .select('id, tmdb_movie_id, title, poster_path, genre_ids, created_at')
+      .select(DISMISSED_MOVIES_SELECT)
       .single();
 
     if (insertError) {

--- a/src/app/api/favorites/[id]/route.ts
+++ b/src/app/api/favorites/[id]/route.ts
@@ -21,6 +21,7 @@ import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 import { favoritesUpdateSchema } from '@/schema/favorites';
 import {
   HTTP_STATUS,
+  FAVORITES_SELECT,
   FAVORITES_ERROR_MESSAGES,
   FAVORITES_SUCCESS_MESSAGES,
   RATE_LIMIT_ACTION,
@@ -66,9 +67,7 @@ export const PATCH = withAuth(
       .eq('id', id)
       .eq('user_id', session.user.id)
       .is('deleted_at', null)
-      .select(
-        'id, tmdb_movie_id, title, poster_path, release_date, rating, added_at',
-      )
+      .select(FAVORITES_SELECT)
       .single();
 
     if (error || !data) {

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -18,6 +18,7 @@ import { favoritesQuerySchema, favoritesAddSchema } from '@/schema/favorites';
 import {
   HTTP_STATUS,
   ERROR_CODE,
+  FAVORITES_SELECT,
   FAVORITES_ERROR_MESSAGES,
   FAVORITES_SUCCESS_MESSAGES,
   RATE_LIMIT_ACTION,
@@ -69,9 +70,7 @@ export const GET = withAuth(
 
     const { data, error } = await supabase
       .from('favorites')
-      .select(
-        'id, tmdb_movie_id, title, poster_path, release_date, rating, added_at',
-      )
+      .select(FAVORITES_SELECT)
       .eq('user_id', session.user.id)
       .is('deleted_at', null)
       .order(sort_by, { ascending: sort_order === 'asc' })
@@ -152,9 +151,7 @@ export const POST = withAuth(
         release_date: parsed.data.release_date ?? null,
         rating: parsed.data.rating,
       })
-      .select(
-        'id, tmdb_movie_id, title, poster_path, release_date, rating, added_at',
-      )
+      .select(FAVORITES_SELECT)
       .single();
 
     if (insertError) {

--- a/src/app/api/movies/[id]/route.ts
+++ b/src/app/api/movies/[id]/route.ts
@@ -15,6 +15,7 @@ import {
   ERROR_CODE,
   MOVIES_ERROR_MESSAGES,
   API_ERROR_MESSAGES,
+  CACHE_CONTROL,
 } from '@/constants';
 
 /**
@@ -74,8 +75,8 @@ export async function GET(
       {
         headers: {
           'Cache-Control': session
-            ? 'private, no-store'
-            : 'public, s-maxage=86400, stale-while-revalidate=604800',
+            ? CACHE_CONTROL.PRIVATE_NO_STORE
+            : CACHE_CONTROL.PUBLIC_24H_SWR_7D,
         },
       },
     );

--- a/src/app/api/movies/genres/route.ts
+++ b/src/app/api/movies/genres/route.ts
@@ -11,6 +11,7 @@ import {
   ERROR_CODE,
   SEARCH_ERROR_MESSAGES,
   GENRE_NAME_OVERRIDES,
+  CACHE_CONTROL,
 } from '@/constants';
 
 export async function GET() {
@@ -31,7 +32,7 @@ export async function GET() {
       {
         status: HTTP_STATUS.OK,
         headers: {
-          'Cache-Control': 'public, s-maxage=604800',
+          'Cache-Control': CACHE_CONTROL.PUBLIC_7D,
         },
       },
     );

--- a/src/app/api/movies/route.ts
+++ b/src/app/api/movies/route.ts
@@ -14,6 +14,7 @@ import {
 import { moviesQuerySchema } from '@/schema/movies';
 import {
   HTTP_STATUS,
+  CACHE_CONTROL,
   PAGINATION,
   CACHE_DURATION_HOURS,
   NOW_PLAYING_CACHE_DURATION_HOURS,
@@ -419,8 +420,8 @@ export async function GET(request: Request) {
         status: HTTP_STATUS.OK,
         headers: {
           'Cache-Control': session
-            ? 'private, no-store'
-            : 'public, s-maxage=3600, stale-while-revalidate=86400',
+            ? CACHE_CONTROL.PRIVATE_NO_STORE
+            : CACHE_CONTROL.PUBLIC_1H_SWR_24H,
         },
       },
     );

--- a/src/app/api/movies/search/route.ts
+++ b/src/app/api/movies/search/route.ts
@@ -12,7 +12,12 @@ import { NextResponse } from 'next/server';
 import { searchMovies, discoverMovies } from '@/lib/tmdb/tmdb';
 import type { Movie, TMDbResponse } from '@/lib/types';
 import { searchQuerySchema } from '@/schema/search';
-import { HTTP_STATUS, ERROR_CODE, SEARCH_ERROR_MESSAGES } from '@/constants';
+import {
+  HTTP_STATUS,
+  ERROR_CODE,
+  SEARCH_ERROR_MESSAGES,
+  CACHE_CONTROL,
+} from '@/constants';
 
 /**
  * ジャンルIDをパースしてnumber配列に変換
@@ -142,8 +147,7 @@ export async function GET(request: Request) {
       {
         status: HTTP_STATUS.OK,
         headers: {
-          'Cache-Control':
-            'public, s-maxage=3600, stale-while-revalidate=86400',
+          'Cache-Control': CACHE_CONTROL.PUBLIC_1H_SWR_24H,
         },
       },
     );

--- a/src/app/api/watchlist/calendar/route.ts
+++ b/src/app/api/watchlist/calendar/route.ts
@@ -11,7 +11,12 @@ import {
   dbConnectionErrorResponse,
 } from '@/helpers/supabase';
 import { calendarQuerySchema } from '@/schema/calendar';
-import { HTTP_STATUS, ERROR_CODE, CALENDAR_ERROR_MESSAGES } from '@/constants';
+import {
+  HTTP_STATUS,
+  ERROR_CODE,
+  CALENDAR_ERROR_MESSAGES,
+  WATCHLIST_SELECT,
+} from '@/constants';
 
 export async function GET(request: Request) {
   try {
@@ -62,7 +67,7 @@ export async function GET(request: Request) {
     // ウォッチリストから指定月の映画を取得
     const { data, error } = await supabase
       .from('watchlist')
-      .select('id, tmdb_movie_id, title, poster_path, release_date, added_at')
+      .select(WATCHLIST_SELECT)
       .eq('user_id', session.user.id)
       .is('deleted_at', null)
       .not('release_date', 'is', null)

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from 'next/server';
 import {
   HTTP_STATUS,
   ERROR_CODE,
+  WATCHLIST_SELECT,
   WATCHLIST_ERROR_MESSAGES,
   WATCHLIST_SUCCESS_MESSAGES,
   RATE_LIMIT_ACTION,
@@ -106,7 +107,7 @@ export const GET = withAuth(
     // デフォルト: 追加日順（既存ロジック）
     let query = supabase
       .from('watchlist')
-      .select('id, tmdb_movie_id, title, poster_path, release_date, added_at')
+      .select(WATCHLIST_SELECT)
       .eq('user_id', session.user.id)
       .is('deleted_at', null);
 
@@ -192,7 +193,7 @@ export const POST = withAuth(
         poster_path: parsed.data.poster_path ?? null,
         release_date: parsed.data.release_date ?? null,
       })
-      .select('id, tmdb_movie_id, title, poster_path, release_date, added_at')
+      .select(WATCHLIST_SELECT)
       .single();
 
     if (insertError) {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -43,6 +43,22 @@ export const HTTP_STATUS = {
 } as const;
 
 /**
+ * Cache-Control ヘッダー値
+ */
+export const CACHE_CONTROL = {
+  /** CDN 1時間 / SWR 24時間 */
+  PUBLIC_1H_SWR_24H: 'public, s-maxage=3600, stale-while-revalidate=86400',
+  /** CDN 24時間 / SWR 7日 */
+  PUBLIC_24H_SWR_7D: 'public, s-maxage=86400, stale-while-revalidate=604800',
+  /** CDN 7日 */
+  PUBLIC_7D: 'public, s-maxage=604800',
+  /** 認証時: キャッシュ無効 */
+  PRIVATE_NO_STORE: 'private, no-store',
+  /** エラー等: キャッシュ無効 */
+  NO_STORE: 'no-store',
+} as const;
+
+/**
  * APIエラーコード
  */
 export const ERROR_CODE = {

--- a/src/constants/dismissedMovies.ts
+++ b/src/constants/dismissedMovies.ts
@@ -4,6 +4,12 @@
 
 import { errorMessage, successMessage } from './common';
 
+/**
+ * 興味なし映画取得SELECTカラム
+ */
+export const DISMISSED_MOVIES_SELECT =
+  'id, tmdb_movie_id, title, poster_path, genre_ids, created_at';
+
 const TARGET = '興味なしリスト';
 
 /**

--- a/src/constants/favorites.ts
+++ b/src/constants/favorites.ts
@@ -15,6 +15,12 @@ export const FAVORITES_DEFAULT_LIMIT = 20;
 export const FAVORITES_MAX_LIMIT = 50;
 
 /**
+ * お気に入り取得SELECTカラム
+ */
+export const FAVORITES_SELECT =
+  'id, tmdb_movie_id, title, poster_path, release_date, rating, added_at';
+
+/**
  * お気に入り評価の最小値
  */
 export const FAVORITES_RATING_MIN = 1;

--- a/src/constants/watchlist.ts
+++ b/src/constants/watchlist.ts
@@ -14,6 +14,12 @@ export const WATCHLIST_DEFAULT_LIMIT = 20;
  */
 export const WATCHLIST_MAX_LIMIT = 50;
 
+/**
+ * ウォッチリスト取得SELECTカラム
+ */
+export const WATCHLIST_SELECT =
+  'id, tmdb_movie_id, title, poster_path, release_date, added_at';
+
 const TARGET = 'ウォッチリスト';
 
 /**


### PR DESCRIPTION
## 概要

ハードコード→constants 移行の**第3弾（C+D）**。並列2エージェントで独立ファイル群を同時に移行しました（互いに非重複）。

- **C（Cache-Control）**: movies/awards 系ルートの `Cache-Control` 直値を `api.ts` の `CACHE_CONTROL` に集約
- **D（SELECT）**: favorites/watchlist/dismissed の SELECT カラム文字列を各ドメイン `*_SELECT` に集約

いずれも**文字列値（カラム順含む）は完全維持＝挙動不変**です。

## ロードマップ

該当なし（リファクタ／設定集約）

## レビューポイント

- 新規定数: `CACHE_CONTROL`（api.ts、5種）／ `FAVORITES_SELECT`（favorites.ts）／ `WATCHLIST_SELECT`（watchlist.ts）／ `DISMISSED_MOVIES_SELECT`（dismissedMovies.ts）
- 10ルートの直値を共有定数へ置換
- `favorites/route.ts` の件数専用 `select('id', { count })`（#324で最小化済み）は全カラムSELECTとは別物のため**対象外**（正しく除外）

## テスト

- 影響領域 **16 スイート / 217 テスト パス**
- 全体 `tsc --noEmit` **0 エラー**、eslint（exit 0）・prettier check クリーン
- 検証: 対象ルートに raw Cache-Control / SELECT 文字列が**残存0件**、定数値が元の文字列と完全一致することを grep で確認

## 補足

残りは **E（その他の設定値: TMDB_GENRE_MAP・BATCH_SIZE・year範囲・DEFAULT_MODEL・release_type 等）** を後続PRで対応します。
