### PR TITLE
fix(theater): 2D座席一覧のテキストコントラストを4.5:1以上に是正（Closes #486）

### DIFF
--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
@@ -69,7 +69,10 @@ $seat-cell-size: 28px;
   height: $seat-cell-size;
   font-size: $font-size-2xs;
   font-weight: $font-weight-medium;
-  color: $text-secondary;
+  // 席番号は 10px(通常テキスト扱い)のため WCAG 1.4.3 の 4.5:1 が必要。
+  // text-secondary(--gray-500) だと 10% alpha 背景を body(#fafafa)に合成後 4.50:1 で
+  // 境界を割るため、--gray-600 に一段濃くして 8.2:1 を確保する（背景依存も解消）。
+  color: $gray-600;
   background-color: color-alpha(--gray-500, 10%);
   border-radius: $border-radius-sm;
   cursor: pointer;
@@ -79,7 +82,9 @@ $seat-cell-size: 28px;
 
   &:hover {
     background-color: color-alpha(--primary-500, 15%);
-    color: $primary-500;
+    // primary-500 文字は同系色(primary@15%)背景の合成で 3.74:1 と不足するため、
+    // primary-800 まで濃くして 5.7:1 を確保する（WCAG 1.4.3）。
+    color: $primary-800;
   }
 
   @include focus-visible;
@@ -120,7 +125,9 @@ $seat-cell-size: 28px;
   color: $text-inverse;
 
   &:hover {
-    background-color: $primary-600;
+    // 白文字×primary-600 は 4.38:1 で 4.5:1 を割るため、primary-700 に濃くして
+    // 5.68:1 を確保する（選択席ホバー時も 1.4.3 を維持）。
+    background-color: $primary-700;
     color: $text-inverse;
   }
 }


### PR DESCRIPTION
## 概要

シアター体験の2D座席一覧（`SeatA11yList`）で、席番号テキストのコントラストが WCAG 1.4.3（通常テキスト 4.5:1）を下回っていた3ケースを是正しました。席番号は 10px(`--font-size-2xs`)/weight 500 = 通常テキスト扱いのため要求は 4.5:1 です。#468（3D↔2D相互ホバー）の敵対的レビュー検証で発見された **#468以前からの既存事象**です。

| 状態 | 修正前 | 修正後 | コントラスト比 |
| --- | --- | --- | --- |
| 静止時 席番号（文字色） | `text-secondary`(gray-500 `#6b6b6b`) | **`gray-600` `#444444`** | 4.50 → **8.22:1** |
| ホバー時（文字色） | `primary-500` `#1878b9`（同系色背景で blue-on-blue） | **`primary-800` `#005a94`** | 3.74 → **5.73:1** |
| 選択席+ホバー時（背景） | `primary-600` `#0d7ec4`（白文字） | **`primary-700` `#006bac`** | 4.38 → **5.68:1** |

いずれもデザインシステム変数のみ使用（ハードコード無し）。

## ロードマップ

- P2改善（シアター体験のアクセシビリティ / WCAG準拠）の一項目。`Closes #486`

## レビューポイント

- **ホバー時に primary-700 でなく primary-800 を採用した理由**: primary-700 は body(`#fafafa`) 合成後 4.48:1 で僅かに 4.5 を割るため、確実に上回る primary-800(5.73:1) を採用しました。
- **セレクタ詳細度の論点**（Issue記載）: `.seat_button:hover`(0,2,0) が相互ハイライト `.highlighted`(0,1,0) に詳細度で勝つが、ホバー自体の文字色を primary-800 に濃くしたため、その組み合わせでも 5.73:1 を満たします。選択席+ホバー(`.selected:hover`)は後方定義で勝ち、白×primary-700=5.68:1。
- 静止時は「文字色を一段濃くする」方式を採用（背景の不透明化ではなく。KISS・変更最小）。選択席(静止)の 白×primary-500=4.75:1 は元から合格のため不変です。
- ※ ダークモード時（`text-secondary`→gray-400）の見え方は本PRのスコープ外（Issueコメントの指摘どおり別途検証）。

## テスト

- 単体テスト: `seatA11yList.test.tsx` 全11ケース パス（クラス付与・相互ホバー等の回帰なし）。純スタイル変更のため色計算のロジックテストは対象外。
- 型（`tsc --noEmit`）・Prettier: パス。
- **agent-browser 目視＋計算済みスタイル検証**（`/theater-experience` standard）:
  - 計算済み `color`/`background-color` が意図トークンと一致することを確認:
    - 静止: `color: rgb(68,68,68)` = gray-600
    - ホバー: `color: rgb(0,90,148)` = primary-800
    - 選択+ホバー: `background-color: rgb(0,107,172)` = primary-700 / 白文字
  - Next.js Dev Toolsバッジ 赤なし（Issue件数表示なし）、コンソールは既存の Three.js deprecation 警告のみ。
  - 3D↔2D相互ホバー（#468）の回帰なし。

### ホバー時（blue-on-blue の是正・本Issueの主眼）拡大比較

ホバー席の番号が明るい青（低コントラスト）から濃紺（primary-800）へ。静止番号も一段濃いグレーに。

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7b62a45d-9b65-464a-8ea0-a7faa0841fc8) | ![after](https://github.com/user-attachments/assets/ac2d4fed-3eb5-45e4-8d40-78ed89667827) |

### 修正後 全体（2D座席一覧が判読可能）

![after-full](https://github.com/user-attachments/assets/52d58599-aa91-4a60-8f34-9ffb3aa1e4fc)

Closes #486
