### PR TITLE
refactor(theater): 座席の無効な2色交互配色を撤廃し単色化（Closes #470）

### DIFF
--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
@@ -96,11 +96,8 @@ describe('getSeatColorKey', () => {
     );
   });
 
-  it('偶数文字コードの列は rowEven（B列）', () => {
-    expect(getSeatColorKey({ ...base, row_label: 'B' }, null)).toBe('rowEven');
-  });
-
-  it('奇数文字コードの列は rowOdd（A列）', () => {
-    expect(getSeatColorKey({ ...base, row_label: 'A' }, null)).toBe('rowOdd');
+  it('通常席は単色 seat（列に依らず一定）', () => {
+    expect(getSeatColorKey({ ...base, row_label: 'A' }, null)).toBe('seat');
+    expect(getSeatColorKey({ ...base, row_label: 'B' }, null)).toBe('seat');
   });
 });

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -39,18 +39,19 @@ declare module '@react-three/fiber' {
 const SEAT_CUSHION = { width: 0.5, height: 0.12, depth: 0.45 };
 const SEAT_BACK = { width: 0.5, height: 0.5, depth: 0.08 };
 
-/** ドールハウス座席カラー（列ごとに交互） */
-const COLOR_SEAT_A = new Color('#c44545');
-const COLOR_SEAT_B = new Color('#b03838');
+/** ドールハウス座席カラー（単色） */
+const COLOR_SEAT = new Color('#bf4040');
 const COLOR_SELECTED = new Color('#ffaa00');
 /** 車椅子席カラー（他席と区別できる青系） */
 const COLOR_WHEELCHAIR = new Color('#3b82f6');
 
 /** 座席の色種別キー（純粋・テスト用にexport） */
-export type SeatColorKey = 'selected' | 'wheelchair' | 'rowEven' | 'rowOdd';
+export type SeatColorKey = 'selected' | 'wheelchair' | 'seat';
 
 /**
- * 座席の色種別を決定する。優先度: 選択中 > 車椅子席 > 列ごとの交互色。
+ * 座席の色種別を決定する。優先度: 選択中 > 車椅子席 > 通常席（単色）。
+ * 旧実装は列ごとの2色交互だったが、輝度差が視認閾値未満（コントラスト比≈1.24:1）で
+ * 列識別に寄与せず無効な配色だったため撤廃。列識別は2D座席一覧が担う。
  */
 export function getSeatColorKey(
   seat: TheaterSeat,
@@ -58,15 +59,13 @@ export function getSeatColorKey(
 ): SeatColorKey {
   if (seat.id === selectedSeatId) return 'selected';
   if (seat.seat_type === 'wheelchair') return 'wheelchair';
-  // 列ごとに2色交互（row_label文字コード偶奇）
-  return seat.row_label.charCodeAt(0) % 2 === 0 ? 'rowEven' : 'rowOdd';
+  return 'seat';
 }
 
 const SEAT_COLOR_BY_KEY: Record<SeatColorKey, Color> = {
   selected: COLOR_SELECTED,
   wheelchair: COLOR_WHEELCHAIR,
-  rowEven: COLOR_SEAT_A,
-  rowOdd: COLOR_SEAT_B,
+  seat: COLOR_SEAT,
 };
 
 function getSeatColor(seat: TheaterSeat, selectedSeatId: string | null): Color {


### PR DESCRIPTION
## 概要
3D座席の「列ごと2色交互」配色（#c44545/#b03838）は輝度差が視認閾値未満（コントラスト比≈1.24:1）で列識別に寄与しない**無効な配色（デッド配色）** だった。単色(#bf4040)へ統一して撤廃。列識別は2D座席一覧（row_label）が担う。

Closes #470

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## スクリーンショット（Dolby Cinema 俯瞰・After）
![after](https://github.com/user-attachments/assets/28192956-37ca-414e-803a-b1e17f6f5b80)

※ 元の2色差は視認閾値未満（≈1.24:1）だったため、**見た目は Before と実質同一**です（＝これが「無効配色の撤廃」の証左）。identical な Before 画像は情報を持たないため省略し、理由を明記しています。座席は単色の赤で描画されます。

## レビューポイント
- `SeatColorKey` を `'rowEven'|'rowOdd'` → `'seat'` に集約、`COLOR_SEAT_A/B` → 単色 `COLOR_SEAT`。
- 選択（琥珀 #ffaa00）／車椅子席（青 #3b82f6）の区別は維持。
- KISS 優先で撤廃（意味のある列配色が必要になれば別途）。

## テスト
- `seatMeshes.test.tsx`: `getSeatColorKey` が通常席で列に依らず `'seat'` を返すことを検証。
- theaterExperience 全体 green / tsc・eslint クリーン。