### PR TITLE
feat(theater): スピーカーを種別で差別化しスクリーンch露出を解消（Closes #467）

### DIFF
--- a/src/features/theaterExperience/component/speakerMeshes/speakerMeshes.tsx
+++ b/src/features/theaterExperience/component/speakerMeshes/speakerMeshes.tsx
@@ -14,19 +14,12 @@ import { Edges } from '@react-three/drei';
 // R3FにRoundedBoxGeometryを登録
 extend({ RoundedBoxGeometry });
 
-import type { TheaterSpeaker, SpeakerChannel } from '../../types';
-
-const SPEAKER_SIZE = { width: 0.6, height: 0.35, depth: 0.4 };
-
-/** 天井チャンネル判定 */
-const CEILING_CHANNELS: ReadonlySet<SpeakerChannel> = new Set([
-  'LTF',
-  'RTF',
-  'LTM',
-  'RTM',
-  'LTR',
-  'RTR',
-]);
+import type { TheaterSpeaker } from '../../types';
+import {
+  getSpeakerKind,
+  getSpeakerSize,
+  isSpeakerVisible,
+} from '../../utils/speakerKinds';
 
 export interface SpeakerMeshesProps {
   /** スピーカーデータ一覧 */
@@ -39,10 +32,14 @@ export const SpeakerMeshes = memo<SpeakerMeshesProps>(function SpeakerMeshes({
   return (
     <group>
       {speakers.map((speaker) => {
-        const isCeiling = CEILING_CHANNELS.has(speaker.channel);
-        const rotation: [number, number, number] = isCeiling
-          ? [Math.PI, 0, 0]
-          : [0, 0, 0];
+        const kind = getSpeakerKind(speaker.channel);
+        // スクリーンch（L/C/R/LFE）は幕裏想定で描画しない（幕手前への露出を解消）
+        if (!isSpeakerVisible(kind)) return null;
+
+        const size = getSpeakerSize(kind);
+        // 天井は下向き、壁掛け（サラウンド）は水平向き
+        const rotation: [number, number, number] =
+          kind === 'ceiling' ? [Math.PI, 0, 0] : [0, 0, 0];
 
         return (
           <mesh
@@ -56,13 +53,7 @@ export const SpeakerMeshes = memo<SpeakerMeshesProps>(function SpeakerMeshes({
             castShadow
           >
             <roundedBoxGeometry
-              args={[
-                SPEAKER_SIZE.width,
-                SPEAKER_SIZE.height,
-                SPEAKER_SIZE.depth,
-                4,
-                0.03,
-              ]}
+              args={[size.width, size.height, size.depth, 4, 0.03]}
             />
             <meshLambertMaterial color='#2a2a3a' />
             <Edges color='#0a0a14' lineWidth={1.2} />

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.test.tsx
@@ -527,7 +527,7 @@ describe('TheaterExperiencePage', () => {
       expect(screen.getByTestId('speaker-meshes')).toBeInTheDocument();
     });
 
-    it('座席選択時はスピーカーが非表示になる', () => {
+    it('座席選択時もスピーカーは表示される（天井/サラウンドで設備感を残す）', () => {
       mockUseSeatSelection.mockReturnValueOnce({
         selectedSeat,
         selectSeat: jest.fn(),
@@ -536,7 +536,9 @@ describe('TheaterExperiencePage', () => {
 
       render(<TheaterExperiencePage initialSlug='standard-medium' />);
 
-      expect(screen.queryByTestId('speaker-meshes')).not.toBeInTheDocument();
+      // スクリーンch(L/C/R/LFE)の非表示は SpeakerMeshes 内部で行うため、
+      // ページ側では俯瞰・着席いずれでも SpeakerMeshes が描画されることを検証する。
+      expect(screen.getByTestId('speaker-meshes')).toBeInTheDocument();
     });
 
     it('座席選択時は俯瞰に戻るボタンが表示される', () => {

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -323,8 +323,12 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
                   />
                   {speakers.length > 0 && (
                     <>
-                      {/* 一人称視点時はスピーカーを非表示（視界の邪魔を防ぐ） */}
-                      {!selectedSeat && <SpeakerMeshes speakers={speakers} />}
+                      {/*
+                        スピーカーは俯瞰・一人称いずれでも表示する。
+                        スクリーンch(L/C/R/LFE)はSpeakerMeshes内で非表示にし、
+                        目線より上の天井/サラウンドを残して設備感を出す。
+                      */}
+                      <SpeakerMeshes speakers={speakers} />
                       {isHeatmapVisible && (
                         <AudioHeatmapPlane
                           uniforms={audioUniforms}

--- a/src/features/theaterExperience/utils/speakerKinds.test.ts
+++ b/src/features/theaterExperience/utils/speakerKinds.test.ts
@@ -1,0 +1,121 @@
+/**
+ * speakerKinds テスト
+ */
+
+import type { SpeakerChannel } from '../types';
+import {
+  getSpeakerKind,
+  getSpeakerSize,
+  isSpeakerVisible,
+  type SpeakerKind,
+} from './speakerKinds';
+
+/** 箱の体積（サイズ差の比較用） */
+function volume(size: {
+  width: number;
+  height: number;
+  depth: number;
+}): number {
+  return size.width * size.height * size.depth;
+}
+
+describe('getSpeakerKind', () => {
+  it('L/R/C/LFE はスクリーンch', () => {
+    for (const ch of ['L', 'R', 'C', 'LFE'] as SpeakerChannel[]) {
+      expect(getSpeakerKind(ch)).toBe('screen');
+    }
+  });
+
+  it('LTF/RTF/LTM/RTM/LTR/RTR は天井ch', () => {
+    for (const ch of [
+      'LTF',
+      'RTF',
+      'LTM',
+      'RTM',
+      'LTR',
+      'RTR',
+    ] as SpeakerChannel[]) {
+      expect(getSpeakerKind(ch)).toBe('ceiling');
+    }
+  });
+
+  it('側壁/後壁ch（LSS/RSS/LSW/RSW/LBS/RBS）はサラウンド', () => {
+    for (const ch of [
+      'LSS',
+      'RSS',
+      'LSW',
+      'RSW',
+      'LBS',
+      'RBS',
+    ] as SpeakerChannel[]) {
+      expect(getSpeakerKind(ch)).toBe('surround');
+    }
+  });
+
+  it('16ch全てがいずれかの種別に分類される', () => {
+    const all: SpeakerChannel[] = [
+      'L',
+      'R',
+      'C',
+      'LFE',
+      'LSS',
+      'RSS',
+      'LBS',
+      'RBS',
+      'LSW',
+      'RSW',
+      'LTF',
+      'RTF',
+      'LTM',
+      'RTM',
+      'LTR',
+      'RTR',
+    ];
+    for (const ch of all) {
+      expect(['screen', 'surround', 'ceiling']).toContain(getSpeakerKind(ch));
+    }
+  });
+});
+
+describe('getSpeakerSize', () => {
+  it('種別ごとに寸法が異なる（差別化されている）', () => {
+    const surround = getSpeakerSize('surround');
+    const ceiling = getSpeakerSize('ceiling');
+    const screen = getSpeakerSize('screen');
+    // 3種別で同一寸法が無い
+    const sigs = [surround, ceiling, screen].map(
+      (s) => `${s.width}x${s.height}x${s.depth}`,
+    );
+    expect(new Set(sigs).size).toBe(3);
+  });
+
+  it('サラウンドは縦長（高さ＞幅）の小型箱', () => {
+    const s = getSpeakerSize('surround');
+    expect(s.height).toBeGreaterThan(s.width);
+  });
+
+  it('天井は薄いフラッシュ型（高さが幅・奥行より小さい）', () => {
+    const c = getSpeakerSize('ceiling');
+    expect(c.height).toBeLessThan(c.width);
+    expect(c.height).toBeLessThan(c.depth);
+  });
+
+  it('サラウンド・天井はスクリーン箱より小型（体積が小さい）', () => {
+    const screenVol = volume(getSpeakerSize('screen'));
+    expect(volume(getSpeakerSize('surround'))).toBeLessThan(screenVol);
+    expect(volume(getSpeakerSize('ceiling'))).toBeLessThan(screenVol);
+  });
+});
+
+describe('isSpeakerVisible', () => {
+  it('スクリーンchは非表示、サラウンド・天井は表示', () => {
+    const cases: [SpeakerKind, boolean][] = [
+      ['screen', false],
+      ['surround', true],
+      ['ceiling', true],
+    ];
+    for (const [kind, visible] of cases) {
+      expect(isSpeakerVisible(kind)).toBe(visible);
+    }
+  });
+});

--- a/src/features/theaterExperience/utils/speakerKinds.ts
+++ b/src/features/theaterExperience/utils/speakerKinds.ts
@@ -1,0 +1,72 @@
+/**
+ * スピーカーの種別判定・種別ごとの描画サイズ・可視判定ユーティリティ
+ *
+ * Atmos 9.1.6 の16chを「スクリーンch / サラウンド / 天井」に分類し、種別ごとに
+ * 箱のサイズ・形状を差別化する。スクリーンch（L/C/R/LFE）は音響透過スクリーンの
+ * 裏に隠れる想定で描画しない（幕の手前への露出を解消）。
+ */
+
+import type { SpeakerChannel } from '../types';
+
+/** スピーカー種別 */
+export type SpeakerKind = 'screen' | 'surround' | 'ceiling';
+
+/** スクリーン背後のフロントch（音響透過スクリーンの裏＝描画しない） */
+const SCREEN_CHANNELS: ReadonlySet<SpeakerChannel> = new Set([
+  'L',
+  'R',
+  'C',
+  'LFE',
+]);
+
+/** 天井Atmos ch */
+const CEILING_CHANNELS: ReadonlySet<SpeakerChannel> = new Set([
+  'LTF',
+  'RTF',
+  'LTM',
+  'RTM',
+  'LTR',
+  'RTR',
+]);
+
+/**
+ * チャンネルから種別を判定する。
+ * スクリーン背後・天井以外（側壁/後壁）はすべてサラウンド扱い。
+ */
+export function getSpeakerKind(channel: SpeakerChannel): SpeakerKind {
+  if (SCREEN_CHANNELS.has(channel)) return 'screen';
+  if (CEILING_CHANNELS.has(channel)) return 'ceiling';
+  return 'surround';
+}
+
+/** スピーカー箱の寸法（m） */
+export interface SpeakerBoxSize {
+  width: number;
+  height: number;
+  depth: number;
+}
+
+/**
+ * 種別ごとの箱サイズ。
+ * - surround: 壁掛けの小型縦箱（高さ＞幅）
+ * - ceiling: 天井面に埋め込む薄い小型フラッシュ型（高さが薄い）
+ * - screen: 非表示だがフォールバック用に従来サイズを保持
+ */
+const SIZE_BY_KIND: Record<SpeakerKind, SpeakerBoxSize> = {
+  screen: { width: 0.6, height: 0.35, depth: 0.4 },
+  surround: { width: 0.34, height: 0.5, depth: 0.24 },
+  ceiling: { width: 0.5, height: 0.14, depth: 0.5 },
+};
+
+/** 種別に対応する箱サイズを返す */
+export function getSpeakerSize(kind: SpeakerKind): SpeakerBoxSize {
+  return SIZE_BY_KIND[kind];
+}
+
+/**
+ * 描画すべきか（スクリーンchは幕裏想定で非表示）。
+ * サラウンド・天井は目線より上にあり、俯瞰・着席いずれでも設備として表示する。
+ */
+export function isSpeakerVisible(kind: SpeakerKind): boolean {
+  return kind !== 'screen';
+}


### PR DESCRIPTION
## 概要

スピーカーが全16chとも同一サイズ・同一箱で描画され種別差が無く、スクリーンch（L/C/R/LFE）が音響透過スクリーンの手前に露出し、さらに着席時は全スピーカーを非表示にして一人称の天井・側壁が無設備の空面になる問題を修正しました。

- **スクリーンch（L/C/R/LFE）を非表示**（幕裏想定）にし、スクリーン面への露出を解消
- **サラウンド**は壁掛け想定の縦長小型箱（`0.34×0.5×0.24`）、**天井Atmos**は薄型フラッシュ型（`0.5×0.14×0.5`）と、種別でサイズ・形状を差別化
- **着席時もスピーカーを表示**（天井/サラウンドは目線より上のため残す）→ 一人称の「上から音が来る」設備感の空面を解消
- 種別判定・サイズ算出は `getSpeakerKind` / `getSpeakerSize` / `isSpeakerVisible`（`utils/speakerKinds.ts`）に切り出し、単体テスト可能に

| 種別 | 対象ch | 表示 | サイズ(w×h×d) | 向き |
| --- | --- | --- | --- | --- |
| screen | L / R / C / LFE | **非表示** | — | — |
| surround | 上記・天井以外 | 表示 | `0.34×0.5×0.24`（縦長・壁掛け） | 水平 |
| ceiling | LTF/RTF/LTM/RTM/LTR/RTR | 表示 | `0.5×0.14×0.5`（薄型フラッシュ） | 下向き |

## ロードマップ

- P2改善（シアター体験の3D品質向上）の一項目。`Closes #467`

## レビューポイント

- **スコープ判断（migration不要）**: Issue推奨のうち「スクリーンchは**非表示**」を採用（もう一方の「スクリーン裏へ移動」は位置変更＝新規マイグレーションが必要なため見送り）。非表示方式のため**DBスキーマ・位置データは変更なし**。
- **サブウーファ大型化について**: 唯一のサブウーファ(LFE)はスクリーンchで非表示対象のため、サイズ差別化は surround / ceiling の2種で満たしています（露出するサブウーファが存在しないため大型化は対象外）。
- `speakerKinds.ts`: `getSpeakerKind(channel)` はスクリーン集合(L/R/C/LFE)→`screen`、天井集合(LTF等6ch)→`ceiling`、他→`surround` を返す純関数。`isSpeakerVisible` は `screen` のみ false。
- `speakerMeshes.tsx`: ローカル定数 `SPEAKER_SIZE`/`CEILING_CHANNELS` を廃し util 経由に。`if (!isSpeakerVisible(kind)) return null` で幕裏chを描画除外、`getSpeakerSize(kind)` で種別サイズ、`kind==='ceiling'` のみ下向き回転。
- `theaterExperiencePage.tsx`: 着席時のスピーカー非表示ガード（`{!selectedSeat && ...}`）を撤去し常時表示（幕裏chは内部でフィルタ）。

## テスト

- 単体テスト: `speakerKinds.test.ts`（新設・全16ch種別マッピング / サイズ差別化 / 表示可否）。`theaterExperiencePage.test.tsx` の「座席選択時はスピーカー非表示」を方針に合わせ「座席選択時もスピーカーは表示される」へ更新。**2 suites / 36 passed**。
- ※ `speakerMeshes.tsx` はR3Fコンポーネントでカバレッジ除外対象のため、判定・サイズロジックを `speakerKinds.ts` に切り出して単体テスト化（Issueの「種別差別化アサーション」を等価に担保）。
- 型・ESLint・Prettier: パス。
- 目視確認（standard・俯瞰・Next.jsエラーバッジ赤なし）: 下記 Before/After。**壁色は#466で変更済みだが standard は従来トーン維持のため、スピーカー変更のみを純粋に比較可能**。

### スクリーンch露出の解消（本Issueの主眼）

スクリーン面に露出していたセンターch（暗いボックス）が非表示になり、幕面がクリーンに。

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/3b4357bf-57d0-4ef9-8a39-5f901a6a9032) | ![after](https://github.com/user-attachments/assets/82036c77-79bc-4f5a-a561-83b57f8ec7a6) |

### 天井Atmosの薄型フラッシュ化

天井スピーカーが厚い箱型（突出）から薄型フラッシュ型に。

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/fab1afa7-95eb-4cde-945c-a449572eec1c) | ![after](https://github.com/user-attachments/assets/02c59c1c-60dc-4242-b7c2-6454507e5958) |

<details>
<summary>俯瞰 全体 Before / After ＋ ピクセル差分</summary>

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/ebc8ab62-53c9-4df0-a95f-50aa221e89e0) | ![after](https://github.com/user-attachments/assets/08e26b6e-bc25-444e-81de-067001b66d54) |

差分（マゼンタ強調・変化2381px/0.046%）: 変化は天井/サラウンド/スクリーン前面のスピーカー位置に限定され、壁・座席・EXITサインは不変。

![diff](https://github.com/user-attachments/assets/e86aac32-fad1-4bc5-80df-21f2891e1282)

</details>

Closes #467
