### PR TITLE
refactor(constants): その他の設定値を constants に集約（ハードコード移行E）

### DIFF
--- a/src/app/api/awards/route.ts
+++ b/src/app/api/awards/route.ts
@@ -12,6 +12,7 @@ import {
   HTTP_STATUS,
   ERROR_CODE,
   AWARD_DEFINITIONS,
+  AWARD_YEAR_RANGE,
   AWARDS_MESSAGES,
   RATE_LIMIT_ACTION,
   RATE_LIMIT_CONFIG,
@@ -95,13 +96,18 @@ export async function GET(request: Request) {
 
     const year = Number(yearParam);
 
-    if (!yearParam || isNaN(year) || year < 1900 || year > 2100) {
+    if (
+      !yearParam ||
+      isNaN(year) ||
+      year < AWARD_YEAR_RANGE.MIN ||
+      year > AWARD_YEAR_RANGE.MAX
+    ) {
       return NextResponse.json(
         {
           success: false,
           error: {
             code: ERROR_CODE.VALIDATION_ERROR,
-            message: 'yearパラメータは必須です（1900〜2100の数値）',
+            message: `yearパラメータは必須です（${AWARD_YEAR_RANGE.MIN}〜${AWARD_YEAR_RANGE.MAX}の数値）`,
           },
         },
         { status: HTTP_STATUS.BAD_REQUEST },

--- a/src/app/api/cron/sync-award-movies/route.ts
+++ b/src/app/api/cron/sync-award-movies/route.ts
@@ -14,7 +14,12 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
-import { HTTP_STATUS, ERROR_CODE, CRON_ERROR_MESSAGES } from '@/constants';
+import {
+  HTTP_STATUS,
+  ERROR_CODE,
+  CRON_ERROR_MESSAGES,
+  AWARD_YEAR_RANGE,
+} from '@/constants';
 import { verifyCronAuth } from '@/helpers/cronAuth';
 import { handleRouteError } from '@/helpers/routeError';
 import {
@@ -39,14 +44,16 @@ export async function GET(request: NextRequest) {
     const targetYear = yearParam ? Number(yearParam) : undefined;
     if (
       yearParam &&
-      (isNaN(targetYear!) || targetYear! < 1900 || targetYear! > 2100)
+      (isNaN(targetYear!) ||
+        targetYear! < AWARD_YEAR_RANGE.MIN ||
+        targetYear! > AWARD_YEAR_RANGE.MAX)
     ) {
       return NextResponse.json(
         {
           success: false,
           error: {
             code: ERROR_CODE.VALIDATION_ERROR,
-            message: 'yearパラメータは1900〜2100の数値で指定してください',
+            message: `yearパラメータは${AWARD_YEAR_RANGE.MIN}〜${AWARD_YEAR_RANGE.MAX}の数値で指定してください`,
           },
         },
         { status: HTTP_STATUS.BAD_REQUEST },

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -15,7 +15,7 @@
 
 import { NextResponse } from 'next/server';
 
-import { IN_MEMORY_RATE_LIMIT } from '@/constants';
+import { HTTP_STATUS, IN_MEMORY_RATE_LIMIT } from '@/constants';
 import { createInMemoryRateLimiter } from '@/lib/rateLimit/inMemoryRateLimit';
 
 /**
@@ -23,9 +23,6 @@ import { createInMemoryRateLimiter } from '@/lib/rateLimit/inMemoryRateLimit';
  * これを超えるレポートは中身を読まずに破棄する（メモリ枯渇・DoS 対策）。
  */
 const MAX_BODY_BYTES = 16 * 1024; // 16KB
-
-/** 正常受信時のレスポンス（本文不要のため 204）。 */
-const NO_CONTENT = 204;
 
 /**
  * IP 単位のレート制限（インメモリ）。
@@ -119,7 +116,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     // レート制限（超過分は処理・ログせず破棄）。CSP レポートは大量に届きうるため
     // インメモリで軽量にスロットリングする（best-effort）。204 を維持する。
     if (!rateLimiter.check(getClientIp(request))) {
-      return new NextResponse(null, { status: NO_CONTENT });
+      return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT });
     }
 
     // 本文サイズ上限チェック（Content-Length が信頼できない場合も後段の
@@ -127,12 +124,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     // 上限超過として扱い、中身を読まずに破棄する（防御的）。
     const contentLength = Number(request.headers.get('content-length') ?? '0');
     if (!Number.isFinite(contentLength) || contentLength > MAX_BODY_BYTES) {
-      return new NextResponse(null, { status: NO_CONTENT });
+      return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT });
     }
 
     const raw = await request.text();
     if (raw.length === 0 || raw.length > MAX_BODY_BYTES) {
-      return new NextResponse(null, { status: NO_CONTENT });
+      return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT });
     }
 
     let payload: unknown;
@@ -140,7 +137,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       payload = JSON.parse(raw);
     } catch {
       // 不正な JSON は破棄（悪用・誤送信対策）。
-      return new NextResponse(null, { status: NO_CONTENT });
+      return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT });
     }
 
     logReports(payload);
@@ -150,5 +147,5 @@ export async function POST(request: Request): Promise<NextResponse> {
     console.error('[csp-report] failed to process report:', error);
   }
 
-  return new NextResponse(null, { status: NO_CONTENT });
+  return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT });
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -28,6 +28,8 @@ export const HTTP_STATUS = {
   OK: 200,
   /** 成功（リソース作成） */
   CREATED: 201,
+  /** 成功（本文なし） */
+  NO_CONTENT: 204,
   /** クライアントエラー（バリデーション等） */
   BAD_REQUEST: 400,
   /** 認証エラー */

--- a/src/constants/awards.ts
+++ b/src/constants/awards.ts
@@ -111,6 +111,29 @@ export const AWARD_DEFINITIONS = {
 } as const satisfies Record<string, AwardDefinition>;
 
 /**
+ * OpenAI からの受賞作品取得リトライ最大回数
+ */
+export const AWARDS_MAX_RETRIES = 3;
+
+/**
+ * 受賞作品の公開年許容差（この差を超える場合は前年に補正）
+ */
+export const AWARDS_YEAR_MATCH_TOLERANCE = 2;
+
+/**
+ * CRON同期の対象外とする賞
+ */
+export const AWARDS_EXCLUDED = ['japan_academy_awards'] as const;
+
+/**
+ * 受賞年バリデーション範囲
+ */
+export const AWARD_YEAR_RANGE = {
+  MIN: 1900,
+  MAX: 2100,
+} as const;
+
+/**
  * 受賞作品ページのメッセージ
  */
 export const AWARDS_MESSAGES = {

--- a/src/constants/movies.ts
+++ b/src/constants/movies.ts
@@ -39,24 +39,32 @@ export const MOVIES_FETCH_MONTHS_AHEAD = 3;
 export const NOW_SHOWING_MONTHS_BACK = 2;
 
 /**
+ * リリースタイプ値（このファイル内のリリースタイプの単一ソース）
+ */
+export const RELEASE_TYPE = {
+  THEATRICAL: 'theatrical',
+  STREAMING: 'streaming',
+} as const;
+
+/**
  * リリースタイプ選択肢
  */
 export const RELEASE_TYPE_OPTIONS = [
-  { label: '劇場公開', value: 'theatrical' },
-  { label: 'ストリーミング', value: 'streaming' },
+  { label: '劇場公開', value: RELEASE_TYPE.THEATRICAL },
+  { label: 'ストリーミング', value: RELEASE_TYPE.STREAMING },
 ] as const;
 
 /**
  * デフォルトリリースタイプ
  */
-export const DEFAULT_RELEASE_TYPE = 'theatrical' as const;
+export const DEFAULT_RELEASE_TYPE = RELEASE_TYPE.THEATRICAL;
 
 /**
  * TMDb APIのwith_release_typeパラメータへのマッピング
  */
 export const RELEASE_TYPE_MAP: Record<string, string> = {
-  theatrical: '2|3',
-  streaming: '4',
+  [RELEASE_TYPE.THEATRICAL]: '2|3',
+  [RELEASE_TYPE.STREAMING]: '4',
 };
 
 /**

--- a/src/constants/nowShowing.ts
+++ b/src/constants/nowShowing.ts
@@ -10,6 +10,11 @@ import { successMessage } from './common';
 export const NOW_SHOWING_DISPLAY_COUNT = 10;
 
 /**
+ * 劇場公開中の人気映画キャッシュの再検証間隔（秒） — 1時間
+ */
+export const NOW_SHOWING_REVALIDATE_SECONDS = 3600;
+
+/**
  * 劇場公開中の人気映画セクションタイトル
  */
 export const NOW_SHOWING_SECTION_TITLE = '劇場公開中の人気作品';

--- a/src/constants/openai.ts
+++ b/src/constants/openai.ts
@@ -3,9 +3,11 @@
  */
 
 /**
- * OpenAI temperature設定
+ * OpenAI設定
  */
 export const OPENAI_CONFIG = {
+  /** デフォルトのモデル名（OPENAI_MODEL 未設定時に使用） */
+  DEFAULT_MODEL: 'gpt-4o-mini',
   /** レコメンド生成時のtemperature */
   RECOMMENDATIONS_TEMPERATURE: 0.8,
   /** タイトルサジェスト時のtemperature */

--- a/src/constants/otp.ts
+++ b/src/constants/otp.ts
@@ -41,6 +41,11 @@ export const OTP_CONFIG = {
 } as const;
 
 /**
+ * タイミング攻撃・メールアドレス列挙防止用のランダム遅延（ミリ秒）
+ */
+export const OTP_RANDOM_DELAY = { MIN_MS: 200, RANGE_MS: 300 } as const;
+
+/**
  * OTPエラーメッセージ
  */
 export const OTP_ERROR_MESSAGES = {

--- a/src/constants/recommendations.ts
+++ b/src/constants/recommendations.ts
@@ -32,6 +32,11 @@ export const RECOMMENDATIONS_YEAR_MATCH_TOLERANCE = 1;
 export const RECOMMENDATIONS_ACTIVE_USER_DAYS = 3;
 
 /**
+ * レコメンド生成CRONのバッチサイズ（同時処理するユーザー数の上限）
+ */
+export const RECOMMENDATIONS_BATCH_SIZE = 5;
+
+/**
  * レコメンド手動更新設定
  */
 export const RECOMMENDATION_REFRESH = {

--- a/src/constants/tmdb.ts
+++ b/src/constants/tmdb.ts
@@ -20,3 +20,31 @@ export const GENRE_NAME_OVERRIDES: Record<string, string> = {
   謎: 'ミステリー',
   西洋: '西部劇',
 };
+
+/** TMDbジャンルID → ジャンル名マッピング */
+export const TMDB_GENRE_MAP: Record<number, string> = {
+  28: 'アクション',
+  12: 'アドベンチャー',
+  16: 'アニメーション',
+  35: 'コメディ',
+  80: '犯罪',
+  99: 'ドキュメンタリー',
+  18: 'ドラマ',
+  10751: 'ファミリー',
+  14: 'ファンタジー',
+  36: '歴史',
+  27: 'ホラー',
+  10402: '音楽',
+  9648: 'ミステリー',
+  10749: 'ロマンス',
+  878: 'SF',
+  10770: 'テレビ映画',
+  53: 'スリラー',
+  10752: '戦争',
+  37: '西部劇',
+};
+
+/**
+ * TMDb Discover APIのsort_byパラメータ値
+ */
+export const TMDB_SORT_BY = { POPULARITY_DESC: 'popularity.desc' } as const;

--- a/src/lib/api/nowShowing/nowShowing.server.ts
+++ b/src/lib/api/nowShowing/nowShowing.server.ts
@@ -5,6 +5,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { unstable_cache } from 'next/cache';
 
+import { NOW_SHOWING_REVALIDATE_SECONDS } from '@/constants/nowShowing';
 import type { NowShowingMovie } from '@/lib/types';
 
 /**
@@ -44,5 +45,5 @@ async function fetchNowShowingMovies(): Promise<NowShowingMovie[]> {
 export const getNowShowingMovies = unstable_cache(
   fetchNowShowingMovies,
   ['now-showing-movies'],
-  { revalidate: 3600 },
+  { revalidate: NOW_SHOWING_REVALIDATE_SECONDS },
 );

--- a/src/lib/awards/syncAwardMoviesService.ts
+++ b/src/lib/awards/syncAwardMoviesService.ts
@@ -11,7 +11,13 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-import { AWARD_DEFINITIONS, type AwardName } from '@/constants/awards';
+import {
+  AWARD_DEFINITIONS,
+  AWARDS_EXCLUDED,
+  AWARDS_MAX_RETRIES,
+  AWARDS_YEAR_MATCH_TOLERANCE,
+  type AwardName,
+} from '@/constants/awards';
 import type { OpenAiAwardItem } from '@/schema/awards';
 import { fetchEigaOscarAwards } from '@/lib/eiga/fetchEigaOscarAwards';
 import {
@@ -52,7 +58,7 @@ interface CronSkipped {
 export type SyncAwardMoviesCronResult = CronSuccess | CronError | CronSkipped;
 
 /** CRON同期対象外の賞 */
-const EXCLUDED_AWARDS: ReadonlySet<string> = new Set(['japan_academy_awards']);
+const EXCLUDED_AWARDS: ReadonlySet<string> = new Set(AWARDS_EXCLUDED);
 
 /**
  * 現在月に該当する賞を取得
@@ -222,7 +228,7 @@ async function fetchAwardItemsViaWikipedia(
   currentYear: number,
 ): Promise<OpenAiAwardItem[]> {
   const allAiItems: OpenAiAwardItem[] = [];
-  const maxRetries = 3;
+  const maxRetries = AWARDS_MAX_RETRIES;
 
   const wikipediaTitle = buildWikipediaTitle(currentYear, awardDef);
   const articleText = await fetchWikipediaArticle(wikipediaTitle);
@@ -261,7 +267,7 @@ async function fetchAwardItemsViaWikipedia(
         return false;
       });
       const corrected = verified.map((item) => {
-        if (Math.abs(item.year - currentYear) > 2) {
+        if (Math.abs(item.year - currentYear) > AWARDS_YEAR_MATCH_TOLERANCE) {
           console.warn(
             `Year corrected: "${item.title_ja}" year=${item.year} → ${currentYear - 1}`,
           );

--- a/src/lib/eiga/syncEigaMovies.ts
+++ b/src/lib/eiga/syncEigaMovies.ts
@@ -4,7 +4,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-import { EXCLUDED_KEYWORD_IDS } from '@/constants/movies';
+import { EXCLUDED_KEYWORD_IDS, RELEASE_TYPE } from '@/constants/movies';
 import { EIGA_SCORING } from '@/constants/eiga';
 import { getMovieKeywordIds, searchMovies } from '@/lib/tmdb/tmdb';
 import type { Movie } from '@/lib/types';
@@ -226,7 +226,7 @@ export async function syncEigaMovies(): Promise<SyncResult> {
           vote_average: bestMatch.vote_average,
           popularity: bestMatch.popularity,
           genre_ids: bestMatch.genre_ids,
-          release_type: 'theatrical',
+          release_type: RELEASE_TYPE.THEATRICAL,
           is_revival: revival,
           cached_at: now,
         },

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -4,7 +4,7 @@
 
 import OpenAI from 'openai';
 
-const DEFAULT_MODEL = 'gpt-4o-mini';
+import { OPENAI_CONFIG } from '@/constants';
 
 /**
  * OpenAIクライアントを作成
@@ -25,5 +25,5 @@ export function createOpenAIClient(): OpenAI | null {
  * 使用するOpenAIモデル名を取得
  */
 export function getOpenAIModel(): string {
-  return process.env.OPENAI_MODEL || DEFAULT_MODEL;
+  return process.env.OPENAI_MODEL || OPENAI_CONFIG.DEFAULT_MODEL;
 }

--- a/src/lib/openai/generateRecommendations.ts
+++ b/src/lib/openai/generateRecommendations.ts
@@ -6,6 +6,7 @@ import {
   RECOMMENDATIONS_MAX_COUNT,
   RECOMMENDATIONS_YEAR_MATCH_TOLERANCE,
   OPENAI_CONFIG,
+  TMDB_GENRE_MAP,
 } from '@/constants';
 import { searchMovies } from '@/lib/tmdb/tmdb';
 import type { Movie } from '@/lib/types';
@@ -15,29 +16,6 @@ import {
 } from '@/schema/recommendations';
 
 import { createOpenAIClient, getOpenAIModel } from './client';
-
-/** TMDbジャンルID → ジャンル名マッピング */
-const TMDB_GENRE_MAP: Record<number, string> = {
-  28: 'アクション',
-  12: 'アドベンチャー',
-  16: 'アニメーション',
-  35: 'コメディ',
-  80: '犯罪',
-  99: 'ドキュメンタリー',
-  18: 'ドラマ',
-  10751: 'ファミリー',
-  14: 'ファンタジー',
-  36: '歴史',
-  27: 'ホラー',
-  10402: '音楽',
-  9648: 'ミステリー',
-  10749: 'ロマンス',
-  878: 'SF',
-  10770: 'テレビ映画',
-  53: 'スリラー',
-  10752: '戦争',
-  37: '西部劇',
-};
 
 /** お気に入り映画の情報 */
 export interface FavoriteMovie {

--- a/src/lib/otp/randomDelay.ts
+++ b/src/lib/otp/randomDelay.ts
@@ -5,15 +5,13 @@
  * 応答時間分布を近づけてメールアドレスの存在を推定されにくくする。
  */
 
-/** ランダム遅延の最小値（ミリ秒） */
-const RANDOM_DELAY_MIN_MS = 200;
-/** ランダム遅延の振れ幅（ミリ秒） */
-const RANDOM_DELAY_RANGE_MS = 300;
+import { OTP_RANDOM_DELAY } from '@/constants';
 
 /**
  * 200〜500ms のランダムな遅延を挿入する。
  */
 export async function randomDelay(): Promise<void> {
-  const delay = RANDOM_DELAY_MIN_MS + Math.random() * RANDOM_DELAY_RANGE_MS;
+  const delay =
+    OTP_RANDOM_DELAY.MIN_MS + Math.random() * OTP_RANDOM_DELAY.RANGE_MS;
   await new Promise((resolve) => setTimeout(resolve, delay));
 }

--- a/src/lib/recommendations/generateRecommendationsService.test.ts
+++ b/src/lib/recommendations/generateRecommendationsService.test.ts
@@ -12,6 +12,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   RECOMMENDATIONS_MAX_COUNT,
   RECOMMENDATIONS_GENERATION_BUFFER,
+  RECOMMENDATIONS_BATCH_SIZE,
 } from '@/constants';
 
 import {
@@ -21,7 +22,6 @@ import {
   generateRecommendationsWithRetry,
   upsertRecommendations,
   processUserRecommendations,
-  BATCH_SIZE,
 } from './generateRecommendationsService';
 
 // --- Mocks ---
@@ -158,9 +158,9 @@ describe('generateRecommendationsService', () => {
     jest.restoreAllMocks();
   });
 
-  describe('BATCH_SIZE', () => {
+  describe('RECOMMENDATIONS_BATCH_SIZE', () => {
     it('バッチサイズが5であること', () => {
-      expect(BATCH_SIZE).toBe(5);
+      expect(RECOMMENDATIONS_BATCH_SIZE).toBe(5);
     });
   });
 

--- a/src/lib/recommendations/generateRecommendationsService.ts
+++ b/src/lib/recommendations/generateRecommendationsService.ts
@@ -10,6 +10,7 @@ import {
   RECOMMENDATIONS_MAX_RETRIES,
   RECOMMENDATIONS_GENERATION_BUFFER,
   RECOMMENDATIONS_ACTIVE_USER_DAYS,
+  RECOMMENDATIONS_BATCH_SIZE,
   CRON_ERROR_MESSAGES,
 } from '@/constants';
 import {
@@ -331,9 +332,6 @@ export async function processUserRecommendations(
   return { status: 'processed', recommendationCount: resolved.length };
 }
 
-/** バッチサイズ（同時処理するユーザー数の上限） */
-export const BATCH_SIZE = 5;
-
 /**
  * レコメンド生成CRONのメイン処理
  * ユーザーをバッチ単位（5件ずつ）で並行処理し、リソース負荷を制限する
@@ -351,11 +349,13 @@ export async function executeGenerateRecommendationsCron(
   let skippedUsers = 0;
   let totalRecommendations = 0;
 
-  const totalBatches = Math.ceil(activeUserIds.length / BATCH_SIZE);
+  const totalBatches = Math.ceil(
+    activeUserIds.length / RECOMMENDATIONS_BATCH_SIZE,
+  );
 
-  for (let i = 0; i < activeUserIds.length; i += BATCH_SIZE) {
-    const batchIndex = Math.floor(i / BATCH_SIZE) + 1;
-    const batch = activeUserIds.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < activeUserIds.length; i += RECOMMENDATIONS_BATCH_SIZE) {
+    const batchIndex = Math.floor(i / RECOMMENDATIONS_BATCH_SIZE) + 1;
+    const batch = activeUserIds.slice(i, i + RECOMMENDATIONS_BATCH_SIZE);
 
     console.log(
       `Processing batch ${batchIndex}/${totalBatches}... (${batch.length} users)`,

--- a/src/lib/sync/syncNowPlayingMovies.ts
+++ b/src/lib/sync/syncNowPlayingMovies.ts
@@ -11,6 +11,7 @@ import {
   MIN_POPULARITY,
   MIN_VOTE_AVERAGE,
   NOW_PLAYING_SYNC_MAX_PAGES,
+  RELEASE_TYPE,
 } from '@/constants/movies';
 import { getMovieKeywordIds, getNowPlayingMovies } from '@/lib/tmdb/tmdb';
 import type { Movie } from '@/lib/types';
@@ -139,7 +140,7 @@ export async function syncNowPlayingMovies(): Promise<NowPlayingSyncResult> {
           vote_average: movie.vote_average,
           popularity: movie.popularity,
           genre_ids: movie.genre_ids,
-          release_type: 'theatrical',
+          release_type: RELEASE_TYPE.THEATRICAL,
           is_now_playing: true,
           cached_at: now,
         },

--- a/src/lib/sync/syncNowShowingMovies.ts
+++ b/src/lib/sync/syncNowShowingMovies.ts
@@ -9,6 +9,7 @@ import {
   NOW_SHOWING_RELEASE_DATE_RANGE_MONTHS,
 } from '@/constants/movies';
 import { NOW_SHOWING_DISPLAY_COUNT } from '@/constants/nowShowing';
+import { TMDB_SORT_BY } from '@/constants/tmdb';
 import { discoverMovies } from '@/lib/tmdb/tmdb';
 
 /**
@@ -57,7 +58,7 @@ export async function syncNowShowingMovies(): Promise<NowShowingSyncResult> {
   );
 
   const response = await discoverMovies({
-    sort_by: 'popularity.desc',
+    sort_by: TMDB_SORT_BY.POPULARITY_DESC,
     with_release_type: RELEASE_TYPE_MAP.theatrical,
     'release_date.gte': formatDate(rangeStart),
     'release_date.lte': formatDate(now),

--- a/src/lib/tmdb/tmdb.ts
+++ b/src/lib/tmdb/tmdb.ts
@@ -7,6 +7,7 @@ import {
   PAGINATION,
   TMDB_ENDPOINTS,
   TMDB_RETRY_CONFIG,
+  TMDB_SORT_BY,
 } from '@/constants';
 import type {
   Movie,
@@ -320,7 +321,7 @@ export async function getMoviesByGenre(
       params: {
         with_genres: genreId,
         page: validatePage(page),
-        sort_by: 'popularity.desc',
+        sort_by: TMDB_SORT_BY.POPULARITY_DESC,
       },
     },
   );


### PR DESCRIPTION
## 概要

ハードコード→constants 移行の**最終弾（E: その他の設定値）**。独立した3領域を**3並列エージェント**で同時実装しました（共有定数ファイル非重複）。すべて値・挙動不変です。

## ロードマップ

該当なし（リファクタ／設定集約）

## レビューポイント

- **tmdb.ts**: `TMDB_GENRE_MAP`（19件を lib から移設）／ `TMDB_SORT_BY`（`popularity.desc`）
- **movies.ts**: `RELEASE_TYPE` を追加し、**単一ソース化**（`DEFAULT_RELEASE_TYPE` / `RELEASE_TYPE_OPTIONS` / `RELEASE_TYPE_MAP` が `RELEASE_TYPE` を参照。pre-commit レビュー指摘の値重複を解消）。sync の `'theatrical'` 書き込みも `RELEASE_TYPE.THEATRICAL` に
- **openai.ts**: `OPENAI_CONFIG.DEFAULT_MODEL` ／ **recommendations.ts**: `RECOMMENDATIONS_BATCH_SIZE`（旧 `BATCH_SIZE` の後方互換 re-export は撤去し、テストを定数 import に更新）／ **otp.ts**: `OTP_RANDOM_DELAY`
- **awards.ts**: `AWARDS_MAX_RETRIES` / `AWARDS_YEAR_MATCH_TOLERANCE` / `AWARDS_EXCLUDED` / `AWARD_YEAR_RANGE`（year範囲＋メッセージ。表示テキストは同一維持）
- **nowShowing.ts**: `NOW_SHOWING_REVALIDATE_SECONDS` ／ **api.ts**: `HTTP_STATUS.NO_CONTENT`(204)（csp-report のローカル定義を置換）

## 除外（今回スコープ外・意図的）

cron `maxDuration`（Next.js route segment config は静的解析が必要でimport定数だと効かないリスク）／ CSP文字列（next.config と単一ソース共有）／ `getClientIp`（ヘルパー共通化が適切＝別Issue向き）／ `API_ENDPOINTS` の大量展開（~30パス、別途大きい作業）／ Wikipedia内部パラメータ

## テスト

- E影響領域 **46 スイート / 558 テスト パス**（movies関連含めると590）
- 全体 `tsc --noEmit` **0 エラー**、eslint（exit 0）・prettier クリーン
- 検証: 旧ローカル定義（`BATCH_SIZE` re-export・生 `gpt-4o-mini` 等）の残存なしを grep で確認
