### PR TITLE
fix(theater): 2Dリストの車椅子席に席番号を併記（Closes #472）

### DIFF
--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
@@ -61,6 +61,7 @@ $seat-cell-size: 28px;
 
 .c_seat_a11y_list__seat_button {
   @include button-reset;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -87,6 +88,19 @@ $seat-cell-size: 28px;
 .c_seat_a11y_list__seat_button__wheelchair {
   // 色以外の形状手掛かり（破線枠）でも車椅子席を示す（色覚に依存しない）
   border: $border-width-1 dashed color-alpha(--gray-500, 55%);
+}
+
+// 車椅子マーカー。番号を主表示に残しつつ、隅に小さく重ねて識別性を保つ
+// （席番号が晴眼者にも読めるようにする）
+.c_seat_a11y_list__wheelchair_icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: $font-size-2xs;
+  line-height: 1;
+  pointer-events: none;
+  transform: scale(0.7);
+  transform-origin: top right;
 }
 
 .c_seat_a11y_list__seat_button__selected {

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
@@ -156,6 +156,8 @@ describe('SeatA11yList', () => {
 
     const button = screen.getByRole('button');
     expect(button.getAttribute('aria-label')).toContain('車椅子席');
+    // 席番号を主表示に残しつつ ♿ マーカーも併記する（番号が読める）
+    expect(button).toHaveTextContent('1');
     expect(button).toHaveTextContent('♿');
   });
 });

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
@@ -143,10 +143,14 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
                     title={formatSeatLabel(seat, metrics)}
                     onClick={() => handleSeatClick(seat)}
                   >
-                    {seat.seat_type === 'wheelchair' ? (
-                      <span aria-hidden='true'>♿</span>
-                    ) : (
-                      seat.seat_number
+                    {seat.seat_number}
+                    {seat.seat_type === 'wheelchair' && (
+                      <span
+                        aria-hidden='true'
+                        className={styles.c_seat_a11y_list__wheelchair_icon}
+                      >
+                        ♿
+                      </span>
                     )}
                   </button>
                 </li>


### PR DESCRIPTION
## 概要
2D座席一覧で車椅子席がマス目の番号の代わりに♿へ置換され、晴眼ユーザーが席番号を読めなかった問題を解消。番号を主表示に戻し、♿を隅の小マーカーとして重ねた（破線枠・凡例は維持）。

Closes #472

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## スクリーンショット（Dolby Cinema・座席一覧 M列に車椅子席）
| Before（♿のみ・番号不明） | After（番号＋♿マーカー） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/a23157e2-571a-4fb3-952c-b225cabea82c) | ![after](https://github.com/user-attachments/assets/e2f6a4fa-395c-469e-abe8-79c8158f8cf9) |

※ M列の車椅子席が Before「♿」→ After「6♿ / 15♿」（番号が読める）。

## レビューポイント
- 番号を主表示、♿ は絶対配置の小マーカー（`aria-hidden` / `pointer-events:none` / 28pxセルに収まるよう `scale(0.7)`）。
- `aria-label` は従来どおり「（車椅子席）」を含み SR でも識別可。
- 破線枠（形状手がかり）は維持。

## テスト
- `seatA11yList.test.tsx`: 車椅子席ボタンに「番号」と「♿」の**両方**が表示されることを検証。
- theaterExperience 全体 green / tsc・eslint クリーン。