### PR TITLE
fix(theater): 通路灯を足元の小型発光体＋加算グローに変更（Closes #464）

### DIFF
--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -16,6 +16,7 @@ import { useThree } from '@react-three/fiber';
 import {
   PlaneGeometry,
   Vector3,
+  AdditiveBlending,
   type OrthographicCamera as OrthographicCameraType,
   type PerspectiveCamera as PerspectiveCameraType,
 } from 'three';
@@ -238,8 +239,10 @@ const BackStepFill = memo<{
 BackStepFill.displayName = 'BackStepFill';
 
 /**
- * 通路灯（壁際の小さな発光体）
- * 両側通路に等間隔で配置。観客の足元を照らす雰囲気作り。
+ * 通路灯（壁際・足元の小さな発光体）
+ * 両側通路に等間隔で配置。旧実装は半径0.22m+グロー0.5mの大きな発光球で「浮いた
+ * 金色の玉」に見え、しかもグローが加算合成でなく暗環（黒い縁取り）になっていた。
+ * 足元(y≈0.15)の小型発光体＋加算合成の淡いグローに変更し、足元灯らしくする。
  */
 const AisleLights = memo<{
   roomWidth: number;
@@ -257,8 +260,9 @@ const AisleLights = memo<{
     for (let i = 0; i < count; i++) {
       const t = i / (count - 1);
       const z = seatAreaFrontZ - t * length;
-      positions.push([-(halfWidth - wallOffset), 0.4, z]);
-      positions.push([halfWidth - wallOffset, 0.4, z]);
+      // 足元(床際)に配置
+      positions.push([-(halfWidth - wallOffset), 0.15, z]);
+      positions.push([halfWidth - wallOffset, 0.15, z]);
     }
     return positions;
   }, [halfWidth, seatAreaFrontZ, seatAreaBackZ]);
@@ -267,18 +271,20 @@ const AisleLights = memo<{
     <group>
       {lights.map((pos) => (
         <group key={`${pos[0]},${pos[2]}`} position={pos}>
-          {/* メイン発光体 */}
+          {/* 足元の小さな発光体 */}
           <mesh>
-            <sphereGeometry args={[0.22, 14, 14]} />
+            <sphereGeometry args={[0.08, 12, 12]} />
             <meshBasicMaterial color={COLOR_AISLE_LIGHT} toneMapped={false} />
           </mesh>
-          {/* 周囲の薄いグロー */}
+          {/* 加算合成の淡いグロー（暗環にならず自然に滲む） */}
           <mesh>
-            <sphereGeometry args={[0.5, 14, 14]} />
+            <sphereGeometry args={[0.22, 12, 12]} />
             <meshBasicMaterial
               color={COLOR_AISLE_LIGHT}
               transparent
-              opacity={0.22}
+              opacity={0.35}
+              blending={AdditiveBlending}
+              depthWrite={false}
               toneMapped={false}
             />
           </mesh>


### PR DESCRIPTION
## 概要
通路灯が半径0.22m＋グロー0.5m（非加算）の大きな発光球で「浮いた金色の玉」に見え、グローが加算合成でないため暗環（黒い縁取り）化していた。足元(y=0.15)の小型球(0.08)＋加算合成の淡いグロー(0.22 / AdditiveBlending / depthWrite=false)へ変更し、足元灯らしくした。

Closes #464

## ロードマップ
該当なし（ロードマップ外のフォローアップ改善）。

## スクリーンショット（標準シアター 俯瞰・右通路の通路灯）
| Before（大きな金色球が浮遊） | After（小さな足元の点光源） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/aa6c39d3-76b0-4b59-ad01-b5b2571e6d7f) | ![after](https://github.com/user-attachments/assets/85153df9-c568-4088-8a18-fc7ba2aaa9a9) |

## レビューポイント
- コア球 0.22→0.08、グロー球 0.5→0.22、y 0.4→0.15（足元）。
- グローに `AdditiveBlending` + `depthWrite=false` を付与し暗環を解消。
- ※ 精密な傾斜床追従は KISS 上見送り（足元高さ固定）。将来 Bloom(#474) 導入時は自作グロー球を削除可。

## テスト
- theaterScene 既存テスト green / tsc・eslint クリーン（描画は既存方針によりユニットテスト対象外）。