### PR TITLE
feat(theater): 壁・天井をフォーマット別配色に（Dolby黒基調・Closes #466）

### DIFF
--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -31,6 +31,7 @@ import {
   interpolateFloorHeight,
 } from '../../utils/theaterGeometry';
 import type { SeatXSegment } from '../../utils/theaterGeometry';
+import { getWallColors } from '../../utils/theaterPalette';
 
 export interface TheaterSceneProps {
   /** 劇場の幅 (m) */
@@ -63,12 +64,13 @@ export interface TheaterSceneProps {
  * シネマカラーパレット（暗色基調）
  * 実映画館では「暗さに目を慣らさせる」目的で内装全体を暗色にしている。
  * ドールハウスのフラット感は維持しつつ、シネマ風の暗色に振る。
+ *
+ * 壁・天井・スクリーン側壁の色はフォーマット別に出し分けるため
+ * `getWallColors(theater.format)`（utils/theaterPalette）から取得する。
+ * 床・傾斜床・装飾帯は素材共通のためここで定数管理する。
  */
 const COLOR_FLOOR = '#1f1820'; // 通路の濃色カーペット
-const COLOR_WALL = '#6a5d68'; // 暗い壁（やや暖かみのあるトーン）
-const COLOR_CEILING = '#252028'; // 暗い天井（投影光反射防止）
 const COLOR_SLOPE = '#2e1f2c'; // 座席エリアの暗色カーペット（やや深め）
-const COLOR_SCREEN_WALL = '#2d2540'; // スクリーン側壁（深紫でシネマ感）
 const COLOR_PROSCENIUM = '#1a1322'; // ステージ前縁の暗色バンド
 const COLOR_EDGE = '#b0a0a8'; // 暗色背景に対する明色エッジ線
 
@@ -103,14 +105,8 @@ const WallMesh = memo<{
   height: number;
   position: [number, number, number];
   rotation?: [number, number, number];
-  color?: string;
-}>(function WallMesh({
-  width,
-  height,
-  position,
-  rotation,
-  color = COLOR_WALL,
-}) {
+  color: string;
+}>(function WallMesh({ width, height, position, rotation, color }) {
   return (
     <mesh position={position} rotation={rotation} receiveShadow>
       <planeGeometry args={[width, height]} />
@@ -127,11 +123,12 @@ const CeilingMesh = memo<{
   roomWidth: number;
   roomDepth: number;
   roomHeight: number;
-}>(function CeilingMesh({ roomWidth, roomDepth, roomHeight }) {
+  color: string;
+}>(function CeilingMesh({ roomWidth, roomDepth, roomHeight, color }) {
   return (
     <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, roomHeight, 0]}>
       <planeGeometry args={[roomWidth, roomDepth]} />
-      <meshLambertMaterial color={COLOR_CEILING} />
+      <meshLambertMaterial color={color} />
     </mesh>
   );
 });
@@ -561,6 +558,11 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
 }) {
   const halfWidth = roomWidth / 2;
   const halfDepth = roomDepth / 2;
+  // 壁・天井・スクリーン側壁の色をフォーマット別に出し分ける
+  const palette = useMemo(
+    () => getWallColors(theater.format),
+    [theater.format],
+  );
 
   return (
     <>
@@ -595,31 +597,34 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
       {/* 床 */}
       <FloorMesh roomWidth={roomWidth} roomDepth={roomDepth} />
 
-      {/* 壁（4面）— 天井とスクリーン側壁は省略してドールハウスの中身が見えるように */}
+      {/* 壁（4面）— フォーマット別の壁色（Dolbyは黒基調） */}
       <WallMesh
         width={roomWidth}
         height={roomHeight}
         position={[0, roomHeight / 2, -halfDepth]}
+        color={palette.wall}
       />
       <WallMesh
         width={roomDepth}
         height={roomHeight}
         position={[-halfWidth, roomHeight / 2, 0]}
         rotation={[0, Math.PI / 2, 0]}
+        color={palette.wall}
       />
       <WallMesh
         width={roomDepth}
         height={roomHeight}
         position={[halfWidth, roomHeight / 2, 0]}
         rotation={[0, -Math.PI / 2, 0]}
+        color={palette.wall}
       />
-      {/* スクリーン側壁（深紫でスクリーンを引き立てる） */}
+      {/* スクリーン側壁（スクリーンを引き立てる暗色・フォーマット別） */}
       <WallMesh
         width={roomWidth}
         height={roomHeight}
         position={[0, roomHeight / 2, halfDepth]}
         rotation={[0, Math.PI, 0]}
-        color={COLOR_SCREEN_WALL}
+        color={palette.screenWall}
       />
 
       {/* ステージ前縁バンド（スクリーン下の細い装飾帯でシアター感を強調） */}
@@ -628,11 +633,12 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
         <meshLambertMaterial color={COLOR_PROSCENIUM} />
       </mesh>
 
-      {/* 天井（ドールハウスとしては開けておいても良いが、雰囲気維持で残す） */}
+      {/* 天井（フォーマット別の暗色・投影光の反射を抑える） */}
       <CeilingMesh
         roomWidth={roomWidth}
         roomDepth={roomDepth}
         roomHeight={roomHeight}
+        color={palette.ceiling}
       />
 
       {/* 部屋外形のエッジ線 */}

--- a/src/features/theaterExperience/utils/theaterPalette.test.ts
+++ b/src/features/theaterExperience/utils/theaterPalette.test.ts
@@ -1,0 +1,68 @@
+/**
+ * theaterPalette テスト
+ */
+
+import type { TheaterFormat } from '../types';
+import { getWallColors } from './theaterPalette';
+
+/** #rrggbb を輝度（0〜1相当の単純平均）に変換 */
+function luminance(hex: string): number {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) throw new Error(`invalid hex: ${hex}`);
+  const int = parseInt(m[1], 16);
+  const r = (int >> 16) & 0xff;
+  const g = (int >> 8) & 0xff;
+  const b = int & 0xff;
+  return (r + g + b) / 3 / 255;
+}
+
+const HEX = /^#[0-9a-f]{6}$/i;
+
+describe('getWallColors', () => {
+  const formats: TheaterFormat[] = ['standard', 'imax', 'dolby_cinema'];
+
+  it('全フォーマットで有効な#rrggbbの色セットを返す', () => {
+    for (const f of formats) {
+      const c = getWallColors(f);
+      expect(c.wall).toMatch(HEX);
+      expect(c.ceiling).toMatch(HEX);
+      expect(c.screenWall).toMatch(HEX);
+    }
+  });
+
+  it('standardは従来トーン（モーブ灰）を維持する', () => {
+    expect(getWallColors('standard')).toEqual({
+      wall: '#6a5d68',
+      ceiling: '#252028',
+      screenWall: '#2d2540',
+    });
+  });
+
+  it('Dolbyは黒基調（最も暗い壁色）である', () => {
+    const dolby = luminance(getWallColors('dolby_cinema').wall);
+    const standard = luminance(getWallColors('standard').wall);
+    const imax = luminance(getWallColors('imax').wall);
+    // Dolby の壁が最も暗い（ブラックアウト内装）
+    expect(dolby).toBeLessThan(imax);
+    expect(dolby).toBeLessThan(standard);
+    // 黒基調：十分に低輝度
+    expect(dolby).toBeLessThan(0.1);
+  });
+
+  it('フォーマット間で壁色が異なる（内装差が出る）', () => {
+    const walls = formats.map((f) => getWallColors(f).wall);
+    expect(new Set(walls).size).toBe(formats.length);
+  });
+
+  it('天井は同フォーマットの壁より暗い（投影光の反射抑制）', () => {
+    for (const f of formats) {
+      const c = getWallColors(f);
+      expect(luminance(c.ceiling)).toBeLessThanOrEqual(luminance(c.wall));
+    }
+  });
+
+  it('未知フォーマットでも標準トーンにフォールバックする', () => {
+    const unknown = getWallColors('unknown' as TheaterFormat);
+    expect(unknown).toEqual(getWallColors('standard'));
+  });
+});

--- a/src/features/theaterExperience/utils/theaterPalette.ts
+++ b/src/features/theaterExperience/utils/theaterPalette.ts
@@ -1,0 +1,57 @@
+/**
+ * シアター3Dシーンの内装カラーパレット（フォーマット別）
+ *
+ * 壁・天井・スクリーン側壁の色を `TheaterFormat` ごとに出し分け、タイプ間の
+ * 内装アイデンティティを表現する。特に Dolby Cinema はブラックアウト内装が特徴の
+ * ため黒基調にする。床・傾斜床（カーペット）は素材共通のためここでは扱わない。
+ */
+
+import type { TheaterFormat } from '../types';
+
+/** 壁・天井・スクリーン側壁の色セット */
+export interface WallColors {
+  /** 側壁・後壁の色 */
+  wall: string;
+  /** 天井の色（投影光の反射を抑える暗色） */
+  ceiling: string;
+  /** スクリーン側壁の色（スクリーンを引き立てる） */
+  screenWall: string;
+}
+
+/**
+ * フォーマット別の内装パレット。
+ * - standard: 従来のやや暖かみのあるモーブ灰（汎用シアターの標準トーン）
+ * - imax: 反射を抑えたクールなグラファイト（IMAXの中立的な暗内装）
+ * - dolby_cinema: ブラックアウト内装を再現する黒マット基調
+ */
+const PALETTE: Record<TheaterFormat, WallColors> = {
+  standard: {
+    wall: '#6a5d68',
+    ceiling: '#252028',
+    screenWall: '#2d2540',
+  },
+  imax: {
+    wall: '#34363d',
+    ceiling: '#1c1d22',
+    screenWall: '#23252e',
+  },
+  dolby_cinema: {
+    wall: '#141216',
+    ceiling: '#0e0d10',
+    screenWall: '#0d0c0f',
+  },
+};
+
+/** 未知フォーマット時のフォールバック（標準トーン） */
+const FALLBACK: WallColors = PALETTE.standard;
+
+/**
+ * フォーマットに応じた壁・天井・スクリーン側壁の色を返す。
+ * 未知の値が来た場合は標準トーンにフォールバックする（描画が破綻しない）。
+ *
+ * @param format 劇場フォーマット
+ * @returns 壁・天井・スクリーン側壁の色セット
+ */
+export function getWallColors(format: TheaterFormat): WallColors {
+  return PALETTE[format] ?? FALLBACK;
+}


### PR DESCRIPTION
## 概要

壁・天井・スクリーン側壁が全劇場共通の無地単色（モーブ灰 `#6a5d68` 等）で、フォーマットごとの内装アイデンティティが無い問題を修正しました。

- `theater.format` に応じて壁・天井・スクリーン側壁の色を出し分け
- 特に **Dolby Cinema はブラックアウト内装を再現する黒基調**（`#141216` 系）
- IMAX は反射を抑えたクールなグラファイト、standard は従来トーンを維持
- 色算出は `getWallColors(format)`（`utils/theaterPalette.ts`）に切り出し、単体テスト可能に

| format | wall | ceiling | screenWall |
| --- | --- | --- | --- |
| standard | `#6a5d68`（従来維持） | `#252028` | `#2d2540` |
| imax | `#34363d` | `#1c1d22` | `#23252e` |
| dolby_cinema | `#141216` | `#0e0d10` | `#0d0c0f` |

## ロードマップ

- P2改善（シアター体験の3D品質向上）の一項目。`Closes #466`

## レビューポイント

- `getWallColors`（新設 util）: フォーマット別パレットを返す純関数。未知フォーマットは standard にフォールバック。床・傾斜床・装飾帯は素材共通のため対象外（KISS）。
- `theaterScene.tsx`: モジュール定数 `COLOR_WALL`/`COLOR_CEILING`/`COLOR_SCREEN_WALL` を廃し、`getWallColors(theater.format)` を `useMemo` で取得して各メッシュへ受け渡し。`WallMesh`/`CeilingMesh` の `color` を必須 prop 化。
- **スコープ判断**: Issue推奨のうち「色のフォーマット別出し分け」を実装（完了条件＝タイプ間の内装差、特にDolby黒基調を満たす）。**音響パネル割り・入口扉（vomitory）は #474（質感向上）と作業範囲が重なるため本PRでは見送り**、必要なら別Issue/別PRで対応します。

## テスト

- 単体テスト: `theaterPalette.test.ts`（新設・6ケース: 有効hex / standard維持 / Dolby最暗 / フォーマット間で相違 / 天井≤壁 / 未知フォールバック）。`theaterScene.test.tsx`・`theaterExperiencePage.test.tsx` 併せて **35 passed**。
- 型・ESLint・Prettier: パス。
- 目視確認（俯瞰・Next.jsエラーバッジ赤なし）: 下記 Before/After。

### Dolby Cinema（黒基調化・本Issueの主眼）

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/e8a06d7b-7a59-4fc7-9a86-60ad46c77aa8) | ![after](https://github.com/user-attachments/assets/8a986817-5bfd-4923-8560-00a1ea690a63) |

### IMAX（モーブ灰 → クールグラファイト）

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/dc1d7b0d-0124-414f-8ff0-2f6e2133d61e) | ![after](https://github.com/user-attachments/assets/9b5aa6d3-f170-4bb8-be00-96c3ff611dd7) |

<details>
<summary>standard（従来トーン維持・回帰確認）Before / After</summary>

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/119f0372-f6a5-4605-b555-7030631b5868) | ![after](https://github.com/user-attachments/assets/c41a6adf-af3f-4c15-9d2e-9064105a7967) |

</details>

Closes #466
