### PR TITLE
fix(theater): 座席メトリクスを3D化し同一列の中央/端席で差を反映（Closes #463）

### DIFF
--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
@@ -76,11 +76,16 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
       map.set(
         seat.id,
         calcFieldOfViewMetrics(
-          { position_x: seat.position_x, position_z: seat.position_z },
+          {
+            position_x: seat.position_x,
+            position_y: seat.position_y,
+            position_z: seat.position_z,
+          },
           {
             width: theater.screen_width,
             height: theater.screen_height,
             center_x: theater.screen_center_x,
+            center_y: theater.screen_center_y,
             center_z: theater.screen_center_z,
           },
         ),

--- a/src/features/theaterExperience/hooks/useFieldOfView.test.ts
+++ b/src/features/theaterExperience/hooks/useFieldOfView.test.ts
@@ -48,12 +48,16 @@ describe('useFieldOfView', () => {
   });
 
   it('中央席の視野メトリクスを計算する', () => {
-    const seat = createSeat({ position_x: 0, position_z: 0 });
+    const seat = createSeat({ position_x: 0, position_y: 0.4, position_z: 0 });
     const { result } = renderHook(() => useFieldOfView(seat, mockTheater));
 
     expect(result.current).not.toBeNull();
-    expect(result.current!.distance_to_screen).toBeCloseTo(12.5);
-    expect(result.current!.distortion_score).toBeCloseTo(0);
+    // 距離は3D（dz=12.5, dy=3.6） → sqrt(12.5^2 + 3.6^2)
+    expect(result.current!.distance_to_screen).toBeCloseTo(
+      Math.sqrt(12.5 * 12.5 + 3.6 * 3.6),
+    );
+    // 中央席は歪みが小さい（見上げ角のみ、左右ズレなし）
+    expect(result.current!.distortion_score).toBeLessThan(0.3);
     expect(result.current!.horizontal_ratio).toBeGreaterThan(0);
     expect(result.current!.vertical_ratio).toBeGreaterThan(0);
   });

--- a/src/features/theaterExperience/hooks/useFieldOfView.ts
+++ b/src/features/theaterExperience/hooks/useFieldOfView.ts
@@ -22,11 +22,16 @@ export function useFieldOfView(
     if (!seat || !theater) return null;
 
     return calcFieldOfViewMetrics(
-      { position_x: seat.position_x, position_z: seat.position_z },
+      {
+        position_x: seat.position_x,
+        position_y: seat.position_y,
+        position_z: seat.position_z,
+      },
       {
         width: theater.screen_width,
         height: theater.screen_height,
         center_x: theater.screen_center_x,
+        center_y: theater.screen_center_y,
         center_z: theater.screen_center_z,
       },
     );

--- a/src/features/theaterExperience/utils/fieldOfView.test.ts
+++ b/src/features/theaterExperience/utils/fieldOfView.test.ts
@@ -3,94 +3,34 @@
  */
 
 import {
-  calcHorizontalFov,
-  calcVerticalFov,
-  calcFovRatios,
-  calcDistortionScore,
+  calcDistance3D,
+  calcViewingFovRatios,
+  calcViewingDistortion,
   calcDistanceToScreen,
   calcFieldOfViewMetrics,
   projectScreenQuad,
   calcYawClampedTargetX,
 } from './fieldOfView';
 
-describe('calcHorizontalFov', () => {
-  it('距離0以下では0を返す', () => {
-    expect(calcHorizontalFov(14, 0)).toBe(0);
-    expect(calcHorizontalFov(14, -1)).toBe(0);
+describe('calcDistance3D', () => {
+  it('X/Y/Zすべてを含む3Dユークリッド距離を返す', () => {
+    // dx=0, dy=-3, dz=-7.5 → sqrt(0+9+56.25)
+    const d = calcDistance3D({ x: 0, y: 1, z: 5 }, { x: 0, y: 4, z: 12.5 });
+    expect(d).toBeCloseTo(Math.sqrt(65.25));
   });
 
-  it('スクリーン幅14m、距離7.5mでの視野角を正しく計算する', () => {
-    const expected = 2 * Math.atan(7 / 7.5);
-    expect(calcHorizontalFov(14, 7.5)).toBeCloseTo(expected);
-  });
-
-  it('距離が大きくなると視野角が小さくなる', () => {
-    const near = calcHorizontalFov(14, 5);
-    const far = calcHorizontalFov(14, 20);
-    expect(near).toBeGreaterThan(far);
-  });
-});
-
-describe('calcVerticalFov', () => {
-  it('距離0以下では0を返す', () => {
-    expect(calcVerticalFov(6, 0)).toBe(0);
-  });
-
-  it('スクリーン高6m、距離7.5mでの視野角を正しく計算する', () => {
-    const expected = 2 * Math.atan(3 / 7.5);
-    expect(calcVerticalFov(6, 7.5)).toBeCloseTo(expected);
-  });
-});
-
-describe('calcFovRatios', () => {
-  it('視野占有率を0〜1の範囲で返す', () => {
-    const { horizontal_ratio, vertical_ratio } = calcFovRatios(14, 6, 7.5);
-    expect(horizontal_ratio).toBeGreaterThan(0);
-    expect(horizontal_ratio).toBeLessThan(1);
-    expect(vertical_ratio).toBeGreaterThan(0);
-    expect(vertical_ratio).toBeLessThan(1);
-  });
-
-  it('水平占有率は垂直占有率より大きい（スクリーンが横長の場合）', () => {
-    const { horizontal_ratio, vertical_ratio } = calcFovRatios(14, 6, 7.5);
-    expect(horizontal_ratio).toBeGreaterThan(vertical_ratio);
-  });
-
-  it('前方席（距離小）は後方席（距離大）より占有率が大きい', () => {
-    const front = calcFovRatios(14, 6, 5);
-    const back = calcFovRatios(14, 6, 15);
-    expect(front.horizontal_ratio).toBeGreaterThan(back.horizontal_ratio);
-  });
-});
-
-describe('calcDistortionScore', () => {
-  it('中央席の歪みは0', () => {
-    expect(calcDistortionScore(0, 0, 14)).toBe(0);
-  });
-
-  it('スクリーン端の席の歪みは1', () => {
-    // スクリーン幅14m、中心0 → 端は±7m
-    expect(calcDistortionScore(7, 0, 14)).toBeCloseTo(1);
-    expect(calcDistortionScore(-7, 0, 14)).toBeCloseTo(1);
-  });
-
-  it('中間位置の歪みは0〜1の間', () => {
-    const score = calcDistortionScore(3.5, 0, 14);
-    expect(score).toBeCloseTo(0.5);
-  });
-
-  it('スクリーン幅外の席の歪みは1でクランプされる', () => {
-    expect(calcDistortionScore(10, 0, 14)).toBe(1);
-  });
-
-  it('スクリーン幅0以下では0を返す', () => {
-    expect(calcDistortionScore(5, 0, 0)).toBe(0);
+  it('同一列でも左右にずれるほど距離が大きくなる', () => {
+    const center = calcDistance3D(
+      { x: 0, y: 1, z: 5 },
+      { x: 0, y: 4, z: 12.5 },
+    );
+    const edge = calcDistance3D({ x: 7, y: 1, z: 5 }, { x: 0, y: 4, z: 12.5 });
+    expect(edge).toBeGreaterThan(center);
   });
 });
 
 describe('calcDistanceToScreen', () => {
   it('Z方向の距離を正しく計算する', () => {
-    // 座席Z=5, スクリーンZ=12.5 → 距離7.5
     expect(calcDistanceToScreen(5, 12.5)).toBeCloseTo(7.5);
   });
 
@@ -99,43 +39,132 @@ describe('calcDistanceToScreen', () => {
   });
 });
 
-describe('calcFieldOfViewMetrics', () => {
-  const screen = { width: 14, height: 6, center_x: 0, center_z: 12.5 };
+describe('calcViewingFovRatios', () => {
+  const screen = {
+    width: 14,
+    height: 6,
+    center_x: 0,
+    center_y: 4,
+    center_z: 12.5,
+  };
 
-  it('中央前方席のメトリクスを正しく計算する', () => {
-    const seat = { position_x: 0, position_z: 5 };
-    const metrics = calcFieldOfViewMetrics(seat, screen);
-
-    expect(metrics.distance_to_screen).toBeCloseTo(7.5);
-    expect(metrics.distortion_score).toBeCloseTo(0);
-    expect(metrics.horizontal_ratio).toBeGreaterThan(0.3);
-    expect(metrics.vertical_ratio).toBeGreaterThan(0);
+  it('視野占有率を0〜1の範囲で返す', () => {
+    const { horizontal_ratio, vertical_ratio } = calcViewingFovRatios(
+      { x: 0, y: 1, z: 5 },
+      screen,
+    );
+    expect(horizontal_ratio).toBeGreaterThan(0);
+    expect(horizontal_ratio).toBeLessThan(1);
+    expect(vertical_ratio).toBeGreaterThan(0);
+    expect(vertical_ratio).toBeLessThan(1);
   });
 
-  it('端席は歪みスコアが高い', () => {
+  it('横長スクリーンでは水平占有率が垂直占有率より大きい', () => {
+    const { horizontal_ratio, vertical_ratio } = calcViewingFovRatios(
+      { x: 0, y: 1, z: 5 },
+      screen,
+    );
+    expect(horizontal_ratio).toBeGreaterThan(vertical_ratio);
+  });
+
+  it('前方席（距離小）は後方席（距離大）より水平占有率が大きい', () => {
+    const front = calcViewingFovRatios({ x: 0, y: 1, z: 5 }, screen);
+    const back = calcViewingFovRatios({ x: 0, y: 1, z: -7 }, screen);
+    expect(front.horizontal_ratio).toBeGreaterThan(back.horizontal_ratio);
+  });
+
+  it('同一列では端席の方が水平占有率が小さい（斜めから見るため）', () => {
+    const center = calcViewingFovRatios({ x: 0, y: 1, z: 5 }, screen);
+    const edge = calcViewingFovRatios({ x: 7, y: 1, z: 5 }, screen);
+    expect(edge.horizontal_ratio).toBeLessThan(center.horizontal_ratio);
+  });
+
+  it('スクリーンが座席の後ろ（dz<=0）なら0を返す', () => {
+    const ratios = calcViewingFovRatios({ x: 0, y: 1, z: 12.5 }, screen);
+    expect(ratios.horizontal_ratio).toBe(0);
+    expect(ratios.vertical_ratio).toBe(0);
+  });
+});
+
+describe('calcViewingDistortion', () => {
+  const center = { x: 0, y: 4, z: 12.5 };
+
+  it('中央付近の席は歪みが小さい', () => {
+    const d = calcViewingDistortion({ x: 0, y: 1, z: 5 }, center);
+    expect(d).toBeGreaterThanOrEqual(0);
+    expect(d).toBeLessThan(0.3);
+  });
+
+  it('端席は歪みが大きい（水平の斜め角）', () => {
+    const c = calcViewingDistortion({ x: 0, y: 1, z: 5 }, center);
+    const edge = calcViewingDistortion({ x: 7, y: 1, z: 5 }, center);
+    expect(edge).toBeGreaterThan(c);
+  });
+
+  it('前列は歪みが大きい（見上げ角=距離依存keystone）', () => {
+    const front = calcViewingDistortion({ x: 0, y: 1, z: 5 }, center);
+    const back = calcViewingDistortion({ x: 0, y: 1, z: -7 }, center);
+    expect(front).toBeGreaterThan(back);
+  });
+
+  it('0〜1にクランプされる', () => {
+    const d = calcViewingDistortion({ x: 20, y: 0, z: 12 }, center);
+    expect(d).toBeLessThanOrEqual(1);
+    expect(d).toBeGreaterThanOrEqual(0);
+  });
+
+  it('スクリーンが座席の後ろ（dz<=0）なら0を返す', () => {
+    expect(calcViewingDistortion({ x: 0, y: 1, z: 13 }, center)).toBe(0);
+  });
+});
+
+describe('calcFieldOfViewMetrics', () => {
+  const screen = {
+    width: 14,
+    height: 6,
+    center_x: 0,
+    center_y: 4,
+    center_z: 12.5,
+  };
+
+  it('中央前方席のメトリクスを正しく計算する', () => {
+    const seat = { position_x: 0, position_y: 1, position_z: 5 };
+    const metrics = calcFieldOfViewMetrics(seat, screen);
+
+    // 距離は3D（dz=7.5, dy=-3）
+    expect(metrics.distance_to_screen).toBeCloseTo(Math.sqrt(65.25));
+    expect(metrics.horizontal_ratio).toBeGreaterThan(0.3);
+    expect(metrics.vertical_ratio).toBeGreaterThan(0);
+    expect(metrics.distortion_score).toBeLessThan(0.3);
+  });
+
+  it('同一列でも中央席と端席で距離・占有率・歪みに差が出る（本Issueの核心）', () => {
     const center = calcFieldOfViewMetrics(
-      { position_x: 0, position_z: 5 },
+      { position_x: 0, position_y: 1, position_z: 5 },
       screen,
     );
     const edge = calcFieldOfViewMetrics(
-      { position_x: 7, position_z: 5 },
+      { position_x: 7, position_y: 1, position_z: 5 },
       screen,
     );
 
+    expect(edge.distance_to_screen).toBeGreaterThan(center.distance_to_screen);
+    expect(edge.horizontal_ratio).toBeLessThan(center.horizontal_ratio);
     expect(edge.distortion_score).toBeGreaterThan(center.distortion_score);
   });
 
-  it('後方席は占有率が低い', () => {
+  it('後方席は占有率が低く、前列は歪みが大きい', () => {
     const front = calcFieldOfViewMetrics(
-      { position_x: 0, position_z: 5 },
+      { position_x: 0, position_y: 1, position_z: 5 },
       screen,
     );
     const back = calcFieldOfViewMetrics(
-      { position_x: 0, position_z: -7 },
+      { position_x: 0, position_y: 1, position_z: -7 },
       screen,
     );
 
     expect(front.horizontal_ratio).toBeGreaterThan(back.horizontal_ratio);
+    expect(front.distortion_score).toBeGreaterThan(back.distortion_score);
   });
 });
 

--- a/src/features/theaterExperience/utils/fieldOfView.ts
+++ b/src/features/theaterExperience/utils/fieldOfView.ts
@@ -2,6 +2,8 @@
  * 視野・歪み計算ユーティリティ
  *
  * 設計書 Section 4 の見え方計算。
+ * メトリクス（距離・視野占有率・歪み）は座席の3D位置(X/Y/Z)を考慮するため、
+ * 同一列でも中央席と端席で値に差が出る。
  */
 
 import type { FieldOfViewMetrics } from '../types';
@@ -12,70 +14,99 @@ export interface Point2D {
   y: number;
 }
 
-/**
- * 水平視野角（ラジアン）
- * θ_h = 2 * atan((screen_width / 2) / distance)
- */
-export function calcHorizontalFov(
-  screenWidth: number,
-  distance: number,
-): number {
-  if (distance <= 0) return 0;
-  return 2 * Math.atan(screenWidth / 2 / distance);
+/** 3D座標 */
+export interface Point3D {
+  x: number;
+  y: number;
+  z: number;
 }
 
 /**
- * 垂直視野角（ラジアン）
- * θ_v = 2 * atan((screen_height / 2) / distance)
+ * 座席からスクリーン中心までの3Dユークリッド距離。
+ * 水平オフセット(X)と高さ(Y)も含むため、同一列でも端席ほど距離が大きくなり、
+ * スクリーンが高い位置にある前列では床上の見た目より距離が長くなる。
  */
-export function calcVerticalFov(
-  screenHeight: number,
-  distance: number,
-): number {
-  if (distance <= 0) return 0;
-  return 2 * Math.atan(screenHeight / 2 / distance);
+export function calcDistance3D(seat: Point3D, screenCenter: Point3D): number {
+  const dx = seat.x - screenCenter.x;
+  const dy = seat.y - screenCenter.y;
+  const dz = seat.z - screenCenter.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
 }
 
 /**
- * 視野占有率を計算する
- * ratio = θ / π（人間の視野約180度で正規化）
- */
-export function calcFovRatios(
-  screenWidth: number,
-  screenHeight: number,
-  distance: number,
-): { horizontal_ratio: number; vertical_ratio: number } {
-  const hFov = calcHorizontalFov(screenWidth, distance);
-  const vFov = calcVerticalFov(screenHeight, distance);
-  return {
-    horizontal_ratio: hFov / Math.PI,
-    vertical_ratio: vFov / Math.PI,
-  };
-}
-
-/**
- * 歪みスコア（0〜1）
- * 座席のX座標とスクリーン中心Xの差をスクリーン幅の半分で正規化。
- * 中央=0、端=1。
- */
-export function calcDistortionScore(
-  seatX: number,
-  screenCenterX: number,
-  screenWidth: number,
-): number {
-  if (screenWidth <= 0) return 0;
-  const offset = Math.abs(seatX - screenCenterX);
-  return Math.min(offset / (screenWidth / 2), 1);
-}
-
-/**
- * 座席からスクリーンまでのZ方向の距離を計算する
+ * 座席からスクリーン平面までのZ方向（前後）距離。
+ * カメラの前方距離など「スクリーン平面までの垂直距離」が必要な箇所で使う
+ * （首振り注視点の計算等）。占有率・歪みの計算には calcDistance3D 等を使う。
  */
 export function calcDistanceToScreen(
   seatZ: number,
   screenCenterZ: number,
 ): number {
   return Math.abs(screenCenterZ - seatZ);
+}
+
+/**
+ * 視野占有率（水平・垂直, 0〜1）を座席の3D位置から計算する。
+ *
+ * スクリーンの端が座席から見込む角度(subtense)を求め、人間の視野 π(=180°)で
+ * 正規化する。座席がスクリーン中心から左右にずれるほど水平の見込み角は
+ * 小さくなる（横長スクリーンを斜めから見るため）ので、同一列でも端席は
+ * 占有率が下がる。
+ */
+export function calcViewingFovRatios(
+  seat: Point3D,
+  screen: {
+    width: number;
+    height: number;
+    center_x: number;
+    center_y: number;
+    center_z: number;
+  },
+): { horizontal_ratio: number; vertical_ratio: number } {
+  const halfW = screen.width / 2;
+  const halfH = screen.height / 2;
+  const dz = screen.center_z - seat.z;
+  if (dz <= 0) return { horizontal_ratio: 0, vertical_ratio: 0 };
+
+  // 水平: スクリーン左右端の見込み角の差（水平面で計算）
+  const dxLeft = screen.center_x - halfW - seat.x;
+  const dxRight = screen.center_x + halfW - seat.x;
+  const hAngle = Math.atan2(dxRight, dz) - Math.atan2(dxLeft, dz);
+
+  // 垂直: 水平面内の距離を実効距離として上下端の見込み角の差を計算
+  const dx = screen.center_x - seat.x;
+  const horizDist = Math.sqrt(dx * dx + dz * dz);
+  const dyTop = screen.center_y + halfH - seat.y;
+  const dyBottom = screen.center_y - halfH - seat.y;
+  const vAngle = Math.atan2(dyTop, horizDist) - Math.atan2(dyBottom, horizDist);
+
+  return {
+    horizontal_ratio: Math.abs(hAngle) / Math.PI,
+    vertical_ratio: Math.abs(vAngle) / Math.PI,
+  };
+}
+
+/**
+ * 歪みスコア（0〜1）。座席からスクリーンを見る視線が「正対」からどれだけ
+ * 外れているか（＝台形歪みの強さ）を、水平の斜め角と垂直の見上げ角の合計を
+ * 90°で正規化して表す。中央=0に近く、端・前列ほど大きい。
+ * - 水平成分: スクリーン中心からの左右ズレ（端席ほど大）
+ * - 垂直成分(keystone): スクリーンを見上げる角度。前列ほど近く見上げが急に
+ *   なるため距離依存で大きくなる。
+ */
+export function calcViewingDistortion(
+  seat: Point3D,
+  screenCenter: Point3D,
+): number {
+  const dz = screenCenter.z - seat.z;
+  if (dz <= 0) return 0;
+  const dx = screenCenter.x - seat.x;
+  const dy = screenCenter.y - seat.y;
+  const horizObliqueness = Math.atan2(Math.abs(dx), dz);
+  const horizDist = Math.sqrt(dx * dx + dz * dz);
+  const verticalLookUp = Math.atan2(Math.abs(dy), horizDist);
+  const total = horizObliqueness + verticalLookUp;
+  return Math.min(total / (Math.PI / 2), 1);
 }
 
 /**
@@ -118,30 +149,35 @@ export function calcYawClampedTargetX(
 }
 
 /**
- * 視野占有率メトリクスを一括計算する
+ * 視野占有率メトリクスを一括計算する（座席の3D位置を考慮）。
  */
 export function calcFieldOfViewMetrics(
-  seat: { position_x: number; position_z: number },
+  seat: { position_x: number; position_y: number; position_z: number },
   screen: {
     width: number;
     height: number;
     center_x: number;
+    center_y: number;
     center_z: number;
   },
 ): FieldOfViewMetrics {
-  const distance = calcDistanceToScreen(seat.position_z, screen.center_z);
-  const ratios = calcFovRatios(screen.width, screen.height, distance);
-  const distortion = calcDistortionScore(
-    seat.position_x,
-    screen.center_x,
-    screen.width,
-  );
+  const seatPoint: Point3D = {
+    x: seat.position_x,
+    y: seat.position_y,
+    z: seat.position_z,
+  };
+  const screenCenter: Point3D = {
+    x: screen.center_x,
+    y: screen.center_y,
+    z: screen.center_z,
+  };
+  const ratios = calcViewingFovRatios(seatPoint, screen);
 
   return {
     horizontal_ratio: ratios.horizontal_ratio,
     vertical_ratio: ratios.vertical_ratio,
-    distance_to_screen: distance,
-    distortion_score: distortion,
+    distance_to_screen: calcDistance3D(seatPoint, screenCenter),
+    distortion_score: calcViewingDistortion(seatPoint, screenCenter),
   };
 }
 

--- a/src/features/theaterExperience/utils/fieldOfView.ts
+++ b/src/features/theaterExperience/utils/fieldOfView.ts
@@ -21,6 +21,15 @@ export interface Point3D {
   z: number;
 }
 
+/** スクリーンの寸法と中心位置 */
+export interface ScreenGeometry {
+  width: number;
+  height: number;
+  center_x: number;
+  center_y: number;
+  center_z: number;
+}
+
 /**
  * 座席からスクリーン中心までの3Dユークリッド距離。
  * 水平オフセット(X)と高さ(Y)も含むため、同一列でも端席ほど距離が大きくなり、
@@ -55,13 +64,7 @@ export function calcDistanceToScreen(
  */
 export function calcViewingFovRatios(
   seat: Point3D,
-  screen: {
-    width: number;
-    height: number;
-    center_x: number;
-    center_y: number;
-    center_z: number;
-  },
+  screen: ScreenGeometry,
 ): { horizontal_ratio: number; vertical_ratio: number } {
   const halfW = screen.width / 2;
   const halfH = screen.height / 2;
@@ -153,13 +156,7 @@ export function calcYawClampedTargetX(
  */
 export function calcFieldOfViewMetrics(
   seat: { position_x: number; position_y: number; position_z: number },
-  screen: {
-    width: number;
-    height: number;
-    center_x: number;
-    center_y: number;
-    center_z: number;
-  },
+  screen: ScreenGeometry,
 ): FieldOfViewMetrics {
   const seatPoint: Point3D = {
     x: seat.position_x,
@@ -192,13 +189,7 @@ export function calcFieldOfViewMetrics(
  */
 export function projectScreenQuad(
   seat: { x: number; y: number; z: number },
-  screen: {
-    width: number;
-    height: number;
-    center_x: number;
-    center_y: number;
-    center_z: number;
-  },
+  screen: ScreenGeometry,
 ): [Point2D, Point2D, Point2D, Point2D] {
   const halfW = screen.width / 2;
   const halfH = screen.height / 2;


### PR DESCRIPTION
## 概要
座席メトリクス（スクリーン距離・視野占有率・歪みスコア）がスクリーンからの**Z軸距離のみ**で計算され、同一列の中央席と端席が同値になる問題を解消。座席の3D位置(X/Y/Z)を考慮した計算に変更した。

- **距離**: スクリーン中心までの3Dユークリッド距離（`calcDistance3D`）。X/Yを含むため同一列でも端席ほど距離が大きく、スクリーンが高い前列は床上の見た目より距離が長くなる。
- **視野占有率**: オフアクシスの見込み角（`calcViewingFovRatios`）。端席は横長スクリーンを斜めから見るため水平占有率が下がる。
- **歪みスコア**: 見上げ角（距離依存keystone・前列ほど大）＋左右の斜め角（`calcViewingDistortion`）。
- `calcDistanceToScreen`（カメラ首振り用のZ距離）は用途が別のため**温存**。
- superseded な `calcFovRatios`/`calcDistortionScore`/`calcHorizontalFov`/`calcVerticalFov` を撤去。
- 呼び出し元（`useFieldOfView`／`seatA11yList`）へ `position_y`／`screen_center_y` を配線。
- pre-commitレビュー指摘に対応し、重複していたスクリーン形状の型を `ScreenGeometry` へ共有化。

Closes #463

## ロードマップ
該当なし（本Issueはロードマップ外のフォローアップ改善）。

## レビューポイント
- メトリクスは**ロジックのみの変更**でUIレイアウトは不変。ただし表示される数値（距離・占有率・歪み）は3D化により変わる。特に前列は距離がやや増える（スクリーンが頭上高くにあるため物理的に正しい）。
- 歪みスコアの定義が「左右ズレ」から「視線の正対からの外れ角（左右＋見上げ）」に変わったため、推奨バッジ（`getRecommendation`）の挙動が一部変化しうる。**バッジ判定の刷新は依存Issue #460 で対応予定**（本PRはメトリクス精度のみ）。
- `calcDistanceToScreen` を温存した点（カメラ首振りの前方距離用途、`theaterScene.tsx` で使用）。

## テスト
- `fieldOfView.test.ts`: 新関数（`calcDistance3D`/`calcViewingFovRatios`/`calcViewingDistortion`）＋`calcFieldOfViewMetrics` の3D差分（同一列で中央≠端、前列≠後列）を検証。
- `useFieldOfView.test.ts`: 3D距離・歪みの新仕様に更新。
- theaterExperience 全体 **180 tests green**、tsc / eslint クリーン。
