### PR TITLE
fix(theater): 段差LEDを座席ブロック単位に分割し座席貫通を解消（Closes #465）

### DIFF
--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -30,6 +30,7 @@ import {
   calcOverviewZoom,
   interpolateFloorHeight,
 } from '../../utils/theaterGeometry';
+import type { SeatXSegment } from '../../utils/theaterGeometry';
 
 export interface TheaterSceneProps {
   /** 劇場の幅 (m) */
@@ -52,8 +53,8 @@ export interface TheaterSceneProps {
   rowZs: number[];
   /** 各列のY位置（前列から後列の順） — 段差LED配置用 */
   rowYs: number[];
-  /** 座席エリア全体の横幅 — 段差LEDの横長サイズ */
-  seatAreaWidth: number;
+  /** 座席ブロックのxセグメント（縦通路で分割） — 段差LEDをブロック単位に分割配置する */
+  seatSegments: SeatXSegment[];
   /** 子要素（座席、スクリーン、ヒートマップ等） */
   children: React.ReactNode;
 }
@@ -333,14 +334,18 @@ const ExitSigns = memo<{
 ExitSigns.displayName = 'ExitSigns';
 
 /**
- * 段差LED（各列の前方リスト部分に細い光帯）
+ * 段差LED（各列の段鼻に細い光帯）
  * スタジアム傾斜の段差を明示し、安全性と雰囲気を両立。
+ *
+ * 座席ブロック（縦通路で分割）ごとに分割配置し、全幅1本の光線が座席を貫通して
+ * 通路の暗部まで伸びるのを防ぐ。輝度は toneMapped を有効化して周囲に馴染ませる
+ * （旧実装の toneMapped=false による全開発光を廃止）。
  */
 const StepLEDs = memo<{
   rowZs: number[];
   rowYs: number[];
-  seatWidth: number;
-}>(function StepLEDs({ rowZs, rowYs, seatWidth }) {
+  seatSegments: SeatXSegment[];
+}>(function StepLEDs({ rowZs, rowYs, seatSegments }) {
   // 通常の列間隔（最小の正の間隔）を基準に、これを大きく超えるペア（横通路）は
   // 段差ではないためLEDを描かない（通路中央に宙浮きのLEDが出るのを防ぐ）
   const normalGap = useMemo(() => {
@@ -358,16 +363,16 @@ const StepLEDs = memo<{
         if (i === 0) return null; // A列は段差なし
         const gap = Math.abs((rowZs[i - 1] ?? z) - z);
         if (gap > normalGap * 1.5) return null; // 横通路（段差でない）はスキップ
-        // 各列の前方端に細い光帯を配置（段の中央高さ・中央Z）
+        // 段の中央高さ・中央Zに、各座席ブロックの幅で光帯を配置
         const prevY = rowYs[i - 1] ?? 0;
         const ledY = (rowYs[i] + prevY) / 2;
         const ledZ = (z + (rowZs[i - 1] ?? z)) / 2;
-        return (
-          <mesh key={z} position={[0, ledY, ledZ]}>
-            <boxGeometry args={[seatWidth, 0.04, 0.04]} />
-            <meshBasicMaterial color={COLOR_STEP_LED} toneMapped={false} />
+        return seatSegments.map((seg) => (
+          <mesh key={`${z}:${seg.center}`} position={[seg.center, ledY, ledZ]}>
+            <boxGeometry args={[seg.width, 0.04, 0.04]} />
+            <meshBasicMaterial color={COLOR_STEP_LED} />
           </mesh>
-        );
+        ));
       })}
     </group>
   );
@@ -551,7 +556,7 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
   seatAreaMaxY,
   rowZs,
   rowYs,
-  seatAreaWidth,
+  seatSegments,
   children,
 }) {
   const halfWidth = roomWidth / 2;
@@ -669,8 +674,8 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
         seatAreaMaxY={seatAreaMaxY}
       />
 
-      {/* 段差LED（各列の段差を明示する細い光帯） */}
-      <StepLEDs rowZs={rowZs} rowYs={rowYs} seatWidth={seatAreaWidth} />
+      {/* 段差LED（各列の段鼻を座席ブロック単位で明示する細い光帯） */}
+      <StepLEDs rowZs={rowZs} rowYs={rowYs} seatSegments={seatSegments} />
 
       {children}
     </>

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -10,6 +10,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import { THEATER_MESSAGES } from '@/constants';
 
 import type { FrequencyBand, TheaterSeat } from '../types';
+import { computeSeatXSegments } from '../utils/theaterGeometry';
 import { useTheater } from '../hooks/useTheater';
 import { useTheaters } from '../hooks/useTheaters';
 import { useTheaterSelection } from '../hooks/useTheaterSelection';
@@ -91,7 +92,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
           maxY: 0,
           rowZs: [] as number[],
           rowYs: [] as number[],
-          width: 0,
+          seatSegments: [] as ReturnType<typeof computeSeatXSegments>,
         };
       }
       const zValues = seats.map((s) => Number(s.position_z));
@@ -120,7 +121,8 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
         maxY: Math.max(...yValues),
         rowZs,
         rowYs,
-        width: Math.max(...xValues) - Math.min(...xValues) + 0.6,
+        // 段差LEDを座席ブロック単位に分割配置するためのxセグメント（縦通路で分割）
+        seatSegments: computeSeatXSegments(xValues),
       };
     }, [seats]);
 
@@ -302,7 +304,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
                   seatAreaMaxY={seatAreaBounds.maxY}
                   rowZs={seatAreaBounds.rowZs}
                   rowYs={seatAreaBounds.rowYs}
-                  seatAreaWidth={seatAreaBounds.width}
+                  seatSegments={seatAreaBounds.seatSegments}
                 >
                   <SeatMeshes
                     seats={seats}

--- a/src/features/theaterExperience/utils/theaterGeometry.test.ts
+++ b/src/features/theaterExperience/utils/theaterGeometry.test.ts
@@ -5,6 +5,7 @@
 import {
   OVERVIEW_MAX_ZOOM,
   calcOverviewZoom,
+  computeSeatXSegments,
   interpolateFloorHeight,
 } from './theaterGeometry';
 
@@ -69,5 +70,59 @@ describe('interpolateFloorHeight', () => {
     const mid = interpolateFloorHeight(-2.5, rowZs, rowYs);
     expect(mid).toBeGreaterThan(0.5);
     expect(mid).toBeLessThan(2);
+  });
+});
+
+describe('computeSeatXSegments', () => {
+  it('縦通路が無ければ1ブロックにまとまる（端席の外側へ張り出す）', () => {
+    // 等間隔4席 -1,0,1,2 → 1ブロック。幅 = (2 - -1) + 0.3*2 = 3.6、中心 0.5
+    const segs = computeSeatXSegments([-1, 0, 1, 2]);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].center).toBeCloseTo(0.5);
+    expect(segs[0].width).toBeCloseTo(3.6);
+  });
+
+  it('通常間隔を大きく超えるギャップ（縦通路）でブロックが分割される', () => {
+    // 間隔1の座席群を、中央の幅3のギャップで2ブロックに分割
+    // 左: -3,-2,-1 / 右: 2,3,4
+    const segs = computeSeatXSegments([-3, -2, -1, 2, 3, 4]);
+    expect(segs).toHaveLength(2);
+    expect(segs[0].center).toBeCloseTo(-2); // (-3 + -1)/2
+    expect(segs[0].width).toBeCloseTo(2 + 0.6); // (-1 - -3) + 0.6
+    expect(segs[1].center).toBeCloseTo(3); // (2 + 4)/2
+    expect(segs[1].width).toBeCloseTo(2 + 0.6);
+  });
+
+  it('縦通路2本で3ブロックに分割される', () => {
+    // -4,-3 | (通路) | 0,1 | (通路) | 4,5
+    const segs = computeSeatXSegments([-4, -3, 0, 1, 4, 5]);
+    expect(segs).toHaveLength(3);
+    expect(segs.map((s) => s.center)).toEqual([-3.5, 0.5, 4.5]);
+  });
+
+  it('重複xは1つに畳まれ、順不同でも正しく分割される', () => {
+    const segs = computeSeatXSegments([1, -1, 0, 1, -1, 5, 6]);
+    // ユニーク昇順: -1,0,1,5,6 → 通常間隔1、5でギャップ4(=通路) → 2ブロック
+    expect(segs).toHaveLength(2);
+    expect(segs[0].center).toBeCloseTo(0); // (-1 + 1)/2
+    expect(segs[1].center).toBeCloseTo(5.5); // (5 + 6)/2
+  });
+
+  it('席が1つなら中心その席・幅は張り出し分のみ', () => {
+    const segs = computeSeatXSegments([2]);
+    expect(segs).toEqual([{ center: 2, width: 0.6 }]);
+  });
+
+  it('空配列では空セグメント', () => {
+    expect(computeSeatXSegments([])).toEqual([]);
+  });
+
+  it('張り出し・通路閾値はパラメータで調整できる', () => {
+    // aisleGapRatio を上げると同じ間隔でも通路とみなされずまとまる
+    const merged = computeSeatXSegments([0, 1, 3, 4], 0.3, 3);
+    expect(merged).toHaveLength(1);
+    // 既定閾値(1.5)ではギャップ2 > 1*1.5 で分割される
+    const split = computeSeatXSegments([0, 1, 3, 4]);
+    expect(split).toHaveLength(2);
   });
 });

--- a/src/features/theaterExperience/utils/theaterGeometry.ts
+++ b/src/features/theaterExperience/utils/theaterGeometry.ts
@@ -27,6 +27,69 @@ export function calcOverviewZoom(
   return Math.min(OVERVIEW_MAX_ZOOM, OVERVIEW_ZOOM_CONSTANT / fitSize);
 }
 
+/** 段差LEDの1セグメント（縦通路で区切られた1つの座席ブロックに対応）。中心xと幅。 */
+export interface SeatXSegment {
+  /** ブロック中心のx座標 */
+  center: number;
+  /** ブロックの幅（端席の外側への張り出しを含む） */
+  width: number;
+}
+
+/**
+ * 座席のx座標群から、縦通路で分割された座席ブロックのxセグメントを算出する。
+ *
+ * 段差LEDを「全幅1本」ではなく座席ブロック単位で分割配置するために使う（座席を貫通する
+ * 光線や通路の暗部まで伸びる帯を防ぐ）。隣接するユニークx間隔の最小を「通常の座席間隔」と
+ * みなし、これを aisleGapRatio 倍を超える間隔を縦通路とみなしてブロックを分割する
+ * （行の横通路判定と同じデータ駆動の考え方）。各ブロックは端席の外側へ seatHalf だけ
+ * 張り出し、座席下を自然に照らす。
+ *
+ * @param xValues 座席のx座標（重複可・順不同）
+ * @param seatHalf 端席の外側への張り出し（座席半幅の目安, m）
+ * @param aisleGapRatio 通常間隔の何倍を超えたら縦通路とみなすか
+ * @returns 各座席ブロックの {center, width}。座席が空なら []
+ */
+export function computeSeatXSegments(
+  xValues: number[],
+  seatHalf = 0.3,
+  aisleGapRatio = 1.5,
+): SeatXSegment[] {
+  const xs = Array.from(new Set(xValues)).sort((a, b) => a - b);
+  if (xs.length === 0) return [];
+  if (xs.length === 1) {
+    return [{ center: xs[0], width: seatHalf * 2 }];
+  }
+
+  // 通常の座席間隔（最小の正の間隔）を基準にする
+  let normalGap = Infinity;
+  for (let i = 1; i < xs.length; i++) {
+    const g = xs[i] - xs[i - 1];
+    if (g > 0.01 && g < normalGap) normalGap = g;
+  }
+  if (!Number.isFinite(normalGap)) normalGap = 0;
+
+  const segments: SeatXSegment[] = [];
+  let blockStart = xs[0];
+  let blockEnd = xs[0];
+  const pushBlock = () => {
+    segments.push({
+      center: (blockStart + blockEnd) / 2,
+      width: blockEnd - blockStart + seatHalf * 2,
+    });
+  };
+  for (let i = 1; i < xs.length; i++) {
+    const g = xs[i] - xs[i - 1];
+    if (normalGap > 0 && g > normalGap * aisleGapRatio) {
+      // 縦通路 → ここまでを1ブロックとして確定し、新ブロックを開始
+      pushBlock();
+      blockStart = xs[i];
+    }
+    blockEnd = xs[i];
+  }
+  pushBlock();
+  return segments;
+}
+
 /**
  * 各列の実Z(rowZs)・実Y(rowYs)から、指定Zにおける傾斜床の高さを線形補間する。
  *


### PR DESCRIPTION
## 概要

段差LED（ステップの段鼻を示す光帯）が「座席エリア全幅×1本」で描画され、座席を貫通して縦通路の暗部まで伸びていた問題を修正しました。

- 全幅1本をやめ、**座席ブロック（縦通路で分割）単位に分割配置**（`computeSeatXSegments` を新設）
- `meshBasicMaterial` の `toneMapped={false}`（全開発光）を外し、**輝度を周囲に馴染ませる**
- 既存の**横通路スキップ**（`gap > normalGap * 1.5`）挙動は維持（回帰防止）

縦通路の判定は、行方向の横通路スキップと同じ「隣接ユニークx間隔の最小＝通常間隔」を基準に、`aisleGapRatio`（既定1.5）倍を超える間隔を通路とみなすデータ駆動方式です。各ブロックは端席の外側へ `seatHalf`（既定0.3m）だけ張り出して座席下を自然に照らします。

## ロードマップ

- P2改善（シアター体験の3D品質向上）の一項目。`Closes #465`

## レビューポイント

- `computeSeatXSegments`（`utils/theaterGeometry.ts`）: 空配列 / 1席 / 通路なし / 通路1本・2本 / x重複・順不同 のロジック。純ロジックとしてutilに切り出し、7ケースを単体テスト。
- `theaterScene.tsx` の `StepLEDs`: prop を `seatAreaWidth: number` → `seatSegments: SeatXSegment[]` に変更。各段差でブロックごとに `<mesh>` を描画。横通路スキップ（A列除外・`normalGap * 1.5`）は不変。
- `theaterExperiencePage.tsx`: `seatAreaBounds` が `seatSegments`（座席xから算出）を返し `TheaterScene` へ受け渡し。旧 `width`/`seatAreaWidth` prop を削除。

## テスト

- 単体テスト: `theaterGeometry.test.ts`（+7ケース）／`theaterExperiencePage.test.tsx` 含め **43 passed**。
- 目視確認（IMAX GT・俯瞰）: 変更は**縦通路の位置に限定**されていることをピクセル差分で確認（下記マゼンタ）。段差LEDは薄い光帯のため俯瞰では微細だが、通路を跨ぐ発光が消え、座席ブロック単位に収まっている。影響範囲はIssue記載どおり「軽微なグリッチ」。

### 差分（変化箇所＝マゼンタ）

LEDが変化したピクセルは**縦通路の位置にのみ**現れ、座席を貫通していた帯が除去されたことを示します。

![led-diff-crop.png](https://github.com/user-attachments/assets/4d45c53b-4a1d-4290-9950-8b1c4a3b5d55)

### Before / After（座席エリア拡大）

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/d1bc86e4-4e38-4e2c-88d9-96372f69f36a) | ![after](https://github.com/user-attachments/assets/70ad8582-939f-436b-8c8f-e58d63b19643) |

<details>
<summary>劇場全体（俯瞰）Before / After</summary>

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/cf7cbbef-255f-469d-8c15-23b26446e0ef) | ![after](https://github.com/user-attachments/assets/0054b8aa-00c2-4c16-8011-97fae8a5f445) |

</details>

Closes #465
