### PR TITLE
fix(theater): 推奨バッジを山型スコアへ刷新し前列中央の「最適」誤誘導を解消（Closes #460）

### DIFF
--- a/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.test.tsx
+++ b/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.test.tsx
@@ -62,11 +62,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('10%')).toBeInTheDocument();
   });
 
-  it('歪みが低く占有率が高い場合は「最適」バッジ', () => {
+  it('スイートスポット（占有率が最良帯・低歪み）は「最適」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
+      horizontal_ratio: 0.25,
       distortion_score: 0.05,
-      horizontal_ratio: 0.4,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -74,11 +74,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('最適')).toBeInTheDocument();
   });
 
-  it('歪みが中程度の場合は「良好」バッジ', () => {
+  it('やや近い/中程度の歪みは「良好」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.2,
-      horizontal_ratio: 0.25,
+      horizontal_ratio: 0.35,
+      distortion_score: 0.15,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -86,11 +86,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('良好')).toBeInTheDocument();
   });
 
-  it('歪みが高い場合は「普通」バッジ', () => {
+  it('スイートスポットから外れると「普通」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.4,
-      horizontal_ratio: 0.15,
+      horizontal_ratio: 0.4,
+      distortion_score: 0.2,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -98,11 +98,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('普通')).toBeInTheDocument();
   });
 
-  it('歪みが非常に高い場合は「非推奨」バッジ', () => {
+  it('近すぎ（占有率過大）＋高歪みは「非推奨」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.6,
-      horizontal_ratio: 0.1,
+      horizontal_ratio: 0.6,
+      distortion_score: 0.5,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);

--- a/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.tsx
+++ b/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.tsx
@@ -10,12 +10,13 @@ import { memo, useMemo } from 'react';
 import { cn } from '@/utils/cn';
 
 import type { TheaterSeat, Theater, FieldOfViewMetrics } from '../../types';
+import {
+  getRecommendation,
+  type RecommendationLevel,
+} from '../../utils/seatRecommendation';
 import { DistortionPreview } from '../distortionPreview/distortionPreview';
 
 import styles from './seatInfoPanel.module.scss';
-
-/** 推奨度レベル */
-type RecommendationLevel = 'excellent' | 'good' | 'fair' | 'poor';
 
 export interface SeatInfoPanelProps {
   /** 選択中の座席 */
@@ -26,18 +27,6 @@ export interface SeatInfoPanelProps {
   theater?: Theater;
   /** 追加クラス名 */
   className?: string;
-}
-
-/**
- * 歪みスコアから推奨度を算出
- */
-function getRecommendation(metrics: FieldOfViewMetrics): RecommendationLevel {
-  const { distortion_score, horizontal_ratio } = metrics;
-
-  if (distortion_score <= 0.15 && horizontal_ratio >= 0.3) return 'excellent';
-  if (distortion_score <= 0.3 && horizontal_ratio >= 0.2) return 'good';
-  if (distortion_score <= 0.5) return 'fair';
-  return 'poor';
 }
 
 const RECOMMENDATION_LABELS: Record<RecommendationLevel, string> = {

--- a/src/features/theaterExperience/utils/seatRecommendation.test.ts
+++ b/src/features/theaterExperience/utils/seatRecommendation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 座席推奨度スコアリング テスト
+ */
+
+import type { FieldOfViewMetrics } from '../types';
+
+import { calcFieldOfViewMetrics } from './fieldOfView';
+import {
+  calcOccupancyScore,
+  calcSeatScore,
+  getRecommendation,
+} from './seatRecommendation';
+
+const metrics = (
+  overrides: Partial<FieldOfViewMetrics> = {},
+): FieldOfViewMetrics => ({
+  horizontal_ratio: 0.25,
+  vertical_ratio: 0.15,
+  distance_to_screen: 12,
+  distortion_score: 0.05,
+  ...overrides,
+});
+
+describe('calcOccupancyScore', () => {
+  it('スイートスポット帯(0.167〜0.30)では1', () => {
+    expect(calcOccupancyScore(0.2)).toBe(1);
+    expect(calcOccupancyScore(0.167)).toBe(1);
+    expect(calcOccupancyScore(0.3)).toBe(1);
+  });
+
+  it('遠すぎ（占有率が低い）ほど減点、下限で0', () => {
+    expect(calcOccupancyScore(0.1)).toBeCloseTo(0);
+    expect(calcOccupancyScore(0.08)).toBe(0);
+    // 帯の手前は0〜1の中間
+    const mid = calcOccupancyScore(0.13);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+  });
+
+  it('近すぎ（占有率が過大）ほど減点、上限で0', () => {
+    expect(calcOccupancyScore(0.5)).toBeCloseTo(0);
+    expect(calcOccupancyScore(0.66)).toBe(0);
+    const mid = calcOccupancyScore(0.4);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+  });
+});
+
+describe('calcSeatScore / getRecommendation', () => {
+  it('スイートスポット＋低歪みは最高スコア＝最適', () => {
+    const m = metrics({ horizontal_ratio: 0.25, distortion_score: 0.05 });
+    expect(calcSeatScore(m)).toBeGreaterThanOrEqual(0.8);
+    expect(getRecommendation(m)).toBe('excellent');
+  });
+
+  it('近すぎ席（占有率過大）は最適にならない', () => {
+    const m = metrics({ horizontal_ratio: 0.6, distortion_score: 0.5 });
+    expect(getRecommendation(m)).not.toBe('excellent');
+    expect(getRecommendation(m)).toBe('poor');
+  });
+
+  it('やや近い/やや外れた席は良好〜普通に収まる', () => {
+    expect(
+      getRecommendation(
+        metrics({ horizontal_ratio: 0.35, distortion_score: 0.15 }),
+      ),
+    ).toBe('good');
+    expect(
+      getRecommendation(
+        metrics({ horizontal_ratio: 0.4, distortion_score: 0.2 }),
+      ),
+    ).toBe('fair');
+  });
+
+  it('歪みが大きいほどスコアが下がる', () => {
+    const low = calcSeatScore(metrics({ distortion_score: 0.05 }));
+    const high = calcSeatScore(metrics({ distortion_score: 0.5 }));
+    expect(high).toBeLessThan(low);
+  });
+});
+
+describe('実座席座標との統合（前列中央が無条件で最適にならない）', () => {
+  const screen = {
+    width: 15,
+    height: 7.13,
+    center_x: 0,
+    center_y: 4.8,
+    center_z: 12.5,
+  };
+
+  const front = calcFieldOfViewMetrics(
+    { position_x: 0, position_y: 0.4, position_z: 8 }, // dz=4.5（最前列中央）
+    screen,
+  );
+  const back = calcFieldOfViewMetrics(
+    { position_x: 0, position_y: 3, position_z: -2.5 }, // dz=15（中後方中央）
+    screen,
+  );
+
+  it('最前列中央は「最適」にならない', () => {
+    expect(getRecommendation(front)).not.toBe('excellent');
+  });
+
+  it('中後方中央は最前列中央よりスコアが高い', () => {
+    expect(calcSeatScore(back)).toBeGreaterThan(calcSeatScore(front));
+  });
+
+  it('中後方中央は最適または良好', () => {
+    expect(['excellent', 'good']).toContain(getRecommendation(back));
+  });
+});

--- a/src/features/theaterExperience/utils/seatRecommendation.ts
+++ b/src/features/theaterExperience/utils/seatRecommendation.ts
@@ -1,0 +1,82 @@
+/**
+ * 座席推奨度スコアリング
+ *
+ * 単純な閾値判定ではなく、近すぎ（占有率過大）/遠すぎ（占有率過小）を減点する
+ * 山型スコアで席の見やすさを総合評価する。入力メトリクスは3D位置を考慮した
+ * calcFieldOfViewMetrics（distortion_score は左右の斜め角＋見上げ角のkeystoneを含む）。
+ */
+
+import type { FieldOfViewMetrics } from '../types';
+
+/** 推奨度レベル */
+export type RecommendationLevel = 'excellent' | 'good' | 'fair' | 'poor';
+
+/**
+ * 水平視野占有率(= 水平視野角 / π)のスイートスポット。
+ * 人が快適に画面全体を捉えられる水平視野角の目安に基づく:
+ * - 約30°(SMPTE下限)〜約54° を最良帯とする（ratio 0.167〜0.30）
+ * - 約18°(ratio 0.10) 未満は「遠すぎ（画面が小さい）」で占有スコア0
+ * - 約90°(ratio 0.50) 超は「近すぎ（画面が視界を溢れ首振りが過大）」で占有スコア0
+ */
+const H_IDEAL_LOW = 0.167;
+const H_IDEAL_HIGH = 0.3;
+const H_MIN = 0.1;
+const H_MAX = 0.5;
+
+/** 歪み(0〜1)がこの値以上で歪み品質を0とする */
+const DISTORTION_MAX = 0.6;
+
+/** 総合スコアの配分（占有率 : 歪み） */
+const W_OCCUPANCY = 0.6;
+const W_DISTORTION = 0.4;
+
+/** 推奨度レベルの閾値（総合スコア 0〜1） */
+const THRESHOLD_EXCELLENT = 0.8;
+const THRESHOLD_GOOD = 0.6;
+const THRESHOLD_FAIR = 0.4;
+
+function clamp01(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}
+
+/**
+ * 水平視野占有率から占有スコア（0〜1, 山型）を求める。
+ * スイートスポット帯で1、近すぎ・遠すぎで0へ線形に減衰する。
+ */
+export function calcOccupancyScore(horizontalRatio: number): number {
+  if (horizontalRatio >= H_IDEAL_LOW && horizontalRatio <= H_IDEAL_HIGH) {
+    return 1;
+  }
+  if (horizontalRatio < H_IDEAL_LOW) {
+    // 遠すぎ側: H_MIN で0 → H_IDEAL_LOW で1
+    return clamp01((horizontalRatio - H_MIN) / (H_IDEAL_LOW - H_MIN));
+  }
+  // 近すぎ側: H_IDEAL_HIGH で1 → H_MAX で0
+  return clamp01((H_MAX - horizontalRatio) / (H_MAX - H_IDEAL_HIGH));
+}
+
+/**
+ * 総合スコア（0〜1）。占有スイートスポット＋歪み品質の加重和。
+ * 前列中央は「占有率過大」と「見上げ歪み大」の両方で減点され、
+ * 単純な閾値判定のように無条件で最高評価にはならない。
+ */
+export function calcSeatScore(metrics: FieldOfViewMetrics): number {
+  const occupancy = calcOccupancyScore(metrics.horizontal_ratio);
+  const distortionQuality = clamp01(
+    1 - metrics.distortion_score / DISTORTION_MAX,
+  );
+  return occupancy * W_OCCUPANCY + distortionQuality * W_DISTORTION;
+}
+
+/**
+ * 総合スコアから推奨度レベルを判定する。
+ */
+export function getRecommendation(
+  metrics: FieldOfViewMetrics,
+): RecommendationLevel {
+  const score = calcSeatScore(metrics);
+  if (score >= THRESHOLD_EXCELLENT) return 'excellent';
+  if (score >= THRESHOLD_GOOD) return 'good';
+  if (score >= THRESHOLD_FAIR) return 'fair';
+  return 'poor';
+}


### PR DESCRIPTION
## 概要
推奨バッジが席の遠近に関わらず一律「最適」になり、最前列中央でも後方中央でも同じ判定になる問題を解消。`getRecommendation` を単純閾値から、近すぎ/遠すぎを減点する山型の総合スコアへ刷新した。

- **占有スコア（山型）**: 水平視野占有率のスイートスポット帯（≈30°〜54°／ratio 0.167〜0.30）で1、遠すぎ（占有率過小・下限18°）／近すぎ（占有率過大・上限90°）で線形に0へ減衰。
- **歪み品質**: `distortion_score`（#463で左右の斜め角＋見上げkeystoneを含む）が低いほど高評価。
- **総合スコア** = 占有 0.6 ＋ 歪み 0.4 の加重和で `excellent`/`good`/`fair`/`poor` を判定。
- 判定ロジックを `utils/seatRecommendation.ts` に切り出して**単体テスト可能**にし、`seatInfoPanel` からは import して使用。

これにより最前列中央（占有率過大＋見上げ大）は無条件で「最適」にならず、中後方のスイートスポット席が最適になる。

Closes #460

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## レビューポイント
- **依存**: 本PRは #463（メトリクス3D化, マージ済み）の `distortion_score`/`horizontal_ratio` を前提にスコア閾値を設計している。
- スイートスポットの閾値（H_IDEAL_LOW/HIGH 等）は SMPTE/THX の視野角目安に基づく定数。劇場非依存の絶対角度で判定するため、大型フォーマットの前列は自然に減点される。
- スコア配分（占有0.6 / 歪み0.4）と各閾値（excellent 0.8 / good 0.6 / fair 0.4）は定数化。調整余地あり。
- ロジックのみの変更（UIレイアウト不変。表示されるバッジ判定結果は変わる）。

## テスト
- `seatRecommendation.test.ts`（新規）: `calcOccupancyScore` の山型（帯で1・近すぎ/遠すぎで0）、`calcSeatScore`/`getRecommendation` の各レベル、**実座席座標との統合**（`calcFieldOfViewMetrics` → 最前列中央は「最適」にならず、中後方中央がスコア上位）を検証。
- `seatInfoPanel.test.tsx`: バッジ表示テストを新スコアの代表値に更新。
- theaterExperience 全体 **190 tests green** / tsc・eslint クリーン。
