### PR TITLE
feat(theater): 俯瞰3Dと2Dリストの相互ホバー＋席番号ラベルで席選択の道具化（Closes #468）

### DIFF
--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
@@ -103,6 +103,15 @@ $seat-cell-size: 28px;
   transform-origin: top right;
 }
 
+// 俯瞰3Dのホバーと相互連動する強調リング。
+// マウスの :hover とは別経路（3D側からのホバーやキーボードフォーカス）でも点灯し、
+// 2Dリストと3D座席のどちらをポイントしても対応席が同時に強調される。
+.c_seat_a11y_list__seat_button__hovered {
+  background-color: color-alpha(--warning-main, 15%);
+  box-shadow: 0 0 0 $border-width-2 $warning-main;
+  color: $text-primary;
+}
+
 .c_seat_a11y_list__seat_button__selected {
   background-color: $primary-500;
   color: $text-inverse;

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
@@ -103,12 +103,15 @@ $seat-cell-size: 28px;
   transform-origin: top right;
 }
 
-// 俯瞰3Dのホバーと相互連動する強調リング。
+// 俯瞰3Dのホバー/フォーカスと相互連動する強調リング。
 // マウスの :hover とは別経路（3D側からのホバーやキーボードフォーカス）でも点灯し、
 // 2Dリストと3D座席のどちらをポイントしても対応席が同時に強調される。
-.c_seat_a11y_list__seat_button__hovered {
-  background-color: color-alpha(--warning-main, 15%);
-  box-shadow: 0 0 0 $border-width-2 $warning-main;
+// リング色は --warning-dark(#d97706)。明色背景(#fafafa)で 3.05:1 と WCAG 1.4.11
+// (非テキスト3:1) を満たす（--warning-main の 2.06:1 では不足）。3D枠と同色に統一。
+// 併せて文字色を $text-primary に濃くし、色以外の手掛かり（輝度差）でも状態を示す。
+.c_seat_a11y_list__seat_button__highlighted {
+  background-color: color-alpha(--warning-dark, 12%);
+  box-shadow: 0 0 0 $border-width-2 $warning-dark;
   color: $text-primary;
 }
 

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import type { TheaterSeat, Theater } from '../../types';
 
 import { SeatA11yList } from './seatA11yList';
+import styles from './seatA11yList.module.scss';
 
 const mockTheater: Theater = {
   id: 'uuid-1',
@@ -60,7 +61,9 @@ describe('SeatA11yList', () => {
     seats: mockSeats,
     theater: mockTheater,
     selectedSeatId: null,
+    hoveredSeatId: null,
     onSelectSeat: jest.fn(),
+    onHoverSeat: jest.fn(),
   };
 
   beforeEach(() => {
@@ -138,6 +141,45 @@ describe('SeatA11yList', () => {
     // グリッド列数は最大席番号
     const ul = li?.parentElement as HTMLElement;
     expect(ul.style.getPropertyValue('--seat-cols')).toBe('5');
+  });
+
+  it('ホバーで onHoverSeat が席IDで呼ばれ、解除で null が渡る（3Dと相互連動）', async () => {
+    const user = userEvent.setup();
+    const onHoverSeat = jest.fn();
+
+    render(<SeatA11yList {...defaultProps} onHoverSeat={onHoverSeat} />);
+
+    const button = screen.getAllByRole('button')[0];
+    await user.hover(button);
+    expect(onHoverSeat).toHaveBeenCalledWith('seat-a1');
+
+    await user.unhover(button);
+    expect(onHoverSeat).toHaveBeenCalledWith(null);
+  });
+
+  it('フォーカスでも onHoverSeat が呼ばれる（キーボード連動）', async () => {
+    const user = userEvent.setup();
+    const onHoverSeat = jest.fn();
+
+    render(<SeatA11yList {...defaultProps} onHoverSeat={onHoverSeat} />);
+
+    await user.tab();
+    expect(screen.getAllByRole('button')[0]).toHaveFocus();
+    expect(onHoverSeat).toHaveBeenCalledWith('seat-a1');
+  });
+
+  it('hoveredSeatId が指す席に強調クラスが付く', () => {
+    render(<SeatA11yList {...defaultProps} hoveredSeatId='seat-a2' />);
+
+    const buttons = screen.getAllByRole('button');
+    // A列2番がホバー強調される
+    expect(buttons[1]).toHaveClass(
+      styles.c_seat_a11y_list__seat_button__hovered,
+    );
+    // その他は強調されない
+    expect(buttons[0]).not.toHaveClass(
+      styles.c_seat_a11y_list__seat_button__hovered,
+    );
   });
 
   it('車椅子席は♿マーカーと車椅子席ラベルが付く', () => {

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.test.tsx
@@ -61,9 +61,10 @@ describe('SeatA11yList', () => {
     seats: mockSeats,
     theater: mockTheater,
     selectedSeatId: null,
-    hoveredSeatId: null,
+    highlightedSeatId: null,
     onSelectSeat: jest.fn(),
     onHoverSeat: jest.fn(),
+    onFocusSeat: jest.fn(),
   };
 
   beforeEach(() => {
@@ -143,7 +144,7 @@ describe('SeatA11yList', () => {
     expect(ul.style.getPropertyValue('--seat-cols')).toBe('5');
   });
 
-  it('ホバーで onHoverSeat が席IDで呼ばれ、解除で null が渡る（3Dと相互連動）', async () => {
+  it('マウスホバーで onHoverSeat が席IDで呼ばれ、解除で null が渡る（3Dと相互連動）', async () => {
     const user = userEvent.setup();
     const onHoverSeat = jest.fn();
 
@@ -157,28 +158,42 @@ describe('SeatA11yList', () => {
     expect(onHoverSeat).toHaveBeenCalledWith(null);
   });
 
-  it('フォーカスでも onHoverSeat が呼ばれる（キーボード連動）', async () => {
+  it('キーボードフォーカスは onFocusSeat（ホバーとは別チャネル）で連動し、blurで解除される', async () => {
     const user = userEvent.setup();
+    const onFocusSeat = jest.fn();
     const onHoverSeat = jest.fn();
 
-    render(<SeatA11yList {...defaultProps} onHoverSeat={onHoverSeat} />);
+    render(
+      <SeatA11yList
+        {...defaultProps}
+        onFocusSeat={onFocusSeat}
+        onHoverSeat={onHoverSeat}
+      />,
+    );
 
+    // 先頭ボタンへフォーカス → onFocusSeat（onHoverSeatは呼ばれない）
     await user.tab();
     expect(screen.getAllByRole('button')[0]).toHaveFocus();
-    expect(onHoverSeat).toHaveBeenCalledWith('seat-a1');
+    expect(onFocusSeat).toHaveBeenCalledWith('seat-a1');
+    expect(onHoverSeat).not.toHaveBeenCalled();
+
+    // 次ボタンへフォーカス移動 → 前ボタンの blur で null、新ボタンで席ID
+    await user.tab();
+    expect(onFocusSeat).toHaveBeenCalledWith(null);
+    expect(onFocusSeat).toHaveBeenLastCalledWith('seat-a2');
   });
 
-  it('hoveredSeatId が指す席に強調クラスが付く', () => {
-    render(<SeatA11yList {...defaultProps} hoveredSeatId='seat-a2' />);
+  it('highlightedSeatId が指す席に強調クラスが付く', () => {
+    render(<SeatA11yList {...defaultProps} highlightedSeatId='seat-a2' />);
 
     const buttons = screen.getAllByRole('button');
-    // A列2番がホバー強調される
+    // A列2番が強調される
     expect(buttons[1]).toHaveClass(
-      styles.c_seat_a11y_list__seat_button__hovered,
+      styles.c_seat_a11y_list__seat_button__highlighted,
     );
     // その他は強調されない
     expect(buttons[0]).not.toHaveClass(
-      styles.c_seat_a11y_list__seat_button__hovered,
+      styles.c_seat_a11y_list__seat_button__highlighted,
     );
   });
 

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
@@ -21,12 +21,14 @@ export interface SeatA11yListProps {
   theater: Theater;
   /** 選択中の座席ID */
   selectedSeatId: string | null;
-  /** ホバー中の座席ID（俯瞰3Dと相互ハイライト） */
-  hoveredSeatId: string | null;
+  /** 強調表示する座席ID（ポインタホバー or キーボードフォーカス由来。俯瞰3Dと相互ハイライト） */
+  highlightedSeatId: string | null;
   /** 座席選択コールバック */
   onSelectSeat: (seat: TheaterSeat) => void;
-  /** 座席ホバー変化コールバック（null=ホバー解除） */
+  /** ポインタホバー変化コールバック（null=ホバー解除） */
   onHoverSeat: (seatId: string | null) => void;
+  /** キーボードフォーカス変化コールバック（null=フォーカス解除） */
+  onFocusSeat: (seatId: string | null) => void;
   /** 追加クラス名 */
   className?: string;
 }
@@ -62,23 +64,27 @@ interface SeatButtonProps {
   seat: TheaterSeat;
   metrics: FieldOfViewMetrics | null;
   isSelected: boolean;
-  isHovered: boolean;
+  isHighlighted: boolean;
   onSelectSeat: (seat: TheaterSeat) => void;
   onHoverSeat: (seatId: string | null) => void;
+  onFocusSeat: (seatId: string | null) => void;
 }
 
 /**
  * 座席ボタン1つ。イベントハンドラーを座席単位で useCallback 安定化するため、
  * リスト map からコンポーネントとして切り出している。
- * マウスホバーに加えキーボードフォーカスでも onHoverSeat を発火し、俯瞰3Dと連動する。
+ * ポインタ(onMouseEnter/Leave)とキーボードフォーカス(onFocus/Blur)を別チャネルで通知し、
+ * ページ側で `hovered ?? focused` に統合して俯瞰3Dと相互連動させる。両者を単一状態に
+ * まとめると、片方の解除（例: 別席へのマウス移動）がフォーカス中の強調を消してしまう。
  */
 const SeatButton = memo<SeatButtonProps>(function SeatButton({
   seat,
   metrics,
   isSelected,
-  isHovered,
+  isHighlighted,
   onSelectSeat,
   onHoverSeat,
+  onFocusSeat,
 }) {
   const label = formatSeatLabel(seat, metrics);
 
@@ -86,11 +92,19 @@ const SeatButton = memo<SeatButtonProps>(function SeatButton({
     () => onSelectSeat(seat),
     [onSelectSeat, seat],
   );
-  const handleHover = useCallback(
+  const handlePointerEnter = useCallback(
     () => onHoverSeat(seat.id),
     [onHoverSeat, seat.id],
   );
-  const handleUnhover = useCallback(() => onHoverSeat(null), [onHoverSeat]);
+  const handlePointerLeave = useCallback(
+    () => onHoverSeat(null),
+    [onHoverSeat],
+  );
+  const handleFocus = useCallback(
+    () => onFocusSeat(seat.id),
+    [onFocusSeat, seat.id],
+  );
+  const handleBlur = useCallback(() => onFocusSeat(null), [onFocusSeat]);
 
   return (
     <li style={{ gridColumn: seat.seat_number }}>
@@ -100,17 +114,17 @@ const SeatButton = memo<SeatButtonProps>(function SeatButton({
           styles.c_seat_a11y_list__seat_button,
           seat.seat_type === 'wheelchair' &&
             styles.c_seat_a11y_list__seat_button__wheelchair,
-          isHovered && styles.c_seat_a11y_list__seat_button__hovered,
+          isHighlighted && styles.c_seat_a11y_list__seat_button__highlighted,
           isSelected && styles.c_seat_a11y_list__seat_button__selected,
         )}
         aria-pressed={isSelected}
         aria-label={label}
         title={label}
         onClick={handleClick}
-        onMouseEnter={handleHover}
-        onMouseLeave={handleUnhover}
-        onFocus={handleHover}
-        onBlur={handleUnhover}
+        onMouseEnter={handlePointerEnter}
+        onMouseLeave={handlePointerLeave}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
       >
         {seat.seat_number}
         {seat.seat_type === 'wheelchair' && (
@@ -131,9 +145,10 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
   seats,
   theater,
   selectedSeatId,
-  hoveredSeatId,
+  highlightedSeatId,
   onSelectSeat,
   onHoverSeat,
+  onFocusSeat,
   className,
 }) {
   const rowGroups = useMemo(() => groupByRow(seats), [seats]);
@@ -197,9 +212,10 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
                 seat={seat}
                 metrics={metricsMap.get(seat.id) ?? null}
                 isSelected={seat.id === selectedSeatId}
-                isHovered={seat.id === hoveredSeatId}
+                isHighlighted={seat.id === highlightedSeatId}
                 onSelectSeat={onSelectSeat}
                 onHoverSeat={onHoverSeat}
+                onFocusSeat={onFocusSeat}
               />
             ))}
           </ul>

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.tsx
@@ -21,8 +21,12 @@ export interface SeatA11yListProps {
   theater: Theater;
   /** 選択中の座席ID */
   selectedSeatId: string | null;
+  /** ホバー中の座席ID（俯瞰3Dと相互ハイライト） */
+  hoveredSeatId: string | null;
   /** 座席選択コールバック */
   onSelectSeat: (seat: TheaterSeat) => void;
+  /** 座席ホバー変化コールバック（null=ホバー解除） */
+  onHoverSeat: (seatId: string | null) => void;
   /** 追加クラス名 */
   className?: string;
 }
@@ -54,11 +58,82 @@ function formatSeatLabel(
   return `${base}、スクリーン距離${dist}m、視野占有率${hRatio}%`;
 }
 
+interface SeatButtonProps {
+  seat: TheaterSeat;
+  metrics: FieldOfViewMetrics | null;
+  isSelected: boolean;
+  isHovered: boolean;
+  onSelectSeat: (seat: TheaterSeat) => void;
+  onHoverSeat: (seatId: string | null) => void;
+}
+
+/**
+ * 座席ボタン1つ。イベントハンドラーを座席単位で useCallback 安定化するため、
+ * リスト map からコンポーネントとして切り出している。
+ * マウスホバーに加えキーボードフォーカスでも onHoverSeat を発火し、俯瞰3Dと連動する。
+ */
+const SeatButton = memo<SeatButtonProps>(function SeatButton({
+  seat,
+  metrics,
+  isSelected,
+  isHovered,
+  onSelectSeat,
+  onHoverSeat,
+}) {
+  const label = formatSeatLabel(seat, metrics);
+
+  const handleClick = useCallback(
+    () => onSelectSeat(seat),
+    [onSelectSeat, seat],
+  );
+  const handleHover = useCallback(
+    () => onHoverSeat(seat.id),
+    [onHoverSeat, seat.id],
+  );
+  const handleUnhover = useCallback(() => onHoverSeat(null), [onHoverSeat]);
+
+  return (
+    <li style={{ gridColumn: seat.seat_number }}>
+      <button
+        type='button'
+        className={cn(
+          styles.c_seat_a11y_list__seat_button,
+          seat.seat_type === 'wheelchair' &&
+            styles.c_seat_a11y_list__seat_button__wheelchair,
+          isHovered && styles.c_seat_a11y_list__seat_button__hovered,
+          isSelected && styles.c_seat_a11y_list__seat_button__selected,
+        )}
+        aria-pressed={isSelected}
+        aria-label={label}
+        title={label}
+        onClick={handleClick}
+        onMouseEnter={handleHover}
+        onMouseLeave={handleUnhover}
+        onFocus={handleHover}
+        onBlur={handleUnhover}
+      >
+        {seat.seat_number}
+        {seat.seat_type === 'wheelchair' && (
+          <span
+            aria-hidden='true'
+            className={styles.c_seat_a11y_list__wheelchair_icon}
+          >
+            ♿
+          </span>
+        )}
+      </button>
+    </li>
+  );
+});
+SeatButton.displayName = 'SeatButton';
+
 export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
   seats,
   theater,
   selectedSeatId,
+  hoveredSeatId,
   onSelectSeat,
+  onHoverSeat,
   className,
 }) {
   const rowGroups = useMemo(() => groupByRow(seats), [seats]);
@@ -94,13 +169,6 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
     return map;
   }, [seats, theater]);
 
-  const handleSeatClick = useCallback(
-    (seat: TheaterSeat) => {
-      onSelectSeat(seat);
-    },
-    [onSelectSeat],
-  );
-
   return (
     <div
       className={cn(styles.c_seat_a11y_list, className)}
@@ -123,39 +191,17 @@ export const SeatA11yList = memo<SeatA11yListProps>(function SeatA11yList({
             role='list'
             style={{ '--seat-cols': maxSeatNumber } as CSSProperties}
           >
-            {rowSeats.map((seat) => {
-              const isSelected = seat.id === selectedSeatId;
-              const metrics = metricsMap.get(seat.id) ?? null;
-
-              return (
-                <li key={seat.id} style={{ gridColumn: seat.seat_number }}>
-                  <button
-                    type='button'
-                    className={cn(
-                      styles.c_seat_a11y_list__seat_button,
-                      seat.seat_type === 'wheelchair' &&
-                        styles.c_seat_a11y_list__seat_button__wheelchair,
-                      isSelected &&
-                        styles.c_seat_a11y_list__seat_button__selected,
-                    )}
-                    aria-pressed={isSelected}
-                    aria-label={formatSeatLabel(seat, metrics)}
-                    title={formatSeatLabel(seat, metrics)}
-                    onClick={() => handleSeatClick(seat)}
-                  >
-                    {seat.seat_number}
-                    {seat.seat_type === 'wheelchair' && (
-                      <span
-                        aria-hidden='true'
-                        className={styles.c_seat_a11y_list__wheelchair_icon}
-                      >
-                        ♿
-                      </span>
-                    )}
-                  </button>
-                </li>
-              );
-            })}
+            {rowSeats.map((seat) => (
+              <SeatButton
+                key={seat.id}
+                seat={seat}
+                metrics={metricsMap.get(seat.id) ?? null}
+                isSelected={seat.id === selectedSeatId}
+                isHovered={seat.id === hoveredSeatId}
+                onSelectSeat={onSelectSeat}
+                onHoverSeat={onHoverSeat}
+              />
+            ))}
           </ul>
         </div>
       ))}

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.module.scss
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.module.scss
@@ -1,0 +1,17 @@
+@use '@/styles/variables' as *;
+
+// ホバー席の番号ラベル（drei Html オーバーレイ）。
+// Canvas上に重ねる小さなツールチップ。ポインタ透過にして3Dのホバー判定を妨げない。
+.c_seat_meshes__label {
+  display: inline-block;
+  padding: $spacing-1 $spacing-2;
+  border-radius: $border-radius-sm;
+  background-color: $overlay-darker;
+  color: $text-inverse;
+  font-size: $font-size-xs;
+  font-weight: $font-weight-medium;
+  line-height: $line-height-tight;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+}

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
@@ -66,7 +66,9 @@ describe('SeatMeshes', () => {
     const props = {
       seats: [mockSeat],
       selectedSeatId: null,
+      hoveredSeatId: null,
       onSeatClick: jest.fn(),
+      onHoverSeat: jest.fn(),
     };
 
     expect(props.seats).toHaveLength(1);

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
@@ -44,7 +44,22 @@ jest.mock('@react-three/drei', () => {
 
 import type { TheaterSeat } from '../../types';
 
-import { SeatMeshes, getSeatColorKey } from './seatMeshes';
+import {
+  SeatMeshes,
+  getSeatColorKey,
+  resolveHoverEmitId,
+  getHoverHighlightSeat,
+} from './seatMeshes';
+
+const seatAt = (id: string): TheaterSeat => ({
+  id,
+  row_label: 'A',
+  seat_number: 1,
+  position_x: 0,
+  position_y: 0,
+  position_z: 0,
+  seat_type: 'standard',
+});
 
 describe('SeatMeshes', () => {
   it('エクスポートが正しく定義されている', () => {
@@ -53,25 +68,49 @@ describe('SeatMeshes', () => {
   });
 
   it('propsの型が正しい', () => {
-    const mockSeat: TheaterSeat = {
-      id: 'seat-1',
-      row_label: 'A',
-      seat_number: 1,
-      position_x: 0,
-      position_y: 0,
-      position_z: 0,
-      seat_type: 'standard',
-    };
-
     const props = {
-      seats: [mockSeat],
+      seats: [seatAt('seat-1')],
       selectedSeatId: null,
-      hoveredSeatId: null,
+      highlightedSeatId: null,
       onSeatClick: jest.fn(),
       onHoverSeat: jest.fn(),
     };
 
     expect(props.seats).toHaveLength(1);
+  });
+});
+
+describe('resolveHoverEmitId', () => {
+  const seats = [seatAt('s0'), seatAt('s1'), seatAt('s2')];
+
+  it('俯瞰時はインスタンスに対応する座席IDを返す', () => {
+    expect(resolveHoverEmitId(seats, 1, null)).toBe('s1');
+  });
+
+  it('一人称時（selectedSeatId あり）は null を返しホバー漏れを防ぐ', () => {
+    expect(resolveHoverEmitId(seats, 1, 's0')).toBeNull();
+  });
+
+  it('instanceId 未定義や範囲外は null', () => {
+    expect(resolveHoverEmitId(seats, undefined, null)).toBeNull();
+    expect(resolveHoverEmitId(seats, 99, null)).toBeNull();
+  });
+});
+
+describe('getHoverHighlightSeat', () => {
+  const seats = [seatAt('s0'), seatAt('s1')];
+
+  it('俯瞰時は強調IDに一致する座席を返す', () => {
+    expect(getHoverHighlightSeat(seats, 's1', null)?.id).toBe('s1');
+  });
+
+  it('一人称時は常に null（枠/ラベルを出さない）', () => {
+    expect(getHoverHighlightSeat(seats, 's1', 's0')).toBeNull();
+  });
+
+  it('強調IDが null / 未一致なら null', () => {
+    expect(getHoverHighlightSeat(seats, null, null)).toBeNull();
+    expect(getHoverHighlightSeat(seats, 'nope', null)).toBeNull();
   });
 });
 

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -46,8 +46,12 @@ const COLOR_SEAT = new Color('#bf4040');
 const COLOR_SELECTED = new Color('#ffaa00');
 /** 車椅子席カラー（他席と区別できる青系） */
 const COLOR_WHEELCHAIR = new Color('#3b82f6');
-/** ホバー強調枠の色（design-system の --warning-main と一致させ、2Dリング色と揃える） */
-const HOVER_FRAME_COLOR = '#f59e0b';
+/**
+ * ホバー強調枠の色（design-system の --warning-dark と一致させ、2Dリング色と揃える）。
+ * 明色背景の2Dリングが WCAG 1.4.11(非テキスト3:1) を満たすよう、--warning-main(#f59e0b,
+ * 2.06:1) ではなく --warning-dark(#d97706, 3.05:1) を採用し、3D枠も同色に統一する。
+ */
+const HOVER_FRAME_COLOR = '#d97706';
 
 /** 座席の色種別キー（純粋・テスト用にexport） */
 export type SeatColorKey = 'selected' | 'wheelchair' | 'seat';
@@ -76,13 +80,43 @@ function getSeatColor(seat: TheaterSeat, selectedSeatId: string | null): Color {
   return SEAT_COLOR_BY_KEY[getSeatColorKey(seat, selectedSeatId)];
 }
 
+/**
+ * ポインタが座席インスタンスに乗ったとき「ホバーとして通知すべき座席ID」を返す。
+ * 一人称時（selectedSeatId あり）は俯瞰専用のホバー演出を出さないため null を返し、
+ * 2Dリストへのホバー漏れ（意図しないリング点灯）とカーソル変化を防ぐ。
+ * R3F描画に依存しない純粋関数としてテスト可能にする。
+ */
+export function resolveHoverEmitId(
+  seats: TheaterSeat[],
+  instanceId: number | undefined,
+  selectedSeatId: string | null,
+): string | null {
+  if (selectedSeatId !== null) return null;
+  if (instanceId === undefined) return null;
+  return seats[instanceId]?.id ?? null;
+}
+
+/**
+ * ホバー強調枠＋番号ラベルを描く座席を返す。俯瞰時（selectedSeatId===null）のみ有効で、
+ * 一人称では視界を妨げないため常に null。R3F描画に依存しない純粋関数。
+ */
+export function getHoverHighlightSeat(
+  seats: TheaterSeat[],
+  highlightedSeatId: string | null,
+  selectedSeatId: string | null,
+): TheaterSeat | null {
+  if (selectedSeatId !== null) return null;
+  if (!highlightedSeatId) return null;
+  return seats.find((s) => s.id === highlightedSeatId) ?? null;
+}
+
 export interface SeatMeshesProps {
   /** 座席データ一覧 */
   seats: TheaterSeat[];
   /** 選択中の座席ID */
   selectedSeatId: string | null;
-  /** ホバー中の座席ID（2Dリストと相互ハイライト） */
-  hoveredSeatId: string | null;
+  /** 強調表示する座席ID（ポインタホバー or キーボードフォーカス由来。2Dリストと相互連動） */
+  highlightedSeatId: string | null;
   /** 座席クリック時コールバック */
   onSeatClick: (seat: TheaterSeat) => void;
   /** 座席ホバー変化コールバック（null=ホバー解除） */
@@ -253,7 +287,7 @@ HoverHighlight.displayName = 'HoverHighlight';
 export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
   seats,
   selectedSeatId,
-  hoveredSeatId,
+  highlightedSeatId,
   onSeatClick,
   onHoverSeat,
 }) {
@@ -278,13 +312,16 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
 
   const handlePointerOver = useCallback(
     (event: { instanceId?: number }) => {
-      if (event.instanceId === undefined) return;
-      const seat = seats[event.instanceId];
-      if (!seat) return;
+      const seatId = resolveHoverEmitId(
+        seats,
+        event.instanceId,
+        selectedSeatId,
+      );
+      if (!seatId) return;
       document.body.style.cursor = 'pointer';
-      onHoverSeat(seat.id);
+      onHoverSeat(seatId);
     },
-    [seats, onHoverSeat],
+    [seats, onHoverSeat, selectedSeatId],
   );
 
   const handlePointerOut = useCallback(() => {
@@ -307,11 +344,8 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
   // ホバー中の席（俯瞰時のみ枠＋番号ラベルを表示）。
   // 一人称時（selectedSeatId あり）は視界を妨げないため表示しない。
   const hoveredSeat = useMemo(
-    () =>
-      selectedSeatId
-        ? null
-        : (seats.find((s) => s.id === hoveredSeatId) ?? null),
-    [seats, hoveredSeatId, selectedSeatId],
+    () => getHoverHighlightSeat(seats, highlightedSeatId, selectedSeatId),
+    [seats, highlightedSeatId, selectedSeatId],
   );
 
   return (

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -329,6 +329,18 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
     onHoverSeat(null);
   }, [onHoverSeat]);
 
+  // 俯瞰ホバーで付与したグローバルカーソル(document.body)を確実に戻す。
+  // R3F はポインタ移動時のみ再判定するため、席を静止クリックして一人称に入ると
+  // onPointerOut が発火せず 'pointer' が残る。選択遷移時とアンマウント時に 'auto' へ戻す。
+  useEffect(() => {
+    if (selectedSeatId !== null) {
+      document.body.style.cursor = 'auto';
+    }
+    return () => {
+      document.body.style.cursor = 'auto';
+    };
+  }, [selectedSeatId]);
+
   const handleClick = useCallback(
     (event: { instanceId?: number; stopPropagation: () => void }) => {
       event.stopPropagation();

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -1,7 +1,7 @@
 /**
  * SeatMeshesコンポーネント
  * アイソメトリック ドールハウススタイル: フラットなRoundedBox座席 + エッジ強調
- * 列ごとに2色交互、選択座席はハイライト
+ * 通常席は単色。ホバー席は枠＋席番号ラベルで強調し、2Dリストと相互連動する。
  */
 
 'use client';
@@ -14,9 +14,11 @@ import {
 } from 'three';
 import { RoundedBoxGeometry } from 'three-stdlib';
 import { extend } from '@react-three/fiber';
-import { Edges } from '@react-three/drei';
+import { Edges, Html } from '@react-three/drei';
 
 import type { TheaterSeat } from '../../types';
+
+import styles from './seatMeshes.module.scss';
 
 // R3FにRoundedBoxGeometryを登録
 extend({ RoundedBoxGeometry });
@@ -44,6 +46,8 @@ const COLOR_SEAT = new Color('#bf4040');
 const COLOR_SELECTED = new Color('#ffaa00');
 /** 車椅子席カラー（他席と区別できる青系） */
 const COLOR_WHEELCHAIR = new Color('#3b82f6');
+/** ホバー強調枠の色（design-system の --warning-main と一致させ、2Dリング色と揃える） */
+const HOVER_FRAME_COLOR = '#f59e0b';
 
 /** 座席の色種別キー（純粋・テスト用にexport） */
 export type SeatColorKey = 'selected' | 'wheelchair' | 'seat';
@@ -77,8 +81,12 @@ export interface SeatMeshesProps {
   seats: TheaterSeat[];
   /** 選択中の座席ID */
   selectedSeatId: string | null;
+  /** ホバー中の座席ID（2Dリストと相互ハイライト） */
+  hoveredSeatId: string | null;
   /** 座席クリック時コールバック */
   onSeatClick: (seat: TheaterSeat) => void;
+  /** 座席ホバー変化コールバック（null=ホバー解除） */
+  onHoverSeat: (seatId: string | null) => void;
 }
 
 /**
@@ -196,10 +204,14 @@ const SeatBacks = memo<{
 SeatBacks.displayName = 'SeatBacks';
 
 /**
- * 選択座席のハイライト枠（emissive + Edges）
+ * ホバー席のハイライト枠（Edges）＋席番号ラベル
+ * 旧 SelectedSeatHighlight は「選択即一人称遷移」で俯瞰に一度も現れないデッド演出
+ * だった。これをホバー強調に転用し、俯瞰3Dで席の識別（枠＋番号）を可能にする。
+ * InstancedMesh は per-instance のラベルを持てないため、ホバー中の1席だけ
+ * drei Html で番号をオーバーレイする（席数に依らず overlay は常に1つ）。
  */
-const SelectedSeatHighlight = memo<{ seat: TheaterSeat | null }>(
-  function SelectedSeatHighlight({ seat }) {
+const HoverHighlight = memo<{ seat: TheaterSeat | null }>(
+  function HoverHighlight({ seat }) {
     if (!seat) return null;
     return (
       <group
@@ -212,23 +224,38 @@ const SelectedSeatHighlight = memo<{ seat: TheaterSeat | null }>(
         <mesh>
           <boxGeometry args={[0.7, 0.85, 0.6]} />
           <meshBasicMaterial
-            color='#ffaa00'
+            color={HOVER_FRAME_COLOR}
             transparent
             opacity={0.0}
             depthWrite={false}
           />
-          <Edges color='#ffaa00' lineWidth={2.5} />
+          <Edges color={HOVER_FRAME_COLOR} lineWidth={2.5} />
         </mesh>
+        {/* pointerEvents:none はラッパーdivを3Dのポインタ判定に透過させるための
+            機能指定（見た目のスタイルはCSS Module側 c_seat_meshes__label に集約） */}
+        <Html
+          center
+          position={[0, 0.75, 0]}
+          style={{ pointerEvents: 'none' }}
+          zIndexRange={[100, 0]}
+        >
+          <span className={styles.c_seat_meshes__label}>
+            {seat.row_label}
+            {seat.seat_number}
+          </span>
+        </Html>
       </group>
     );
   },
 );
-SelectedSeatHighlight.displayName = 'SelectedSeatHighlight';
+HoverHighlight.displayName = 'HoverHighlight';
 
 export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
   seats,
   selectedSeatId,
+  hoveredSeatId,
   onSeatClick,
+  onHoverSeat,
 }) {
   /** 透明なクリック判定用InstancedMesh */
   const hitRef = useRef<InstancedMeshType>(null);
@@ -253,16 +280,17 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
     (event: { instanceId?: number }) => {
       if (event.instanceId === undefined) return;
       const seat = seats[event.instanceId];
-      if (seat && seat.id !== selectedSeatId) {
-        document.body.style.cursor = 'pointer';
-      }
+      if (!seat) return;
+      document.body.style.cursor = 'pointer';
+      onHoverSeat(seat.id);
     },
-    [seats, selectedSeatId],
+    [seats, onHoverSeat],
   );
 
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = 'auto';
-  }, []);
+    onHoverSeat(null);
+  }, [onHoverSeat]);
 
   const handleClick = useCallback(
     (event: { instanceId?: number; stopPropagation: () => void }) => {
@@ -276,16 +304,21 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
     [seats, onSeatClick],
   );
 
-  const selectedSeat = useMemo(
-    () => seats.find((s) => s.id === selectedSeatId) ?? null,
-    [seats, selectedSeatId],
+  // ホバー中の席（俯瞰時のみ枠＋番号ラベルを表示）。
+  // 一人称時（selectedSeatId あり）は視界を妨げないため表示しない。
+  const hoveredSeat = useMemo(
+    () =>
+      selectedSeatId
+        ? null
+        : (seats.find((s) => s.id === hoveredSeatId) ?? null),
+    [seats, hoveredSeatId, selectedSeatId],
   );
 
   return (
     <group>
       <SeatCushions seats={seats} selectedSeatId={selectedSeatId} />
       <SeatBacks seats={seats} selectedSeatId={selectedSeatId} />
-      <SelectedSeatHighlight seat={selectedSeat} />
+      <HoverHighlight seat={hoveredSeat} />
 
       {/* 透明なクリック判定メッシュ */}
       <instancedMesh

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
@@ -2,7 +2,7 @@
  * TheaterExperiencePage コンポーネント テスト
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // matchMedia モック（jsdom未実装）
@@ -131,6 +131,8 @@ import { useTheaters } from '../hooks/useTheaters';
 import { useTheaterSelection } from '../hooks/useTheaterSelection';
 import { useWebGL2Support } from '../hooks/useWebGL2Support';
 import { useSeatSelection } from '../hooks/useSeatSelection';
+import { SeatMeshes } from '../component/seatMeshes/seatMeshes';
+import { SeatA11yList } from '../component/seatA11yList/seatA11yList';
 
 import { TheaterExperiencePage } from './theaterExperiencePage';
 
@@ -138,6 +140,11 @@ const mockUseTheater = useTheater as jest.Mock;
 const mockUseTheaters = useTheaters as jest.Mock;
 const mockUseTheaterSelection = useTheaterSelection as jest.Mock;
 const mockUseWebGL2Support = useWebGL2Support as jest.Mock;
+const mockSeatMeshes = SeatMeshes as unknown as jest.Mock;
+const mockSeatA11yList = SeatA11yList as unknown as jest.Mock;
+
+/** モック子コンポーネントに最後に渡された props を取得する */
+const lastProps = (m: jest.Mock) => m.mock.calls[m.mock.calls.length - 1][0];
 const mockUseSeatSelection = useSeatSelection as jest.Mock;
 
 const mockTheaterDetail = {
@@ -379,6 +386,49 @@ describe('TheaterExperiencePage', () => {
 
       expect(selectTheater).toHaveBeenCalledWith('imax-gt');
       expect(clearSelection).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('座席の相互ハイライト（ホバー/フォーカス連動）', () => {
+    it('初期は強調なしで、3D/2D 双方に highlightedSeatId=null が渡る', () => {
+      render(<TheaterExperiencePage initialSlug='standard-medium' />);
+
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBeNull();
+      expect(lastProps(mockSeatA11yList).highlightedSeatId).toBeNull();
+    });
+
+    it('ホバーはフォーカスより優先され、ホバー解除でフォーカス席に戻る（片方の解除で消えない）', () => {
+      render(<TheaterExperiencePage initialSlug='standard-medium' />);
+
+      // キーボードフォーカス（2Dリスト）→ 3D/2D が focus 席で強調
+      act(() => lastProps(mockSeatA11yList).onFocusSeat('focus-seat'));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('focus-seat');
+      expect(lastProps(mockSeatA11yList).highlightedSeatId).toBe('focus-seat');
+
+      // 3Dホバー（別席）→ ホバーが優先される
+      act(() => lastProps(mockSeatMeshes).onHoverSeat('hover-seat'));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('hover-seat');
+      expect(lastProps(mockSeatA11yList).highlightedSeatId).toBe('hover-seat');
+
+      // ホバー解除 → フォーカス席へ戻る（null にはならない＝チャネル分離）
+      act(() => lastProps(mockSeatMeshes).onHoverSeat(null));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('focus-seat');
+    });
+
+    it('劇場を切り替えると強調（ホバー/フォーカス）がリセットされる', () => {
+      render(<TheaterExperiencePage initialSlug='standard-medium' />);
+
+      act(() => lastProps(mockSeatA11yList).onFocusSeat('focus-seat'));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('focus-seat');
+
+      act(() => {
+        fireEvent.change(screen.getByTestId('theater-selector'), {
+          target: { value: 'imax-gt' },
+        });
+      });
+
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBeNull();
+      expect(lastProps(mockSeatA11yList).highlightedSeatId).toBeNull();
     });
   });
 

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
@@ -418,14 +418,34 @@ describe('TheaterExperiencePage', () => {
     it('劇場を切り替えると強調（ホバー/フォーカス）がリセットされる', () => {
       render(<TheaterExperiencePage initialSlug='standard-medium' />);
 
+      // ホバーとフォーカスを両方付与（ホバー優先で hover-seat が強調される）。
+      // 両チャネルを立てることで、切替時の hovered/focused 双方のリセット漏れを検出する。
       act(() => lastProps(mockSeatA11yList).onFocusSeat('focus-seat'));
-      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('focus-seat');
+      act(() => lastProps(mockSeatMeshes).onHoverSeat('hover-seat'));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('hover-seat');
 
       act(() => {
         fireEvent.change(screen.getByTestId('theater-selector'), {
           target: { value: 'imax-gt' },
         });
       });
+
+      // ホバー・フォーカス両チャネルが解除される
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBeNull();
+      expect(lastProps(mockSeatA11yList).highlightedSeatId).toBeNull();
+    });
+
+    it('席を選択（一人称遷移）するとホバー/フォーカス強調がリセットされる（stale漏れ防止）', () => {
+      render(<TheaterExperiencePage initialSlug='standard-medium' />);
+
+      // 俯瞰でホバー＋フォーカスを付与（ホバー優先で hover-seat 強調）
+      act(() => lastProps(mockSeatA11yList).onFocusSeat('focus-seat'));
+      act(() => lastProps(mockSeatMeshes).onHoverSeat('hover-seat'));
+      expect(lastProps(mockSeatMeshes).highlightedSeatId).toBe('hover-seat');
+
+      // 3D席を静止クリック→一人称。R3Fは onPointerOut を発火しないため、
+      // 選択時に明示リセットしないと stale hover が残りキーボード強調をマスクする。
+      act(() => lastProps(mockSeatMeshes).onSeatClick({ id: 'seat-x' }));
 
       expect(lastProps(mockSeatMeshes).highlightedSeatId).toBeNull();
       expect(lastProps(mockSeatA11yList).highlightedSeatId).toBeNull();
@@ -547,6 +567,37 @@ describe('TheaterExperiencePage', () => {
       await user.click(screen.getByRole('button', { name: '← 俯瞰に戻る' }));
 
       expect(clearSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('俯瞰に戻ると一人称中に付いたホバー/フォーカス強調がリセットされる', async () => {
+      // 再レンダーをまたいで selectedSeat を維持するため persistent モックを使い、
+      // テスト後に既定（selectedSeat=null）へ復元してリークを防ぐ。
+      mockUseSeatSelection.mockReturnValue({
+        selectedSeat,
+        selectSeat: jest.fn(),
+        clearSelection: jest.fn(),
+      });
+      const user = userEvent.setup();
+
+      try {
+        render(<TheaterExperiencePage initialSlug='standard-medium' />);
+
+        // 一人称中でも2Dリストのホバーは連動する
+        act(() => lastProps(mockSeatA11yList).onHoverSeat('hover-seat'));
+        expect(lastProps(mockSeatA11yList).highlightedSeatId).toBe(
+          'hover-seat',
+        );
+
+        await user.click(screen.getByRole('button', { name: '← 俯瞰に戻る' }));
+
+        expect(lastProps(mockSeatA11yList).highlightedSeatId).toBeNull();
+      } finally {
+        mockUseSeatSelection.mockReturnValue({
+          selectedSeat: null,
+          selectSeat: jest.fn(),
+          clearSelection: jest.fn(),
+        });
+      }
     });
   });
 });

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -159,6 +159,12 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
     const handleSeatClick = useCallback(
       (seat: TheaterSeat) => {
         selectSeat(seat);
+        // 一人称に入る際、俯瞰で拾ったホバー/フォーカス強調を解除する。
+        // R3F は静止クリックでは onPointerOut を発火しないため、これをしないと
+        // stale な hoveredSeatId が highlightedSeatId を占有し、一人称中の2Dリストで
+        // キーボードフォーカスの強調が追従しなくなる（3D→2D のホバー漏れ）。
+        setHoveredSeatId(null);
+        setFocusedSeatId(null);
       },
       [selectSeat],
     );
@@ -173,6 +179,14 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
 
     // 強調対象: ポインタホバーを優先し、無ければキーボードフォーカス席
     const highlightedSeatId = hoveredSeatId ?? focusedSeatId;
+
+    const handleBackToOverview = useCallback(() => {
+      // 俯瞰へ戻る際、一人称中に2Dリストで拾ったホバー/フォーカス強調も解除する
+      // （handleSeatClick / handleTheaterChange と対称）。
+      clearSelection();
+      setHoveredSeatId(null);
+      setFocusedSeatId(null);
+    }, [clearSelection]);
 
     const handleTheaterChange = useCallback(
       (nextSlug: string) => {
@@ -333,7 +347,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
             {isWebGL2Supported && selectedSeat && (
               <button
                 type='button'
-                onClick={clearSelection}
+                onClick={handleBackToOverview}
                 className={styles.c_theater_experience__back_to_overview}
               >
                 ← 俯瞰に戻る

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -57,6 +57,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
     } = useTheaters();
     const { data: theaterDetail, isLoading, error } = useTheater(slug);
     const { selectedSeat, selectSeat, clearSelection } = useSeatSelection();
+    const [hoveredSeatId, setHoveredSeatId] = useState<string | null>(null);
     const [frequencyBand, setFrequencyBand] = useState<FrequencyBand>('mid');
     const [isHeatmapVisible, setIsHeatmapVisible] = useState(false);
     const { isSupported: isWebGL2Supported, isChecking } = useWebGL2Support();
@@ -158,11 +159,17 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
       [selectSeat],
     );
 
+    const handleHoverSeat = useCallback((seatId: string | null) => {
+      setHoveredSeatId(seatId);
+    }, []);
+
     const handleTheaterChange = useCallback(
       (nextSlug: string) => {
         // 劇場を切り替えたら、旧劇場の座席選択（一人称視点）を解除して俯瞰に戻す
         selectTheater(nextSlug);
         clearSelection();
+        // 旧劇場の座席を指していたホバー強調も解除する
+        setHoveredSeatId(null);
       },
       [selectTheater, clearSelection],
     );
@@ -274,7 +281,9 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
                   <SeatMeshes
                     seats={seats}
                     selectedSeatId={selectedSeatId}
+                    hoveredSeatId={hoveredSeatId}
                     onSeatClick={handleSeatClick}
+                    onHoverSeat={handleHoverSeat}
                   />
                   <ScreenMesh
                     width={theater.screen_width}
@@ -345,7 +354,9 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
             seats={seats}
             theater={theater}
             selectedSeatId={selectedSeatId}
+            hoveredSeatId={hoveredSeatId}
             onSelectSeat={handleSeatClick}
+            onHoverSeat={handleHoverSeat}
           />
         </section>
       </div>

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -57,7 +57,11 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
     } = useTheaters();
     const { data: theaterDetail, isLoading, error } = useTheater(slug);
     const { selectedSeat, selectSeat, clearSelection } = useSeatSelection();
+    // ポインタホバーとキーボードフォーカスは独立チャネルとして別々に保持し、
+    // 強調対象は `hovered ?? focused` で導出する。単一状態にまとめると、片方の解除
+    // （別席へのマウス移動など）がフォーカス中の強調を消してしまう（3D↔2D の desync）。
     const [hoveredSeatId, setHoveredSeatId] = useState<string | null>(null);
+    const [focusedSeatId, setFocusedSeatId] = useState<string | null>(null);
     const [frequencyBand, setFrequencyBand] = useState<FrequencyBand>('mid');
     const [isHeatmapVisible, setIsHeatmapVisible] = useState(false);
     const { isSupported: isWebGL2Supported, isChecking } = useWebGL2Support();
@@ -163,13 +167,21 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
       setHoveredSeatId(seatId);
     }, []);
 
+    const handleFocusSeat = useCallback((seatId: string | null) => {
+      setFocusedSeatId(seatId);
+    }, []);
+
+    // 強調対象: ポインタホバーを優先し、無ければキーボードフォーカス席
+    const highlightedSeatId = hoveredSeatId ?? focusedSeatId;
+
     const handleTheaterChange = useCallback(
       (nextSlug: string) => {
         // 劇場を切り替えたら、旧劇場の座席選択（一人称視点）を解除して俯瞰に戻す
         selectTheater(nextSlug);
         clearSelection();
-        // 旧劇場の座席を指していたホバー強調も解除する
+        // 旧劇場の座席を指していた強調（ホバー/フォーカス）も解除する
         setHoveredSeatId(null);
+        setFocusedSeatId(null);
       },
       [selectTheater, clearSelection],
     );
@@ -281,7 +293,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
                   <SeatMeshes
                     seats={seats}
                     selectedSeatId={selectedSeatId}
-                    hoveredSeatId={hoveredSeatId}
+                    highlightedSeatId={highlightedSeatId}
                     onSeatClick={handleSeatClick}
                     onHoverSeat={handleHoverSeat}
                   />
@@ -354,9 +366,10 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
             seats={seats}
             theater={theater}
             selectedSeatId={selectedSeatId}
-            hoveredSeatId={hoveredSeatId}
+            highlightedSeatId={highlightedSeatId}
             onSelectSeat={handleSeatClick}
             onHoverSeat={handleHoverSeat}
+            onFocusSeat={handleFocusSeat}
           />
         </section>
       </div>


### PR DESCRIPTION
## 概要

俯瞰3Dが「席を選ぶ道具」として機能していなかった問題（#468）に対応。3D座席に席番号が無く A1 と A16 を見分けられず、ホバーの視覚フィードバックも無く、選択席ハイライトは「選択即一人称遷移」のため俯瞰で一度も見えないデッド演出だった。

- **3D↔2D 相互ハイライト**: 強調状態をページに持ち上げ、`SeatMeshes`(3D) と `SeatA11yList`(2D) で共有。どちらをポイントしても対応席が**同時に**強調される
- **席番号の可視化**: ホバー中の1席にだけ drei `Html` で番号ラベル（例「G8」）をオーバーレイ。InstancedMesh は per-instance ラベルを持てないため、席数に依らず overlay は常に1つに抑える
- **デッド演出の活用**: 俯瞰で一度も現れなかった `SelectedSeatHighlight` を `HoverHighlight` に転用（Issue の「活用 or 撤去」＝活用）
- **a11y 経路の維持**: 2Dリストはマウスホバーに加え**キーボードフォーカス**でも連動。スクリーンリーダー/キーボードの正規経路は従来どおり2Dリストが担う
- 強調色は 3D 枠 / 2D リング 共に design-system `--warning-dark`(#d97706) に統一し、連動を視覚的に結ぶ（WCAG 1.4.11 非テキスト 3:1 を満たす、下記レビュー対応参照）

## ロードマップ

個別Issue管理（ロードマップへの個別記載なし）。本PRは #468 に対応。

## レビュー対応（多角レビュー＋敵対的検証で確定した指摘）

実装後にマルチエージェントのレビュー（correctness / R3F / a11y / rules-tests）＋敵対的検証を実施し、confirmed となった指摘に対応した。

**第1ラウンド（コミット `1a30110`）**
- **一人称時のホバー漏れ**: 3D側の hover 発火を俯瞰時のみに制限（`resolveHoverEmitId`）。一人称でキャンバス上をマウス移動しても2Dリストへリングが漏れず、カーソルも変化しない
- **ホバー/フォーカスのチャネル分離**: 単一状態を `hoveredSeatId`(ポインタ) と `focusedSeatId`(キーボード) に分け、`highlightedSeatId = hovered ?? focused` で導出。別席へのマウス移動や blur がフォーカス中の強調を消す desync を解消
- **a11y コントラスト**: 2Dリング/3D枠の色を `--warning-main`(#f59e0b, 2.06:1) から `--warning-dark`(#d97706, 3.05:1) へ変更し WCAG 1.4.11（非テキスト 3:1）を満たす。強調時は文字色も濃くし色以外の手掛かり（輝度差）でも状態を示す

**第2ラウンド（コミット `65cffda`・上記修正の再検証で確定）**
- **stale hover がキーボード強調をマスク**: R3F は静止クリックで `onPointerOut` を発火しないため、俯瞰で拾った `hoveredSeatId` が席選択後も残り、一人称中の2Dリストでキーボードフォーカスの強調が追従しなくなっていた。`handleSeatClick`（＋`handleBackToOverview` を新設）で選択/俯瞰復帰時に両チャネルをリセット
- **グローバルカーソル残留**: `SeatMeshes` に `useEffect` を追加し、席選択（一人称遷移）時とアンマウント時に `document.body.style.cursor` を `'auto'` へ戻す（静止クリックで `'pointer'` が残る問題を解消）
- **テストギャップ**: 劇場切替リセットテストを hover チャネルも立てる形へ拡張（mutation 耐性）。席選択で強調がリセット／俯瞰復帰で強調がリセットも追加検証

**別Issue化（本PR以前からの既存事象・スコープ外）**: 2Dボタンのマウス `:hover` テキスト blue-on-blue 3.74:1、静止時の席番号 4.4987:1（いずれも WCAG 1.4.3 通常テキスト 4.5:1 未満）→ #486

## レビューポイント

- 強調状態の持ち上げ位置（ページ）と 3D/2D 双方向への配線、`highlightedSeatId = hovered ?? focused` の導出（`theaterExperiencePage.tsx`）
- チャネル分離とリセット点（`handleSeatClick` / `handleBackToOverview` / `handleTheaterChange`）の対称性
- 3D側 `HoverHighlight`：俯瞰時のみ描画（`selectedSeatId === null`）で一人称の視界を妨げない。`Html` ラッパーは `pointerEvents:none` で 3D のホバー判定を透過
- 純粋関数 `resolveHoverEmitId` / `getHoverHighlightSeat`（一人称ゲート含む）を抽出しユニットテスト化

## テスト

- `tsc --noEmit` ✅ / `eslint` ✅
- 関連ユニットテスト **49件** ✅（`theaterExperiencePage` / `seatA11yList` / `seatMeshes`）
  - ホバー優先＋ホバー解除でフォーカス席へ復帰／キーボードフォーカスは別チャネルで連動＋blur解除／席選択・俯瞰復帰・劇場切替で強調リセット／`resolveHoverEmitId`・`getHoverHighlightSeat` の一人称ゲート
- フルスイート カバレッジ 閾値（全指標80%）クリア ✅
- 3D メッシュ層（`seatMeshes`）は jsdom で描画検証不可のためカバレッジ対象外（既存方針）。純粋ロジックは抽出してユニットテスト、見え方は下記 Before/After で担保

## Before / After

同一劇場・同一席（G列8番）を2Dリストからホバーした状態。

| Before（main） | After（本PR） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7a3297c3-bf8c-4244-b9ad-ab527109ddb1) | ![after](https://github.com/user-attachments/assets/61ea2aca-183c-4995-9efc-2732e3289027) |

- **Before**: G列8番ホバー → 2Dボタンは薄青の `:hover` のみ。3Dは無反応で、どの座席が G8 か俯瞰から判別できない
- **After**: G列8番ホバー → 3Dに**強調枠＋「G8」ラベル**、2Dボタンに**リング**が同時点灯。3D↔2D の相互連動と席番号の可視化を実証
- ※ After 画像は色調整前（`--warning-main`）の撮影。最終版は上記レビュー対応で強調色を `--warning-dark`(#d97706) に確定（WCAG 1.4.11 対応）。同系アンバーで見た目の差は僅少

🤖 Generated with [Claude Code](https://claude.com/claude-code)