### PR TITLE
feat(theater): 音響ヒートマップをviridis配色化＋数値凡例を追加（Closes #461）

### DIFF
--- a/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.module.scss
+++ b/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.module.scss
@@ -1,0 +1,42 @@
+@use '@/styles/variables' as *;
+
+// viridis カラーマップのCSS近似。
+// GLSLシェーダー(audioHeatmap.frag) の intensityToColor と配色を一致させる。
+// viridis は知覚均一・色覚多様性(CVD)セーフな連続カラーマップ。
+$viridis-gradient: linear-gradient(
+  to right,
+  #440154 0%,
+  #3b528b 25%,
+  #21918c 50%,
+  #5ec962 75%,
+  #fde725 100%
+);
+
+.c_heatmap_legend {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+}
+
+.c_heatmap_legend__title {
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  color: $text-secondary;
+}
+
+.c_heatmap_legend__bar {
+  height: $spacing-2;
+  border-radius: $border-radius-sm;
+  background: $viridis-gradient;
+  border: $border-width-1 solid color-alpha(--gray-500, 20%);
+}
+
+.c_heatmap_legend__ticks {
+  display: flex;
+  justify-content: space-between;
+}
+
+.c_heatmap_legend__tick {
+  font-size: $font-size-2xs;
+  color: $text-secondary;
+}

--- a/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.test.tsx
+++ b/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * HeatmapLegend コンポーネント テスト
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { HeatmapLegend } from './heatmapLegend';
+
+describe('HeatmapLegend', () => {
+  it('凡例グループがラベル付きで表示される', () => {
+    render(<HeatmapLegend />);
+
+    expect(
+      screen.getByRole('group', { name: '音響ヒートマップの凡例' }),
+    ).toBeInTheDocument();
+  });
+
+  it('タイトル（相対音圧）を表示する', () => {
+    render(<HeatmapLegend />);
+
+    expect(screen.getByText('相対音圧（正規化）')).toBeInTheDocument();
+  });
+
+  it('色に依存せず読める数値スケール（0%/50%/100%）を表示する', () => {
+    render(<HeatmapLegend />);
+
+    expect(screen.getByText('弱 0%')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('強 100%')).toBeInTheDocument();
+  });
+});

--- a/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.tsx
+++ b/src/features/theaterExperience/component/heatmapLegend/heatmapLegend.tsx
@@ -1,0 +1,40 @@
+/**
+ * HeatmapLegendコンポーネント
+ * 音響ヒートマップのカラーマップ（viridis）と相対音圧スケールの凡例。
+ * 色のみに依存せず数値ラベルで強度を読めるようにする（色覚多様性への配慮）。
+ */
+
+'use client';
+
+import { memo } from 'react';
+
+import { cn } from '@/utils/cn';
+
+import styles from './heatmapLegend.module.scss';
+
+export interface HeatmapLegendProps {
+  /** 追加クラス名 */
+  className?: string;
+}
+
+export const HeatmapLegend = memo<HeatmapLegendProps>(function HeatmapLegend({
+  className,
+}) {
+  return (
+    <div
+      className={cn(styles.c_heatmap_legend, className)}
+      role='group'
+      aria-label='音響ヒートマップの凡例'
+    >
+      <span className={styles.c_heatmap_legend__title}>相対音圧（正規化）</span>
+      <div className={styles.c_heatmap_legend__bar} aria-hidden='true' />
+      <div className={styles.c_heatmap_legend__ticks}>
+        <span className={styles.c_heatmap_legend__tick}>弱 0%</span>
+        <span className={styles.c_heatmap_legend__tick}>50%</span>
+        <span className={styles.c_heatmap_legend__tick}>強 100%</span>
+      </div>
+    </div>
+  );
+});
+
+HeatmapLegend.displayName = 'HeatmapLegend';

--- a/src/features/theaterExperience/shaders/audioHeatmap.frag.glsl
+++ b/src/features/theaterExperience/shaders/audioHeatmap.frag.glsl
@@ -5,7 +5,7 @@
  * - 距離減衰（振幅 ∝ 1/d, 逆二乗則ベース）
  * - 大気吸収（ISO 9613-1ベース, exp(-kd)）
  * - Phasor sum による時間平均干渉パターン
- * - カラーマッピング（青→緑→黄→赤）
+ * - カラーマッピング（viridis: 知覚均一・色覚多様性(CVD)セーフ）
  */
 
 precision mediump float;
@@ -91,25 +91,22 @@ float calcAbsorptionLoss(float distance) {
 }
 
 /**
- * HSVからRGBへの変換
- */
-vec3 hsv2rgb(vec3 c) {
-  vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-  vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-  return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-}
-
-/**
- * 強度からヒートマップカラーへ変換
- * 紫(低) → 青 → シアン → 緑 → 黄 → 赤(高)
+ * 強度からヒートマップカラーへ変換（viridis 近似）
+ * viridis は知覚均一かつ色覚多様性(CVD)セーフな連続カラーマップ。
+ * レインボー(hue回転)は中〜高で緑〜黄〜赤が潰れて判別不能なため置換。
+ * 多項式近似の係数は公開実装（https://www.shadertoy.com/view/WlfXRN, public domain）由来。
+ * 低(暗い紫) → 青 → 緑 → 黄(高)
  */
 vec3 intensityToColor(float intensity) {
   float t = clamp(intensity, 0.0, 1.0);
-  // Hue: 0.75(purple) → 0.0(red)
-  float hue = mix(0.75, 0.0, t);
-  float sat = 0.7 + 0.3 * t;
-  float val = 0.4 + 0.6 * t;
-  return hsv2rgb(vec3(hue, sat, val));
+  const vec3 c0 = vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
+  const vec3 c1 = vec3(0.1050930431085774, 1.404613529898575, 1.384590162594685);
+  const vec3 c2 = vec3(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
+  const vec3 c3 = vec3(-4.634230498983486, -5.799100973351585, -19.33244095627987);
+  const vec3 c4 = vec3(6.228269936347081, 14.17993336680509, 56.69055260068105);
+  const vec3 c5 = vec3(4.776384997670288, -13.74514537774601, -65.35303263337234);
+  const vec3 c6 = vec3(-5.435455855934631, 4.645852612178535, 26.3124352495832);
+  return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
 void main() {

--- a/src/features/theaterExperience/shaders/audioHeatmap.frag.ts
+++ b/src/features/theaterExperience/shaders/audioHeatmap.frag.ts
@@ -13,7 +13,7 @@ export const fragmentShader = /* glsl */ `
  * - 距離減衰（振幅 ∝ 1/d, 逆二乗則ベース）
  * - 大気吸収（ISO 9613-1ベース, exp(-kd)）
  * - Phasor sum による時間平均干渉パターン
- * - カラーマッピング（青→緑→黄→赤）
+ * - カラーマッピング（viridis: 知覚均一・色覚多様性(CVD)セーフ）
  */
 
 precision mediump float;
@@ -99,25 +99,22 @@ float calcAbsorptionLoss(float distance) {
 }
 
 /**
- * HSVからRGBへの変換
- */
-vec3 hsv2rgb(vec3 c) {
-  vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-  vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-  return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-}
-
-/**
- * 強度からヒートマップカラーへ変換
- * 紫(低) → 青 → シアン → 緑 → 黄 → 赤(高)
+ * 強度からヒートマップカラーへ変換（viridis 近似）
+ * viridis は知覚均一かつ色覚多様性(CVD)セーフな連続カラーマップ。
+ * レインボー(hue回転)は中〜高で緑〜黄〜赤が潰れて判別不能なため置換。
+ * 多項式近似の係数は公開実装（https://www.shadertoy.com/view/WlfXRN, public domain）由来。
+ * 低(暗い紫) → 青 → 緑 → 黄(高)
  */
 vec3 intensityToColor(float intensity) {
   float t = clamp(intensity, 0.0, 1.0);
-  // Hue: 0.75(purple) → 0.0(red)
-  float hue = mix(0.75, 0.0, t);
-  float sat = 0.7 + 0.3 * t;
-  float val = 0.4 + 0.6 * t;
-  return hsv2rgb(vec3(hue, sat, val));
+  const vec3 c0 = vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
+  const vec3 c1 = vec3(0.1050930431085774, 1.404613529898575, 1.384590162594685);
+  const vec3 c2 = vec3(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
+  const vec3 c3 = vec3(-4.634230498983486, -5.799100973351585, -19.33244095627987);
+  const vec3 c4 = vec3(6.228269936347081, 14.17993336680509, 56.69055260068105);
+  const vec3 c5 = vec3(4.776384997670288, -13.74514537774601, -65.35303263337234);
+  const vec3 c6 = vec3(-5.435455855934631, 4.645852612178535, 26.3124352495832);
+  return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
 }
 
 void main() {

--- a/src/features/theaterExperience/shaders/audioHeatmapShader.test.ts
+++ b/src/features/theaterExperience/shaders/audioHeatmapShader.test.ts
@@ -1,0 +1,36 @@
+/**
+ * 音響ヒートマップシェーダーのカラーマップ配線テスト
+ * レインボー(hue回転)から viridis(CVDセーフ・知覚均一)への置換と、
+ * 実バンドル(.ts)と正規ソース(.glsl)の同期を担保する。
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { fragmentShader } from './audioHeatmap.frag';
+
+/** viridis 多項式近似の代表係数（c0.r） */
+const VIRIDIS_MARKER = '0.2777273272234177';
+
+describe('audioHeatmap fragment shader (実バンドル .ts)', () => {
+  it('viridis 近似カラーマップを使用する', () => {
+    expect(fragmentShader).toContain('intensityToColor');
+    expect(fragmentShader).toContain(VIRIDIS_MARKER);
+  });
+
+  it('レインボー(hsv2rgb / hue回転)を使用しない', () => {
+    expect(fragmentShader).not.toContain('hsv2rgb');
+  });
+});
+
+describe('audioHeatmap 正規ソース .glsl との同期', () => {
+  const glsl = readFileSync(join(__dirname, 'audioHeatmap.frag.glsl'), 'utf8');
+
+  it('.glsl も viridis 係数を持つ', () => {
+    expect(glsl).toContain(VIRIDIS_MARKER);
+  });
+
+  it('.glsl も hsv2rgb を含まない', () => {
+    expect(glsl).not.toContain('hsv2rgb');
+  });
+});

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -27,6 +27,7 @@ import { SeatInfoPanel } from '../component/seatInfoPanel/seatInfoPanel';
 import { SeatA11yList } from '../component/seatA11yList/seatA11yList';
 import { FrequencySelector } from '../component/frequencySelector/frequencySelector';
 import { HeatmapToggle } from '../component/heatmapToggle/heatmapToggle';
+import { HeatmapLegend } from '../component/heatmapLegend/heatmapLegend';
 import { UnsupportedBrowserNotice } from '../component/unsupportedBrowserNotice/unsupportedBrowserNotice';
 import { TheaterSelector } from '../component/theaterSelector/theaterSelector';
 
@@ -329,6 +330,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
               value={frequencyBand}
               onValueChange={handleFrequencyChange}
             />
+            {isHeatmapVisible && <HeatmapLegend />}
             <SeatInfoPanel
               seat={selectedSeat}
               fovMetrics={fovMetrics}


### PR DESCRIPTION
## 概要
音響ヒートマップのカラーマップを**レインボー(HSV hue回転)** から **viridis(知覚均一・色覚多様性(CVD)セーフ)** へ置換し、色のみ依存を排除する相対音圧の**数値凡例(HeatmapLegend)** を追加。

- レインボーは中〜高音圧の緑〜黄〜赤が deuteranopia/protanopia で潰れ判別不能 → viridis 近似へ。
- 実バンドル `audioHeatmap.frag.ts` と正規ソース `.glsl` の**両方を更新し同期**（未使用になった `hsv2rgb` を撤去）。
- `HeatmapLegend`: viridis グラデ＋「弱 0% / 50% / 強 100%」の数値目盛り（ヒートマップ表示中のみ表示）。

Closes #461

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## スクリーンショット（Dolby Cinema・音響ヒートマップ表示）
| Before（レインボー・凡例なし） | After（viridis＋数値凡例） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/78f7a63c-2625-4ba9-b693-785907567d9e) | ![after](https://github.com/user-attachments/assets/7967b05c-7e68-4d67-8eb7-79c8eab73901) |

## 動作動画（viridis ヒートマップ）

https://github.com/user-attachments/assets/e0c0bdda-88a7-45c7-8ea8-aa092567e347

## レビューポイント
- カラーマップは `.ts`（実バンドル＝Turbopack回避のインライン）と `.glsl`（正規ソース）の**2ファイル同期**が必要。テストで両方を検証。
- 凡例の viridis HEX（`heatmapLegend.module.scss`）は**シェーダー出力と一致させる科学的カラーマップ**のためデザイントークン化に馴染まない例外（pre-commitレビューでも許容と判断、コメントで意図明記。消費者は1箇所のみ）。
- 凡例は「色＋数値目盛り」で色のみ依存を排除（CVD配慮）。
- ※ スクショ左の**スクリーンが青い**のは、本ブランチが #459（スクリーンのシェーダー配線）マージ前に分岐したためで、本PRのヒートマップ変更とは無関係（main マージ時に解消）。

## テスト
- `audioHeatmapShader.test.ts`（新規）: `.ts`/`.glsl` 両方で viridis 係数・`hsv2rgb` 除去を検証（同期担保）。
- `heatmapLegend.test.tsx`（新規）: グループラベル・タイトル・数値スケール表示を検証。
- theaterExperience 全体 **197 tests green** / tsc・eslint クリーン。
