### PR TITLE
refactor(constants): 内部APIパスを API_ENDPOINTS に集約（Closes #450）

### DIFF
--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -1,10 +1,71 @@
 /**
  * 内部APIエンドポイント定数
+ *
+ * `src/lib/api` の client 群が使う `/api/...` パスの単一ソース。
+ * 静的パスは定数、パラメータ付きの動的パスはビルダー関数で表現する。
  */
 
 export const API_ENDPOINTS = {
+  // --- 認証 ---
   /** OTP検証 */
   OTP_VERIFY: '/api/auth/otp/verify',
   /** OTP送信 */
   OTP_SEND: '/api/auth/otp/send',
+  /** 新規登録 */
+  AUTH_REGISTER: '/api/auth/register',
+
+  // --- ユーザー ---
+  /** プロフィール更新 */
+  USER_PROFILE: '/api/user/profile',
+  /** 設定取得・更新 */
+  USER_SETTINGS: '/api/user/settings',
+  /** パスワード変更 */
+  USER_CHANGE_PASSWORD: '/api/user/change-password',
+
+  // --- お気に入り ---
+  /** お気に入り一覧・追加 */
+  FAVORITES: '/api/favorites',
+  /** お気に入り個別（更新・削除） */
+  favoriteById: (id: string) => `/api/favorites/${id}`,
+
+  // --- ウォッチリスト ---
+  /** ウォッチリスト一覧・追加 */
+  WATCHLIST: '/api/watchlist',
+  /** ウォッチリスト個別（削除） */
+  watchlistById: (id: string) => `/api/watchlist/${id}`,
+  /** ウォッチリストのカレンダー */
+  WATCHLIST_CALENDAR: '/api/watchlist/calendar',
+
+  // --- 興味なし ---
+  /** 興味なし一覧・追加 */
+  DISMISSED_MOVIES: '/api/dismissed-movies',
+  /** 興味なし削除（tmdb_movie_id 指定） */
+  dismissedMovieByTmdbId: (tmdbMovieId: number) =>
+    `/api/dismissed-movies?tmdb_movie_id=${tmdbMovieId}`,
+
+  // --- 映画 ---
+  /** 映画一覧 */
+  MOVIES: '/api/movies',
+  /** 映画詳細 */
+  movieById: (movieId: number) => `/api/movies/${movieId}`,
+  /** 映画検索 */
+  MOVIES_SEARCH: '/api/movies/search',
+  /** ジャンル一覧 */
+  MOVIES_GENRES: '/api/movies/genres',
+  /** 原題提案 */
+  MOVIES_SUGGEST_TITLE: '/api/movies/suggest-title',
+
+  // --- 受賞・劇場・その他 ---
+  /** 受賞作品 */
+  AWARDS: '/api/awards',
+  /** 劇場一覧 */
+  THEATERS: '/api/theaters',
+  /** 劇場詳細（slug 指定） */
+  theaterBySlug: (slug: string) => `/api/theaters/${slug}`,
+  /** 保存フィルタ取得・更新 */
+  FILTERS: '/api/filters',
+  /** レコメンド手動更新 */
+  RECOMMENDATIONS_REFRESH: '/api/recommendations/refresh',
+  /** レコメンド更新回数 */
+  RECOMMENDATIONS_REFRESH_COUNT: '/api/recommendations/refresh-count',
 } as const;

--- a/src/lib/api/auth/auth.ts
+++ b/src/lib/api/auth/auth.ts
@@ -33,7 +33,7 @@ export async function registerUser(
   data: RegisterRequest,
 ): Promise<RegisterResponse> {
   const response = await axiosInstance.post<RegisterResponse>(
-    '/api/auth/register',
+    API_ENDPOINTS.AUTH_REGISTER,
     data,
   );
   return response.data;
@@ -97,7 +97,7 @@ export async function changePassword(
   data: ChangePasswordRequest,
 ): Promise<ChangePasswordResponse> {
   const response = await axiosInstance.post<ChangePasswordResponse>(
-    '/api/user/change-password',
+    API_ENDPOINTS.USER_CHANGE_PASSWORD,
     data,
   );
   return response.data;

--- a/src/lib/api/awards/awards.ts
+++ b/src/lib/api/awards/awards.ts
@@ -2,6 +2,7 @@
  * 受賞作品API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import type { AwardsApiResponse } from '@/features/awards/types';
 import { axiosInstance } from '@/lib/axios/axios';
 
@@ -11,8 +12,11 @@ import { axiosInstance } from '@/lib/axios/axios';
 export async function getAwards(
   year: number,
 ): Promise<AwardsApiResponse['data']> {
-  const response = await axiosInstance.get<AwardsApiResponse>('/api/awards', {
-    params: { year },
-  });
+  const response = await axiosInstance.get<AwardsApiResponse>(
+    API_ENDPOINTS.AWARDS,
+    {
+      params: { year },
+    },
+  );
   return response.data.data;
 }

--- a/src/lib/api/calendar/calendar.ts
+++ b/src/lib/api/calendar/calendar.ts
@@ -2,6 +2,7 @@
  * カレンダーAPI クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 
 /**
@@ -50,7 +51,7 @@ export async function getCalendarMovies(
   params: GetCalendarRequest = {},
 ): Promise<GetCalendarResponse> {
   const response = await axiosInstance.get<GetCalendarResponse>(
-    '/api/watchlist/calendar',
+    API_ENDPOINTS.WATCHLIST_CALENDAR,
     { params },
   );
   return response.data;

--- a/src/lib/api/dismissedMovies/dismissedMovies.ts
+++ b/src/lib/api/dismissedMovies/dismissedMovies.ts
@@ -2,6 +2,7 @@
  * 興味なし映画API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 
 /**
@@ -54,7 +55,7 @@ export interface GetDismissedMoviesResponse {
  */
 export async function getDismissedMovies(): Promise<DismissedMovieItem[]> {
   const response = await axiosInstance.get<GetDismissedMoviesResponse>(
-    '/api/dismissed-movies',
+    API_ENDPOINTS.DISMISSED_MOVIES,
   );
   return response.data.data;
 }
@@ -66,7 +67,7 @@ export async function addDismissedMovie(
   data: AddDismissedMovieRequest,
 ): Promise<AddDismissedMovieResponse> {
   const response = await axiosInstance.post<AddDismissedMovieResponse>(
-    '/api/dismissed-movies',
+    API_ENDPOINTS.DISMISSED_MOVIES,
     data,
   );
   return response.data;
@@ -76,7 +77,5 @@ export async function addDismissedMovie(
  * 興味なしから削除
  */
 export async function removeDismissedMovie(tmdbMovieId: number): Promise<void> {
-  await axiosInstance.delete(
-    `/api/dismissed-movies?tmdb_movie_id=${tmdbMovieId}`,
-  );
+  await axiosInstance.delete(API_ENDPOINTS.dismissedMovieByTmdbId(tmdbMovieId));
 }

--- a/src/lib/api/favorites/favorites.ts
+++ b/src/lib/api/favorites/favorites.ts
@@ -2,6 +2,7 @@
  * お気に入りAPI クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type {
   FavoritesAddFormData,
@@ -99,7 +100,7 @@ export async function getFavorites(
   params: GetFavoritesRequest = {},
 ): Promise<GetFavoritesResponse> {
   const response = await axiosInstance.get<GetFavoritesResponse>(
-    '/api/favorites',
+    API_ENDPOINTS.FAVORITES,
     { params },
   );
   return response.data;
@@ -115,7 +116,7 @@ export async function addFavorite(
   data: FavoritesAddFormData,
 ): Promise<AddFavoriteResponse> {
   const response = await axiosInstance.post<AddFavoriteResponse>(
-    '/api/favorites',
+    API_ENDPOINTS.FAVORITES,
     data,
   );
   return response.data;
@@ -133,7 +134,7 @@ export async function updateFavoriteRating(
   data: FavoritesUpdateFormData,
 ): Promise<UpdateFavoriteRatingResponse> {
   const response = await axiosInstance.patch<UpdateFavoriteRatingResponse>(
-    `/api/favorites/${id}`,
+    API_ENDPOINTS.favoriteById(id),
     data,
   );
   return response.data;
@@ -145,5 +146,5 @@ export async function updateFavoriteRating(
  * @param id - お気に入りID
  */
 export async function removeFavorite(id: string): Promise<void> {
-  await axiosInstance.delete(`/api/favorites/${id}`);
+  await axiosInstance.delete(API_ENDPOINTS.favoriteById(id));
 }

--- a/src/lib/api/filters/filters.ts
+++ b/src/lib/api/filters/filters.ts
@@ -2,6 +2,7 @@
  * フィルター条件保存API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { FilterConditions } from '@/schema/filters';
 
@@ -21,8 +22,9 @@ export interface GetSavedFilterResponse {
  * @returns フィルター条件（未保存の場合は空オブジェクト）
  */
 export async function getSavedFilter(): Promise<FilterConditions> {
-  const response =
-    await axiosInstance.get<GetSavedFilterResponse>('/api/filters');
+  const response = await axiosInstance.get<GetSavedFilterResponse>(
+    API_ENDPOINTS.FILTERS,
+  );
   return response.data.data.filter_conditions;
 }
 
@@ -32,5 +34,5 @@ export async function getSavedFilter(): Promise<FilterConditions> {
  * @param conditions - 保存するフィルター条件
  */
 export async function saveFilter(conditions: FilterConditions): Promise<void> {
-  await axiosInstance.put('/api/filters', conditions);
+  await axiosInstance.put(API_ENDPOINTS.FILTERS, conditions);
 }

--- a/src/lib/api/genres/genres.ts
+++ b/src/lib/api/genres/genres.ts
@@ -2,6 +2,7 @@
  * ジャンルAPI クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { Genre } from '@/lib/types';
 
@@ -19,7 +20,8 @@ export interface GetGenresResponse {
  * ジャンル一覧を取得
  */
 export async function getGenresApi(): Promise<GetGenresResponse> {
-  const response =
-    await axiosInstance.get<GetGenresResponse>('/api/movies/genres');
+  const response = await axiosInstance.get<GetGenresResponse>(
+    API_ENDPOINTS.MOVIES_GENRES,
+  );
   return response.data;
 }

--- a/src/lib/api/movies/movies.ts
+++ b/src/lib/api/movies/movies.ts
@@ -2,6 +2,7 @@
  * 映画API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { MovieDetail } from '@/lib/types';
 
@@ -89,10 +90,13 @@ export async function getMovies(
   params: GetMoviesRequest = {},
   options?: { signal?: AbortSignal },
 ): Promise<GetMoviesResponse> {
-  const response = await axiosInstance.get<GetMoviesResponse>('/api/movies', {
-    params,
-    signal: options?.signal,
-  });
+  const response = await axiosInstance.get<GetMoviesResponse>(
+    API_ENDPOINTS.MOVIES,
+    {
+      params,
+      signal: options?.signal,
+    },
+  );
   return response.data;
 }
 
@@ -114,7 +118,7 @@ export async function getMovieDetail(
   movieId: number,
 ): Promise<GetMovieDetailResponse> {
   const response = await axiosInstance.get<GetMovieDetailResponse>(
-    `/api/movies/${movieId}`,
+    API_ENDPOINTS.movieById(movieId),
   );
   return response.data;
 }

--- a/src/lib/api/recommendations/recommendations.ts
+++ b/src/lib/api/recommendations/recommendations.ts
@@ -2,6 +2,7 @@
  * レコメンド手動更新API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { Recommendation } from '@/schema/recommendations';
 
@@ -35,7 +36,7 @@ export async function refreshRecommendations(): Promise<
   RefreshRecommendationsResponse['data']
 > {
   const response = await axiosInstance.post<RefreshRecommendationsResponse>(
-    '/api/recommendations/refresh',
+    API_ENDPOINTS.RECOMMENDATIONS_REFRESH,
   );
   return response.data.data;
 }
@@ -45,7 +46,7 @@ export async function refreshRecommendations(): Promise<
  */
 export async function getRefreshCount(): Promise<RefreshCountResponse['data']> {
   const response = await axiosInstance.get<RefreshCountResponse>(
-    '/api/recommendations/refresh-count',
+    API_ENDPOINTS.RECOMMENDATIONS_REFRESH_COUNT,
   );
   return response.data.data;
 }

--- a/src/lib/api/search/search.ts
+++ b/src/lib/api/search/search.ts
@@ -2,6 +2,7 @@
  * 検索API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { Movie } from '@/lib/types';
 
@@ -54,7 +55,7 @@ export async function searchMoviesApi(
   options?: { signal?: AbortSignal },
 ): Promise<SearchMoviesResponse> {
   const response = await axiosInstance.get<SearchMoviesResponse>(
-    '/api/movies/search',
+    API_ENDPOINTS.MOVIES_SEARCH,
     {
       params,
       signal: options?.signal,

--- a/src/lib/api/theaters/theaters.ts
+++ b/src/lib/api/theaters/theaters.ts
@@ -2,6 +2,7 @@
  * 劇場API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import type {
   TheatersApiResponse,
   TheaterDetailApiResponse,
@@ -12,8 +13,9 @@ import { axiosInstance } from '@/lib/axios/axios';
  * 劇場一覧を取得する
  */
 export async function getTheaters(): Promise<TheatersApiResponse['data']> {
-  const response =
-    await axiosInstance.get<TheatersApiResponse>('/api/theaters');
+  const response = await axiosInstance.get<TheatersApiResponse>(
+    API_ENDPOINTS.THEATERS,
+  );
   return response.data.data;
 }
 
@@ -24,7 +26,7 @@ export async function getTheaterBySlug(
   slug: string,
 ): Promise<TheaterDetailApiResponse['data']> {
   const response = await axiosInstance.get<TheaterDetailApiResponse>(
-    `/api/theaters/${slug}`,
+    API_ENDPOINTS.theaterBySlug(slug),
   );
   return response.data.data;
 }

--- a/src/lib/api/titleSuggestion/titleSuggestion.ts
+++ b/src/lib/api/titleSuggestion/titleSuggestion.ts
@@ -2,6 +2,7 @@
  * 原題提案API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 
 /**
@@ -25,7 +26,7 @@ export async function suggestTitleApi(
   options?: { signal?: AbortSignal },
 ): Promise<TitleSuggestionResponse> {
   const response = await axiosInstance.get<TitleSuggestionResponse>(
-    '/api/movies/suggest-title',
+    API_ENDPOINTS.MOVIES_SUGGEST_TITLE,
     {
       params: { query },
       signal: options?.signal,

--- a/src/lib/api/user/user.ts
+++ b/src/lib/api/user/user.ts
@@ -2,6 +2,7 @@
  * ユーザー設定API クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type { UserSettings } from '@/schema/user';
 
@@ -19,7 +20,7 @@ export interface GetSettingsResponse {
  * @param name - 新しい表示名
  */
 export async function updateProfile(name: string): Promise<void> {
-  await axiosInstance.put('/api/user/profile', { name });
+  await axiosInstance.put(API_ENDPOINTS.USER_PROFILE, { name });
 }
 
 /**
@@ -28,8 +29,9 @@ export async function updateProfile(name: string): Promise<void> {
  * @returns ユーザー設定
  */
 export async function getSettings(): Promise<UserSettings> {
-  const response =
-    await axiosInstance.get<GetSettingsResponse>('/api/user/settings');
+  const response = await axiosInstance.get<GetSettingsResponse>(
+    API_ENDPOINTS.USER_SETTINGS,
+  );
   return response.data.data;
 }
 
@@ -41,7 +43,7 @@ export async function getSettings(): Promise<UserSettings> {
 export async function updateSettings(
   settings: Partial<UserSettings>,
 ): Promise<void> {
-  await axiosInstance.put('/api/user/settings', {
+  await axiosInstance.put(API_ENDPOINTS.USER_SETTINGS, {
     theme: settings.theme,
     notificationEnabled: settings.notificationEnabled,
   });

--- a/src/lib/api/watchlist/watchlist.ts
+++ b/src/lib/api/watchlist/watchlist.ts
@@ -2,6 +2,7 @@
  * ウォッチリストAPI クライアント
  */
 
+import { API_ENDPOINTS } from '@/constants';
 import { axiosInstance } from '@/lib/axios/axios';
 import type {
   WatchlistAddFormData,
@@ -66,7 +67,7 @@ export async function getWatchlist(
   params: GetWatchlistRequest = {},
 ): Promise<GetWatchlistResponse> {
   const response = await axiosInstance.get<GetWatchlistResponse>(
-    '/api/watchlist',
+    API_ENDPOINTS.WATCHLIST,
     { params },
   );
   return response.data;
@@ -82,7 +83,7 @@ export async function addWatchlist(
   data: WatchlistAddFormData,
 ): Promise<AddWatchlistResponse> {
   const response = await axiosInstance.post<AddWatchlistResponse>(
-    '/api/watchlist',
+    API_ENDPOINTS.WATCHLIST,
     data,
   );
   return response.data;
@@ -94,5 +95,5 @@ export async function addWatchlist(
  * @param id - ウォッチリストID
  */
 export async function removeWatchlist(id: string): Promise<void> {
-  await axiosInstance.delete(`/api/watchlist/${id}`);
+  await axiosInstance.delete(API_ENDPOINTS.watchlistById(id));
 }


### PR DESCRIPTION
## 概要

`src/lib/api` の client 群に散在していた内部APIパス（`/api/...`）を、`API_ENDPOINTS`（`apiEndpoints.ts`）に集約します。ハードコード→constants 移行のフォローアップ（#450）。**パス文字列・挙動は不変**。

Closes #450

## ロードマップ

該当なし（リファクタ／設定集約）

## レビューポイント

- `apiEndpoints.ts`: **静的パスは定数**（`FAVORITES` 等17種＋既存OTP2）、**動的パスはビルダー関数**（`favoriteById(id)` / `watchlistById(id)` / `theaterBySlug(slug)` / `movieById(movieId)` / `dismissedMovieByTmdbId(tmdbMovieId)`）で表現。ビルダーは元と同一URLを生成
- lib/api 14ファイルの直値を全置換 → **lib/api 内の `/api/` 直値は残存0件**
- client 群の置換は**並列2エージェント**（独立ファイル）で実施、結合後に全数検証
- ※ #450本文の「静的18種」はレビュー指摘どおり実測**17種**（`standard-medium` は動的 `theaterBySlug` の実行時値で二重計上だった）。実装は17種で正

## テスト

- lib/api **11スイート58テストパス**（グループ別でも A:250 / B:53 パス）
- 全体 `tsc --noEmit` **0エラー**、eslint（exit 0）・prettier クリーン
- 検証: `/api/` 直値の残存0件を grep 確認

## 補足

これでハードコード→constants 移行（#446〜#449 の A〜E ＋ 本 #450）が一区切りです。低優先の残（`getClientIp` 重複・軽微な散在定数）は #450 に併記済み、cron `maxDuration`/CSP は意図的に対象外です。
