### PR TITLE
feat(theater): スクリーンを投影風シェーダーに接続し「青い板」を解消（Closes #459）

### DIFF
--- a/src/features/theaterExperience/component/screenMesh/screenMesh.test.tsx
+++ b/src/features/theaterExperience/component/screenMesh/screenMesh.test.tsx
@@ -13,7 +13,6 @@ jest.mock('@react-three/drei', () => ({
 
 jest.mock('three', () => ({
   DoubleSide: 2,
-  ShaderMaterial: jest.fn(),
 }));
 
 jest.mock('../../shaders/screenVertex', () => ({
@@ -24,7 +23,18 @@ jest.mock('../../shaders/screenFragment', () => ({
   screenFragmentShader: 'mock-fragment-shader',
 }));
 
-import { ScreenMesh } from './screenMesh';
+import { ScreenMesh, advanceScreenTime } from './screenMesh';
+
+describe('advanceScreenTime', () => {
+  it('通常時は経過時間(delta)だけ進む', () => {
+    expect(advanceScreenTime(1, 0.5, false)).toBeCloseTo(1.5);
+  });
+
+  it('reducedMotion時は現在値を維持しアニメ（フリッカー含む）を停止する', () => {
+    expect(advanceScreenTime(1, 0.5, true)).toBe(1);
+    expect(advanceScreenTime(0, 999, true)).toBe(0);
+  });
+});
 
 describe('ScreenMesh', () => {
   it('エクスポートが正しく定義されている', () => {

--- a/src/features/theaterExperience/component/screenMesh/screenMesh.tsx
+++ b/src/features/theaterExperience/component/screenMesh/screenMesh.tsx
@@ -1,14 +1,20 @@
 /**
  * ScreenMeshコンポーネント
  * スクリーン矩形メッシュ + ベゼル（暗いフレーム）
- * アイソメトリック ドールハウス: フラットな単色 + エッジ強調
+ * 本体は投影風シェーダー（screenVertex/screenFragment）で「上映中の幕」を表現する。
+ * prefers-reduced-motion 有効時はアニメ（フリッカー含む）を停止する。
  */
 
 'use client';
 
-import { memo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { DoubleSide } from 'three';
+import type { ShaderMaterial } from 'three';
+import { useFrame } from '@react-three/fiber';
 import { Edges } from '@react-three/drei';
+
+import { screenVertexShader } from '../../shaders/screenVertex';
+import { screenFragmentShader } from '../../shaders/screenFragment';
 
 /** ベゼル（フレーム）の太さ (m) */
 const BEZEL_THICKNESS = 0.08;
@@ -26,8 +32,21 @@ export interface ScreenMeshProps {
   centerY: number;
   /** スクリーン中心Z座標 */
   centerZ: number;
-  /** prefers-reduced-motion 有効時は true（プロトタイプでは未使用） */
+  /** prefers-reduced-motion 有効時は true（投影アニメを停止する） */
   reducedMotion?: boolean;
+}
+
+/**
+ * 投影シェーダーの経過時間を進める。
+ * reducedMotion 有効時は現在値を維持してアニメ（12Hzフリッカー含む）を停止する
+ * （WCAG 2.3.1 点滅/発作、prefers-reduced-motion への配慮）。
+ */
+export function advanceScreenTime(
+  current: number,
+  delta: number,
+  reducedMotion: boolean,
+): number {
+  return reducedMotion ? current : current + delta;
 }
 
 export const ScreenMesh = memo<ScreenMeshProps>(function ScreenMesh({
@@ -36,9 +55,23 @@ export const ScreenMesh = memo<ScreenMeshProps>(function ScreenMesh({
   centerX,
   centerY,
   centerZ,
+  reducedMotion = false,
 }) {
   const halfW = width / 2;
   const halfH = height / 2;
+
+  const materialRef = useRef<ShaderMaterial>(null);
+  const uniforms = useMemo(() => ({ uTime: { value: 0 } }), []);
+
+  useFrame((_, delta) => {
+    const material = materialRef.current;
+    if (!material) return;
+    material.uniforms.uTime.value = advanceScreenTime(
+      material.uniforms.uTime.value,
+      delta,
+      reducedMotion,
+    );
+  });
 
   return (
     /*
@@ -47,11 +80,14 @@ export const ScreenMesh = memo<ScreenMeshProps>(function ScreenMesh({
       同じ値だと両者が同一平面に重なってシマ模様のアーティファクトが発生する。
     */
     <group position={[centerX, centerY, centerZ - 0.1]}>
-      {/* スクリーン本体（フラットな単色） */}
+      {/* スクリーン本体（投影風シェーダー） */}
       <mesh>
         <planeGeometry args={[width, height]} />
-        <meshBasicMaterial
-          color='#3a4a8a'
+        <shaderMaterial
+          ref={materialRef}
+          vertexShader={screenVertexShader}
+          fragmentShader={screenFragmentShader}
+          uniforms={uniforms}
           side={DoubleSide}
           toneMapped={false}
         />

--- a/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.test.tsx
+++ b/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.test.tsx
@@ -62,11 +62,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('10%')).toBeInTheDocument();
   });
 
-  it('歪みが低く占有率が高い場合は「最適」バッジ', () => {
+  it('スイートスポット（占有率が最良帯・低歪み）は「最適」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
+      horizontal_ratio: 0.25,
       distortion_score: 0.05,
-      horizontal_ratio: 0.4,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -74,11 +74,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('最適')).toBeInTheDocument();
   });
 
-  it('歪みが中程度の場合は「良好」バッジ', () => {
+  it('やや近い/中程度の歪みは「良好」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.2,
-      horizontal_ratio: 0.25,
+      horizontal_ratio: 0.35,
+      distortion_score: 0.15,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -86,11 +86,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('良好')).toBeInTheDocument();
   });
 
-  it('歪みが高い場合は「普通」バッジ', () => {
+  it('スイートスポットから外れると「普通」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.4,
-      horizontal_ratio: 0.15,
+      horizontal_ratio: 0.4,
+      distortion_score: 0.2,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);
@@ -98,11 +98,11 @@ describe('SeatInfoPanel', () => {
     expect(screen.getByText('普通')).toBeInTheDocument();
   });
 
-  it('歪みが非常に高い場合は「非推奨」バッジ', () => {
+  it('近すぎ（占有率過大）＋高歪みは「非推奨」バッジ', () => {
     const seat = createSeat();
     const metrics = createMetrics({
-      distortion_score: 0.6,
-      horizontal_ratio: 0.1,
+      horizontal_ratio: 0.6,
+      distortion_score: 0.5,
     });
 
     render(<SeatInfoPanel seat={seat} fovMetrics={metrics} />);

--- a/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.tsx
+++ b/src/features/theaterExperience/component/seatInfoPanel/seatInfoPanel.tsx
@@ -10,12 +10,13 @@ import { memo, useMemo } from 'react';
 import { cn } from '@/utils/cn';
 
 import type { TheaterSeat, Theater, FieldOfViewMetrics } from '../../types';
+import {
+  getRecommendation,
+  type RecommendationLevel,
+} from '../../utils/seatRecommendation';
 import { DistortionPreview } from '../distortionPreview/distortionPreview';
 
 import styles from './seatInfoPanel.module.scss';
-
-/** 推奨度レベル */
-type RecommendationLevel = 'excellent' | 'good' | 'fair' | 'poor';
 
 export interface SeatInfoPanelProps {
   /** 選択中の座席 */
@@ -26,18 +27,6 @@ export interface SeatInfoPanelProps {
   theater?: Theater;
   /** 追加クラス名 */
   className?: string;
-}
-
-/**
- * 歪みスコアから推奨度を算出
- */
-function getRecommendation(metrics: FieldOfViewMetrics): RecommendationLevel {
-  const { distortion_score, horizontal_ratio } = metrics;
-
-  if (distortion_score <= 0.15 && horizontal_ratio >= 0.3) return 'excellent';
-  if (distortion_score <= 0.3 && horizontal_ratio >= 0.2) return 'good';
-  if (distortion_score <= 0.5) return 'fair';
-  return 'poor';
 }
 
 const RECOMMENDATION_LABELS: Record<RecommendationLevel, string> = {

--- a/src/features/theaterExperience/shaders/screenShaders.test.ts
+++ b/src/features/theaterExperience/shaders/screenShaders.test.ts
@@ -1,0 +1,30 @@
+/**
+ * スクリーン投影シェーダーの配線テスト
+ * ScreenMesh が実際に使用するシェーダー（頂点/フラグメント）が、想定の
+ * uniform/varying・演出要素を備えていることを表明する。
+ */
+
+import { screenFragmentShader } from './screenFragment';
+import { screenVertexShader } from './screenVertex';
+
+describe('screenVertexShader', () => {
+  it('UV座標をvUvとしてパススルーする', () => {
+    expect(screenVertexShader).toContain('varying vec2 vUv');
+    expect(screenVertexShader).toContain('vUv = uv');
+  });
+});
+
+describe('screenFragmentShader', () => {
+  it('uTime uniform で時間変化する', () => {
+    expect(screenFragmentShader).toContain('uniform float uTime');
+  });
+
+  it('ビネット演出を含む', () => {
+    expect(screenFragmentShader).toContain('vignette');
+  });
+
+  it('フリッカー演出（uTime依存）を含む', () => {
+    expect(screenFragmentShader).toContain('flicker');
+    expect(screenFragmentShader).toContain('uTime');
+  });
+});

--- a/src/features/theaterExperience/utils/seatRecommendation.test.ts
+++ b/src/features/theaterExperience/utils/seatRecommendation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 座席推奨度スコアリング テスト
+ */
+
+import type { FieldOfViewMetrics } from '../types';
+
+import { calcFieldOfViewMetrics } from './fieldOfView';
+import {
+  calcOccupancyScore,
+  calcSeatScore,
+  getRecommendation,
+} from './seatRecommendation';
+
+const metrics = (
+  overrides: Partial<FieldOfViewMetrics> = {},
+): FieldOfViewMetrics => ({
+  horizontal_ratio: 0.25,
+  vertical_ratio: 0.15,
+  distance_to_screen: 12,
+  distortion_score: 0.05,
+  ...overrides,
+});
+
+describe('calcOccupancyScore', () => {
+  it('スイートスポット帯(0.167〜0.30)では1', () => {
+    expect(calcOccupancyScore(0.2)).toBe(1);
+    expect(calcOccupancyScore(0.167)).toBe(1);
+    expect(calcOccupancyScore(0.3)).toBe(1);
+  });
+
+  it('遠すぎ（占有率が低い）ほど減点、下限で0', () => {
+    expect(calcOccupancyScore(0.1)).toBeCloseTo(0);
+    expect(calcOccupancyScore(0.08)).toBe(0);
+    // 帯の手前は0〜1の中間
+    const mid = calcOccupancyScore(0.13);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+  });
+
+  it('近すぎ（占有率が過大）ほど減点、上限で0', () => {
+    expect(calcOccupancyScore(0.5)).toBeCloseTo(0);
+    expect(calcOccupancyScore(0.66)).toBe(0);
+    const mid = calcOccupancyScore(0.4);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+  });
+});
+
+describe('calcSeatScore / getRecommendation', () => {
+  it('スイートスポット＋低歪みは最高スコア＝最適', () => {
+    const m = metrics({ horizontal_ratio: 0.25, distortion_score: 0.05 });
+    expect(calcSeatScore(m)).toBeGreaterThanOrEqual(0.8);
+    expect(getRecommendation(m)).toBe('excellent');
+  });
+
+  it('近すぎ席（占有率過大）は最適にならない', () => {
+    const m = metrics({ horizontal_ratio: 0.6, distortion_score: 0.5 });
+    expect(getRecommendation(m)).not.toBe('excellent');
+    expect(getRecommendation(m)).toBe('poor');
+  });
+
+  it('やや近い/やや外れた席は良好〜普通に収まる', () => {
+    expect(
+      getRecommendation(
+        metrics({ horizontal_ratio: 0.35, distortion_score: 0.15 }),
+      ),
+    ).toBe('good');
+    expect(
+      getRecommendation(
+        metrics({ horizontal_ratio: 0.4, distortion_score: 0.2 }),
+      ),
+    ).toBe('fair');
+  });
+
+  it('歪みが大きいほどスコアが下がる', () => {
+    const low = calcSeatScore(metrics({ distortion_score: 0.05 }));
+    const high = calcSeatScore(metrics({ distortion_score: 0.5 }));
+    expect(high).toBeLessThan(low);
+  });
+});
+
+describe('実座席座標との統合（前列中央が無条件で最適にならない）', () => {
+  const screen = {
+    width: 15,
+    height: 7.13,
+    center_x: 0,
+    center_y: 4.8,
+    center_z: 12.5,
+  };
+
+  const front = calcFieldOfViewMetrics(
+    { position_x: 0, position_y: 0.4, position_z: 8 }, // dz=4.5（最前列中央）
+    screen,
+  );
+  const back = calcFieldOfViewMetrics(
+    { position_x: 0, position_y: 3, position_z: -2.5 }, // dz=15（中後方中央）
+    screen,
+  );
+
+  it('最前列中央は「最適」にならない', () => {
+    expect(getRecommendation(front)).not.toBe('excellent');
+  });
+
+  it('中後方中央は最前列中央よりスコアが高い', () => {
+    expect(calcSeatScore(back)).toBeGreaterThan(calcSeatScore(front));
+  });
+
+  it('中後方中央は最適または良好', () => {
+    expect(['excellent', 'good']).toContain(getRecommendation(back));
+  });
+});

--- a/src/features/theaterExperience/utils/seatRecommendation.ts
+++ b/src/features/theaterExperience/utils/seatRecommendation.ts
@@ -1,0 +1,82 @@
+/**
+ * 座席推奨度スコアリング
+ *
+ * 単純な閾値判定ではなく、近すぎ（占有率過大）/遠すぎ（占有率過小）を減点する
+ * 山型スコアで席の見やすさを総合評価する。入力メトリクスは3D位置を考慮した
+ * calcFieldOfViewMetrics（distortion_score は左右の斜め角＋見上げ角のkeystoneを含む）。
+ */
+
+import type { FieldOfViewMetrics } from '../types';
+
+/** 推奨度レベル */
+export type RecommendationLevel = 'excellent' | 'good' | 'fair' | 'poor';
+
+/**
+ * 水平視野占有率(= 水平視野角 / π)のスイートスポット。
+ * 人が快適に画面全体を捉えられる水平視野角の目安に基づく:
+ * - 約30°(SMPTE下限)〜約54° を最良帯とする（ratio 0.167〜0.30）
+ * - 約18°(ratio 0.10) 未満は「遠すぎ（画面が小さい）」で占有スコア0
+ * - 約90°(ratio 0.50) 超は「近すぎ（画面が視界を溢れ首振りが過大）」で占有スコア0
+ */
+const H_IDEAL_LOW = 0.167;
+const H_IDEAL_HIGH = 0.3;
+const H_MIN = 0.1;
+const H_MAX = 0.5;
+
+/** 歪み(0〜1)がこの値以上で歪み品質を0とする */
+const DISTORTION_MAX = 0.6;
+
+/** 総合スコアの配分（占有率 : 歪み） */
+const W_OCCUPANCY = 0.6;
+const W_DISTORTION = 0.4;
+
+/** 推奨度レベルの閾値（総合スコア 0〜1） */
+const THRESHOLD_EXCELLENT = 0.8;
+const THRESHOLD_GOOD = 0.6;
+const THRESHOLD_FAIR = 0.4;
+
+function clamp01(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}
+
+/**
+ * 水平視野占有率から占有スコア（0〜1, 山型）を求める。
+ * スイートスポット帯で1、近すぎ・遠すぎで0へ線形に減衰する。
+ */
+export function calcOccupancyScore(horizontalRatio: number): number {
+  if (horizontalRatio >= H_IDEAL_LOW && horizontalRatio <= H_IDEAL_HIGH) {
+    return 1;
+  }
+  if (horizontalRatio < H_IDEAL_LOW) {
+    // 遠すぎ側: H_MIN で0 → H_IDEAL_LOW で1
+    return clamp01((horizontalRatio - H_MIN) / (H_IDEAL_LOW - H_MIN));
+  }
+  // 近すぎ側: H_IDEAL_HIGH で1 → H_MAX で0
+  return clamp01((H_MAX - horizontalRatio) / (H_MAX - H_IDEAL_HIGH));
+}
+
+/**
+ * 総合スコア（0〜1）。占有スイートスポット＋歪み品質の加重和。
+ * 前列中央は「占有率過大」と「見上げ歪み大」の両方で減点され、
+ * 単純な閾値判定のように無条件で最高評価にはならない。
+ */
+export function calcSeatScore(metrics: FieldOfViewMetrics): number {
+  const occupancy = calcOccupancyScore(metrics.horizontal_ratio);
+  const distortionQuality = clamp01(
+    1 - metrics.distortion_score / DISTORTION_MAX,
+  );
+  return occupancy * W_OCCUPANCY + distortionQuality * W_DISTORTION;
+}
+
+/**
+ * 総合スコアから推奨度レベルを判定する。
+ */
+export function getRecommendation(
+  metrics: FieldOfViewMetrics,
+): RecommendationLevel {
+  const score = calcSeatScore(metrics);
+  if (score >= THRESHOLD_EXCELLENT) return 'excellent';
+  if (score >= THRESHOLD_GOOD) return 'good';
+  if (score >= THRESHOLD_FAIR) return 'fair';
+  return 'poor';
+}


### PR DESCRIPTION
## 概要
未接続だった投影風シェーダー（`screenVertex`/`screenFragment`）を `ScreenMesh` へ配線し、スクリーンを `meshBasicMaterial` の単色青（#3a4a8a）＝「青い板」から、「上映中の幕」風の暗色グラデ＋ビネットに変更。

- **prefers-reduced-motion 有効時は `uTime` を進めず**アニメ（12Hzフリッカー含む）を停止（WCAG 2.3.1 点滅/発作）。
- フレーム更新ロジックを `advanceScreenTime` として純関数化し単体テスト。
- `screenShaders.test.ts` でシェーダー配線（uTime/vUv/ビネット/フリッカー）を表明。
- `screenMesh.test.tsx` の stale モックを整理。

Closes #459

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## スクリーンショット（一人称・Dolby Cinema H列10番・同一席で比較）
| Before（単色青の「板」） | After（投影シェーダー） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/756a60da-f211-4f74-9c03-2f380271fd2e) | ![after](https://github.com/user-attachments/assets/ddae99a1-a4e5-4e80-a414-e91dd565abc5) |

俯瞰（After）:

![overview-after](https://github.com/user-attachments/assets/b6156ac2-ad36-4db1-a205-c8b69fcf88f8)

## 動作動画（一人称・シェーダー描画）

https://github.com/user-attachments/assets/6738fb79-34e3-4a9c-bef5-b5833a511a91

## レビューポイント
- スクリーン本体を `shaderMaterial`（既存 `screenVertexShader`/`screenFragmentShader`）へ置換。`toneMapped={false}` は従来踏襲。
- `reducedMotion`（page→ScreenMesh に既存配線）で `useFrame` の時間更新をゲート＝アニメ停止。
- ベゼル・Edges・Z-fighting 回避オフセットは従来のまま。
- ※ Before の単色青は #463/#460 マージ前の main 実装。After は本ブランチ。

## テスト
- `screenMesh.test.tsx`: `advanceScreenTime`（通常は delta 加算 / reducedMotion で据え置き＝フリッカー停止）を検証。
- `screenShaders.test.ts`（新規）: 配線シェーダーの uniform/varying・演出要素を表明。
- theaterExperience 全体 **196 tests green** / tsc・eslint クリーン。
