### PR TITLE
feat(theater): 一人称カメラをfov/見上げ角の可変化＋フライスルーで忠実化（Closes #473）

### DIFF
--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -12,7 +12,7 @@ import {
   PerspectiveCamera,
   Edges,
 } from '@react-three/drei';
-import { useThree } from '@react-three/fiber';
+import { useThree, useFrame } from '@react-three/fiber';
 import {
   PlaneGeometry,
   Vector3,
@@ -23,11 +23,17 @@ import {
 
 import type { TheaterSeat, Theater } from '../../types';
 import {
+  calcDistance3D,
   calcDistanceToScreen,
   calcYawClampedTargetX,
+  calcPitchClampedTargetY,
+  calcFirstPersonFov,
+  easeOutCubic,
+  resolveFlythroughStart,
 } from '../../utils/fieldOfView';
 import {
   calcOverviewZoom,
+  calcOverviewCameraPosition,
   interpolateFloorHeight,
 } from '../../utils/theaterGeometry';
 import type { SeatXSegment } from '../../utils/theaterGeometry';
@@ -56,6 +62,8 @@ export interface TheaterSceneProps {
   rowYs: number[];
   /** 座席ブロックのxセグメント（縦通路で分割） — 段差LEDをブロック単位に分割配置する */
   seatSegments: SeatXSegment[];
+  /** prefers-reduced-motion 有効時は true（俯瞰→一人称のフライスルーを即時カットにする） */
+  reducedMotion?: boolean;
   /** 子要素（座席、スクリーン、ヒートマップ等） */
   children: React.ReactNode;
 }
@@ -394,6 +402,27 @@ const YAW_DEADZONE_DEG = 15;
 const YAW_DEADZONE_RAD = (YAW_DEADZONE_DEG * Math.PI) / 180;
 
 /**
+ * 一人称視点の見上げ角の上限（度）。スクリーン中心が高い位置（IMAX等）でも、
+ * 首を反らし過ぎない自然なリクライン姿勢の上限。超過分はスクリーンが視野の上方に寄る
+ * （高い大画面を「見上げている」実態がそのまま表現される）。
+ */
+const MAX_PITCH_DEG = 22;
+const MAX_PITCH_RAD = (MAX_PITCH_DEG * Math.PI) / 180;
+
+/**
+ * 首を上げ始めない不感帯（度）。スクリーン中心の仰角がこの角度以内なら首を上げず、
+ * 眼の高さの真正面を向く（僅かな高低差は目・周辺視で捉える）。
+ */
+const PITCH_DEADZONE_DEG = 6;
+const PITCH_DEADZONE_RAD = (PITCH_DEADZONE_DEG * Math.PI) / 180;
+
+/**
+ * 俯瞰→一人称のフライスルー時間（秒）。空間の対応付けを助ける短い移動。
+ * prefers-reduced-motion 有効時は 0 として即時カットにする（WCAG 2.3.3 配慮）。
+ */
+const FLYTHROUGH_DURATION_S = 0.55;
+
+/**
  * 等角投影カメラ + lookAt 原点向き
  * drei の OrthographicCamera は lookAt プロパティを取らないため
  * ref 経由で手動で向きを設定する
@@ -405,7 +434,11 @@ const IsometricCameraRig = memo<{
 }>(function IsometricCameraRig({ roomWidth, roomDepth, roomHeight }) {
   const cameraRef = useRef<OrthographicCameraType | null>(null);
   const set = useThree((state) => state.set);
-  const camDistance = Math.max(roomWidth, roomDepth) * 1.2;
+  // 設置位置は一人称フライスルーの開始点と共有（単一ソース）
+  const position = useMemo(
+    () => calcOverviewCameraPosition(roomWidth, roomDepth),
+    [roomWidth, roomDepth],
+  );
   // 部屋サイズに応じて等角カメラのズームを調整（大型ルームでも全体が収まる）
   const zoom = calcOverviewZoom(roomWidth, roomDepth, roomHeight);
   const target = useMemo<[number, number, number]>(
@@ -425,7 +458,7 @@ const IsometricCameraRig = memo<{
     <OrthographicCamera
       ref={cameraRef}
       makeDefault
-      position={[camDistance, camDistance, camDistance]}
+      position={position}
       zoom={zoom}
       near={0.1}
       far={200}
@@ -436,21 +469,29 @@ IsometricCameraRig.displayName = 'IsometricCameraRig';
 
 /**
  * 一人称カメラ（選択座席の目線位置）
- * 座席が変わるたびに位置と注視点を更新し、OrbitControlsで自由視点許可
+ * 座席が変わるたびに位置・注視点・FOVを更新し、俯瞰視点から着座点への
+ * 短いフライスルー（reduced-motion時は即時）で空間の対応付けを助ける。
  */
 const FirstPersonCameraRig = memo<{
   selectedSeat: TheaterSeat;
   theater: Theater;
-}>(function FirstPersonCameraRig({ selectedSeat, theater }) {
+  roomWidth: number;
+  roomDepth: number;
+  roomHeight: number;
+  reducedMotion: boolean;
+}>(function FirstPersonCameraRig({
+  selectedSeat,
+  theater,
+  roomWidth,
+  roomDepth,
+  roomHeight,
+  reducedMotion,
+}) {
   const cameraRef = useRef<PerspectiveCameraType | null>(null);
   const set = useThree((state) => state.set);
 
   /**
-   * 注視点: 座席の真正面・水平方向。
-   * 実際の映画館では観客は水平に前を向いて座り、スクリーンは結果として視野の
-   * 上方に現れる。スクリーン中心を直接 lookAt すると首が上下左右に回って
-   * しまうため、顔は座席のX位置・目の高さで真正面（+Z）を向く。
-   *
+   * カメラ位置: 座席の目線。
    * 左右の見え方について:
    * Three.js は +Z方向を向くカメラで世界の +X 軸を画面左に投影する。本アプリの
    * 座標系は +X = 観客から見て右なので、座席X座標をそのまま使うと端席で左右が
@@ -468,20 +509,17 @@ const FirstPersonCameraRig = memo<{
     ],
     [selectedSeat.position_x, selectedSeat.position_y, selectedSeat.position_z],
   );
+
   /**
    * 注視点の決め方:
    *
    * - X（水平の首振り）: 中央〜中央寄りの席は首を振らず真正面（スクリーン中心が
-   *   不感帯 YAW_DEADZONE_DEG 以内）。それを超えた分だけスクリーン中心方向へ首を
-   *   振り、上限角 MAX_YAW_DEG で頭打ちにする（超過分はスクリーンが視野の端に寄る）。
-   *   旧実装は「座席Xとスクリーン中心Xの中点」(α=0.5)固定で、中央寄りでも首を振り、
-   *   前列端では約36°も振り過剰だった（例: A列端 full 55° → 上限20°で頭打ち）。
-   *
-   * - Y: 眼の高さ＋1.5m。スクリーン中心(y=4.5)を直接 lookAt すると
-   *   前列で33°もの上向きになり「首を反らす」状態になる。実際の映画館では
-   *   椅子のリクライン姿勢で 15-20° 程度の自然な上向きなので、注視点を
-   *   スクリーン下半分の中央付近（眼+1.5m）に置く。
-   *
+   *   不感帯 YAW_DEADZONE_DEG 以内）。超過分だけスクリーン中心方向へ首を振り、
+   *   上限角 MAX_YAW_DEG で頭打ちにする。
+   * - Y（見上げ）: 旧実装の「眼+1.5m」固定をやめ、実際のスクリーン中心Yに追従する
+   *   pitch-clamp に変更。フォーマットでスクリーン中心Yが大きく異なる
+   *   （standard 4.35 / IMAX 10.45 等）ため、固定値では特にIMAX前列で見上げが
+   *   過小表現された。上限角 MAX_PITCH_DEG で頭打ちにする（首を反らし過ぎない）。
    * - Z: スクリーン平面のZに固定。
    */
   const target = useMemo<[number, number, number]>(() => {
@@ -489,8 +527,8 @@ const FirstPersonCameraRig = memo<{
     const screenX = Number(theater.screen_center_x);
     const seatZ = Number(selectedSeat.position_z);
     const screenZ = Number(theater.screen_center_z);
+    const screenCenterY = Number(theater.screen_center_y);
     const eyeY = Number(selectedSeat.position_y) + SEATED_EYE_HEIGHT;
-    // スクリーン中心を向くが、水平首振りは MAX_YAW で頭打ちにする
     const forwardDist = calcDistanceToScreen(seatZ, screenZ);
     const targetX = calcYawClampedTargetX(
       seatX,
@@ -499,9 +537,16 @@ const FirstPersonCameraRig = memo<{
       MAX_YAW_RAD,
       YAW_DEADZONE_RAD,
     );
+    const targetY = calcPitchClampedTargetY(
+      eyeY,
+      screenCenterY,
+      forwardDist,
+      MAX_PITCH_RAD,
+      PITCH_DEADZONE_RAD,
+    );
     return [
       -targetX, // ミラー反転（カメラ位置と同じ補正）
-      eyeY + 1.5,
+      targetY,
       screenZ,
     ];
   }, [
@@ -509,35 +554,121 @@ const FirstPersonCameraRig = memo<{
     selectedSeat.position_y,
     selectedSeat.position_z,
     theater.screen_center_x,
+    theater.screen_center_y,
     theater.screen_center_z,
   ]);
 
+  /**
+   * FOV: スクリーン寸法/フォーマット・席距離に追従して可変（旧実装は 85° 固定）。
+   * 眼→スクリーン中心の視聴距離とスクリーン高から、スクリーンが視野の一定割合を
+   * 占めるFOVを算出し上下限でクランプする。IMAX等の大画面ほど広く、後列ほど狭くなる。
+   */
+  const fov = useMemo(() => {
+    const eye = {
+      x: Number(selectedSeat.position_x),
+      y: Number(selectedSeat.position_y) + SEATED_EYE_HEIGHT,
+      z: Number(selectedSeat.position_z),
+    };
+    const screenCenter = {
+      x: Number(theater.screen_center_x),
+      y: Number(theater.screen_center_y),
+      z: Number(theater.screen_center_z),
+    };
+    const viewingDistance = calcDistance3D(eye, screenCenter);
+    return calcFirstPersonFov(viewingDistance, Number(theater.screen_height));
+  }, [
+    selectedSeat.position_x,
+    selectedSeat.position_y,
+    selectedSeat.position_z,
+    theater.screen_center_x,
+    theater.screen_center_y,
+    theater.screen_center_z,
+    theater.screen_height,
+  ]);
+
+  // フライスルー開始点（俯瞰カメラと同じ設置位置・注視点＝俯瞰の見え方から着座へ繋ぐ）
+  const overviewPos = useMemo(
+    () => calcOverviewCameraPosition(roomWidth, roomDepth),
+    [roomWidth, roomDepth],
+  );
+  const overviewTarget = useMemo<[number, number, number]>(
+    () => [0, roomHeight / 2, 0],
+    [roomHeight],
+  );
+
+  // フライスルーのアニメーション状態（useFrameで進める。R3F描画依存のため単体テスト対象外）
+  const anim = useRef({
+    elapsed: FLYTHROUGH_DURATION_S,
+    from: new Vector3(),
+    fromTarget: new Vector3(),
+    started: false,
+  });
+  // 現在の注視点（座席切替時に「今向いている点」から補間を再開するため保持）
+  const currentTarget = useRef(new Vector3());
+
+  // 座席選択・切替時にフライスルーを（再）開始する。開始点の決定は
+  // resolveFlythroughStart（純ロジック・単体テスト済み）に委譲する。
   useEffect(() => {
-    if (cameraRef.current) {
-      cameraRef.current.position.set(seatPos[0], seatPos[1], seatPos[2]);
-      cameraRef.current.lookAt(new Vector3(target[0], target[1], target[2]));
-      cameraRef.current.updateProjectionMatrix();
-      set({ camera: cameraRef.current });
+    const cam = cameraRef.current;
+    if (!cam) return;
+    cam.fov = fov;
+    cam.updateProjectionMatrix();
+
+    const start = resolveFlythroughStart({
+      started: anim.current.started,
+      reducedMotion,
+      durationS: FLYTHROUGH_DURATION_S,
+      overviewPos,
+      overviewTarget,
+      currentPos: [cam.position.x, cam.position.y, cam.position.z],
+      currentTarget: [
+        currentTarget.current.x,
+        currentTarget.current.y,
+        currentTarget.current.z,
+      ],
+    });
+    anim.current.from.set(start.from[0], start.from[1], start.from[2]);
+    anim.current.fromTarget.set(
+      start.fromTarget[0],
+      start.fromTarget[1],
+      start.fromTarget[2],
+    );
+    anim.current.elapsed = start.elapsed;
+    anim.current.started = true;
+    set({ camera: cam });
+  }, [seatPos, target, fov, overviewPos, overviewTarget, reducedMotion, set]);
+
+  // 毎フレーム、開始点→着座点へ ease-out 補間する（満了後は着座点で静止＝冪等）
+  useFrame((_, delta) => {
+    const cam = cameraRef.current;
+    if (!cam) return;
+    const a = anim.current;
+    if (a.elapsed < FLYTHROUGH_DURATION_S) {
+      a.elapsed = Math.min(a.elapsed + delta, FLYTHROUGH_DURATION_S);
     }
-  }, [seatPos, target, set]);
+    const t = easeOutCubic(a.elapsed / FLYTHROUGH_DURATION_S);
+    cam.position.set(
+      a.from.x + (seatPos[0] - a.from.x) * t,
+      a.from.y + (seatPos[1] - a.from.y) * t,
+      a.from.z + (seatPos[2] - a.from.z) * t,
+    );
+    currentTarget.current.set(
+      a.fromTarget.x + (target[0] - a.fromTarget.x) * t,
+      a.fromTarget.y + (target[1] - a.fromTarget.y) * t,
+      a.fromTarget.z + (target[2] - a.fromTarget.z) * t,
+    );
+    cam.lookAt(currentTarget.current);
+  });
 
   return (
-    <>
-      {/*
-        FOV 85° (垂直): 16:9 で水平 ~116°。人間の視野の周辺認識ぎりぎりの
-        広角でスクリーン+周囲（壁・天井・床）が同時に視野に入る。
-        OrbitControls は使わず、座席ごとにカメラ位置と注視点を固定する。
-        座席を変えるとカメラがその座席の視点に瞬時に切り替わる。
-      */}
-      <PerspectiveCamera
-        ref={cameraRef}
-        makeDefault
-        position={seatPos}
-        fov={85}
-        near={0.05}
-        far={100}
-      />
-    </>
+    <PerspectiveCamera
+      ref={cameraRef}
+      makeDefault
+      position={overviewPos}
+      fov={fov}
+      near={0.05}
+      far={200}
+    />
   );
 });
 FirstPersonCameraRig.displayName = 'FirstPersonCameraRig';
@@ -554,6 +685,7 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
   rowZs,
   rowYs,
   seatSegments,
+  reducedMotion = false,
   children,
 }) {
   const halfWidth = roomWidth / 2;
@@ -568,7 +700,14 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
     <>
       {/* 座席選択時は一人称、未選択時は等角投影 */}
       {selectedSeat ? (
-        <FirstPersonCameraRig selectedSeat={selectedSeat} theater={theater} />
+        <FirstPersonCameraRig
+          selectedSeat={selectedSeat}
+          theater={theater}
+          roomWidth={roomWidth}
+          roomDepth={roomDepth}
+          roomHeight={roomHeight}
+          reducedMotion={reducedMotion}
+        />
       ) : (
         <IsometricCameraRig
           roomWidth={roomWidth}

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.tsx
@@ -305,6 +305,7 @@ export const TheaterExperiencePage = memo<TheaterExperiencePageProps>(
                   rowZs={seatAreaBounds.rowZs}
                   rowYs={seatAreaBounds.rowYs}
                   seatSegments={seatAreaBounds.seatSegments}
+                  reducedMotion={reducedMotion}
                 >
                   <SeatMeshes
                     seats={seats}

--- a/src/features/theaterExperience/utils/fieldOfView.test.ts
+++ b/src/features/theaterExperience/utils/fieldOfView.test.ts
@@ -10,6 +10,10 @@ import {
   calcFieldOfViewMetrics,
   projectScreenQuad,
   calcYawClampedTargetX,
+  calcPitchClampedTargetY,
+  calcFirstPersonFov,
+  easeOutCubic,
+  resolveFlythroughStart,
 } from './fieldOfView';
 
 describe('calcDistance3D', () => {
@@ -263,5 +267,184 @@ describe('calcYawClampedTargetX', () => {
   it('前方距離が0以下ならスクリーン中心を返す（フォールバック）', () => {
     expect(calcYawClampedTargetX(-7.2, 0, 0, MAX_YAW, DEADZONE)).toBe(0);
     expect(calcYawClampedTargetX(-7.2, 0, -3, MAX_YAW, DEADZONE)).toBe(0);
+  });
+});
+
+describe('calcPitchClampedTargetY', () => {
+  const MAX_PITCH = (22 * Math.PI) / 180;
+  const DEADZONE = (6 * Math.PI) / 180;
+  const EYE_Y = 1.5;
+
+  it('スクリーン中心が眼と同高（仰角0）なら首を上げず眼の高さを向く', () => {
+    expect(
+      calcPitchClampedTargetY(EYE_Y, EYE_Y, 5, MAX_PITCH, DEADZONE),
+    ).toBeCloseTo(EYE_Y, 6);
+  });
+
+  it('不感帯内（低い仰角）の高さは首を上げず眼の高さを向く', () => {
+    // 仰角 = atan(0.5/5) ≒ 5.7° < 6°(不感帯) → 首を上げず eyeY
+    expect(
+      calcPitchClampedTargetY(EYE_Y, EYE_Y + 0.5, 5, MAX_PITCH, DEADZONE),
+    ).toBeCloseTo(EYE_Y, 6);
+  });
+
+  it('不感帯を超えた分だけ首を上げる（超過角のみ）', () => {
+    // 中心仰角20°の高さ → 見上げ = 20° - 6°(不感帯) = 14°
+    const screenY = EYE_Y + 5 * Math.tan((20 * Math.PI) / 180);
+    const targetY = calcPitchClampedTargetY(
+      EYE_Y,
+      screenY,
+      5,
+      MAX_PITCH,
+      DEADZONE,
+    );
+    const pitch = Math.atan((targetY - EYE_Y) / 5);
+    expect(pitch).toBeCloseTo((14 * Math.PI) / 180, 6);
+  });
+
+  it('高いスクリーン（IMAX相当）は上限角で頭打ちになる（首を反らし過ぎない）', () => {
+    // 仰角57°相当（IMAX前列: 中心10.45 - 眼~1.2 を距離6で見上げ）→ 22°で頭打ち
+    const screenY = EYE_Y + 6 * Math.tan((57 * Math.PI) / 180);
+    const targetY = calcPitchClampedTargetY(
+      EYE_Y,
+      screenY,
+      6,
+      MAX_PITCH,
+      DEADZONE,
+    );
+    const pitch = Math.atan((targetY - EYE_Y) / 6);
+    expect(pitch).toBeCloseTo(MAX_PITCH, 6);
+  });
+
+  it('スクリーンが眼より低い場合は符号を保って下向きになる', () => {
+    const screenY = EYE_Y - 5 * Math.tan((15 * Math.PI) / 180);
+    const targetY = calcPitchClampedTargetY(
+      EYE_Y,
+      screenY,
+      5,
+      MAX_PITCH,
+      DEADZONE,
+    );
+    expect(targetY).toBeLessThan(EYE_Y);
+  });
+
+  it('前方距離が0以下ならスクリーン中心の高さを返す（フォールバック）', () => {
+    expect(calcPitchClampedTargetY(EYE_Y, 8, 0, MAX_PITCH, DEADZONE)).toBe(8);
+    expect(calcPitchClampedTargetY(EYE_Y, 8, -2, MAX_PITCH, DEADZONE)).toBe(8);
+  });
+});
+
+describe('calcFirstPersonFov', () => {
+  it('FOVは既定の上下限[50,75]°の範囲に収まる', () => {
+    // 近い大画面（IMAX前列相当）: 上限に張り付く
+    expect(calcFirstPersonFov(11, 18.9)).toBe(75);
+    // 遠い小画面（後列相当）: 下限で頭打ち
+    expect(calcFirstPersonFov(18.8, 6.7)).toBe(50);
+  });
+
+  it('同一距離では大画面ほどFOVが広い（フォーマット追従）', () => {
+    const standard = calcFirstPersonFov(15, 6.7);
+    const imax = calcFirstPersonFov(15, 18.9);
+    expect(imax).toBeGreaterThan(standard);
+  });
+
+  it('同一スクリーンでは近いほどFOVが広い（席距離追従）', () => {
+    const near = calcFirstPersonFov(8, 8);
+    const far = calcFirstPersonFov(20, 8);
+    expect(near).toBeGreaterThan(far);
+  });
+
+  it('中間域では fillRatio に基づく垂直サブテンスからFOVを算出する', () => {
+    // subtense = 2*atan(4/12) ≒ 36.87°、fillRatio 0.7 → 52.7°（[50,75]内）
+    const expected = ((2 * Math.atan(4 / 12)) / 0.7) * (180 / Math.PI);
+    expect(calcFirstPersonFov(12, 8)).toBeCloseTo(expected, 4);
+    expect(calcFirstPersonFov(12, 8)).toBeGreaterThan(50);
+    expect(calcFirstPersonFov(12, 8)).toBeLessThan(75);
+  });
+
+  it('視聴距離やスクリーン高が0以下なら上限FOVを返す（フォールバック）', () => {
+    expect(calcFirstPersonFov(0, 8)).toBe(75);
+    expect(calcFirstPersonFov(10, 0)).toBe(75);
+  });
+
+  it('options で上下限・fillRatio を上書きできる', () => {
+    expect(calcFirstPersonFov(11, 18.9, { maxFovDeg: 90 })).toBeGreaterThan(75);
+    expect(
+      calcFirstPersonFov(30, 6.7, { minFovDeg: 40 }),
+    ).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('easeOutCubic', () => {
+  it('端点は 0→0, 1→1 に写像する', () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+  });
+
+  it('中間は線形より進んでいる（開始直後に速い ease-out）', () => {
+    expect(easeOutCubic(0.5)).toBeGreaterThan(0.5);
+    // 1 - (1-0.5)^3 = 0.875
+    expect(easeOutCubic(0.5)).toBeCloseTo(0.875, 6);
+  });
+
+  it('範囲外入力は0〜1にクランプされる', () => {
+    expect(easeOutCubic(-1)).toBe(0);
+    expect(easeOutCubic(2)).toBe(1);
+  });
+
+  it('単調増加する', () => {
+    expect(easeOutCubic(0.2)).toBeLessThan(easeOutCubic(0.4));
+    expect(easeOutCubic(0.4)).toBeLessThan(easeOutCubic(0.6));
+  });
+});
+
+describe('resolveFlythroughStart', () => {
+  const base = {
+    durationS: 0.55,
+    overviewPos: [30, 30, 30] as [number, number, number],
+    overviewTarget: [0, 4, 0] as [number, number, number],
+    currentPos: [-2, 1.2, 5] as [number, number, number],
+    currentTarget: [-1, 5, 10] as [number, number, number],
+  };
+
+  it('初回（未起動）は俯瞰視点から補間を始める', () => {
+    const r = resolveFlythroughStart({
+      ...base,
+      started: false,
+      reducedMotion: false,
+    });
+    expect(r.from).toEqual([30, 30, 30]);
+    expect(r.fromTarget).toEqual([0, 4, 0]);
+    expect(r.elapsed).toBe(0);
+  });
+
+  it('一人称中の席替え（起動済み）は現在のカメラ状態から補間を始める', () => {
+    const r = resolveFlythroughStart({
+      ...base,
+      started: true,
+      reducedMotion: false,
+    });
+    expect(r.from).toEqual([-2, 1.2, 5]);
+    expect(r.fromTarget).toEqual([-1, 5, 10]);
+    expect(r.elapsed).toBe(0);
+  });
+
+  it('reduced-motion 時は elapsed を満了させ即時カットにする', () => {
+    const r = resolveFlythroughStart({
+      ...base,
+      started: false,
+      reducedMotion: true,
+    });
+    expect(r.elapsed).toBe(0.55);
+  });
+
+  it('reduced-motion は起点の決定には影響しない（席替えでも現在位置起点）', () => {
+    const r = resolveFlythroughStart({
+      ...base,
+      started: true,
+      reducedMotion: true,
+    });
+    expect(r.from).toEqual([-2, 1.2, 5]);
+    expect(r.elapsed).toBe(0.55);
   });
 });

--- a/src/features/theaterExperience/utils/fieldOfView.ts
+++ b/src/features/theaterExperience/utils/fieldOfView.ts
@@ -152,6 +152,133 @@ export function calcYawClampedTargetX(
 }
 
 /**
+ * 一人称視点の垂直FOV（度）を、視聴距離とスクリーン高から算出する。
+ *
+ * 旧実装は全フォーマット共通の fov=85° 固定で、広角すぎて魚眼的な歪みが出るうえ、
+ * IMAX(スクリーン高18.9m)と standard(6.7m) のフォーマット差に追従しなかった。
+ * ここではスクリーン高が視野に占める見込み角（垂直サブテンス）を基準に、
+ * スクリーンが視野の一定割合(fillRatio)を占めるFOVを求め、上下限でクランプする。
+ *
+ * - 近い/大画面（IMAX最前列など）: サブテンスが大 → FOVは上限に張り付き、
+ *   スクリーンがFOVを超えて「はみ出す」実態がそのまま表現される（過小表現しない）。
+ * - 遠い/小画面（後列など）: サブテンスが小 → FOVは下限で頭打ちになり、
+ *   スクリーンが小さく見える（＝距離感が残る。常に画面いっぱいに再フレームしない）。
+ *
+ * @param viewingDistance 眼からスクリーン中心までの視聴距離(m, >0想定)
+ * @param screenHeight スクリーンの高さ(m)
+ * @param options fillRatio: スクリーン高がFOVに占める目標割合 / min,maxFovDeg: FOV上下限(度)
+ * @returns 垂直FOV(度)
+ */
+export function calcFirstPersonFov(
+  viewingDistance: number,
+  screenHeight: number,
+  options: {
+    fillRatio?: number;
+    minFovDeg?: number;
+    maxFovDeg?: number;
+  } = {},
+): number {
+  const { fillRatio = 0.7, minFovDeg = 50, maxFovDeg = 75 } = options;
+  if (viewingDistance <= 0 || screenHeight <= 0) return maxFovDeg;
+  // スクリーン高の垂直サブテンス（上端・下端の見込み角の差）
+  const subtenseRad = 2 * Math.atan(screenHeight / 2 / viewingDistance);
+  const fovDeg = ((subtenseRad / fillRatio) * 180) / Math.PI;
+  return Math.min(Math.max(fovDeg, minFovDeg), maxFovDeg);
+}
+
+/**
+ * 一人称視点の垂直注視点Y（見上げの向き）を計算する。
+ * calcYawClampedTargetX（水平首振り）の垂直版で、対称のロジック:
+ * - スクリーン中心の仰角が deadzonePitchRad 以内なら首を上げず、眼の高さの真正面を向く。
+ * - それを超える分だけ首を上向け、maxPitchRad で頭打ちにする（過度な首反りを防ぐ）。
+ *
+ * 旧実装は「眼の高さ+1.5m」固定で、スクリーン中心Yがフォーマットで大きく異なる
+ * （standard 4.35 / IMAX 10.45 等）のに追従せず、特にIMAX前列で見上げが過小表現された。
+ * 本関数は実際のスクリーン中心Yに追従し、上限角で頭打ちにする。
+ *
+ * @param eyeY 眼の高さ(m)
+ * @param screenCenterY スクリーン中心のY(m)
+ * @param forwardDistance 座席→スクリーン平面の前方距離(m, >0想定)
+ * @param maxPitchRad 見上げ角の上限(rad, >=0)
+ * @param deadzonePitchRad 首を上げ始めない不感帯(rad, >=0, 既定0)
+ * @returns 注視点のY座標
+ */
+export function calcPitchClampedTargetY(
+  eyeY: number,
+  screenCenterY: number,
+  forwardDistance: number,
+  maxPitchRad: number,
+  deadzonePitchRad = 0,
+): number {
+  const verticalToCenter = screenCenterY - eyeY;
+  // 前方距離が取れない場合はスクリーン中心の高さを向く（フォールバック）
+  if (forwardDistance <= 0) return screenCenterY;
+  const pitchToCenter = Math.atan(Math.abs(verticalToCenter) / forwardDistance);
+  // 不感帯を超えた分だけ首を上げ、上限角で頭打ちにする
+  const headPitch = Math.min(
+    Math.max(pitchToCenter - deadzonePitchRad, 0),
+    maxPitchRad,
+  );
+  const vertical =
+    Math.sign(verticalToCenter) * forwardDistance * Math.tan(headPitch);
+  return eyeY + vertical;
+}
+
+/**
+ * ease-out cubic 補間係数。俯瞰→一人称のフライスルーで、開始直後に速く動き
+ * 着座点へ滑らかに減速して収束させる（0→1 を単調増加で写像）。
+ * 範囲外入力は 0〜1 にクランプする。
+ */
+export function easeOutCubic(t: number): number {
+  const clamped = Math.min(Math.max(t, 0), 1);
+  return 1 - Math.pow(1 - clamped, 3);
+}
+
+/** フライスルー補間の開始状態（開始位置・開始注視点・初期経過秒） */
+export interface FlythroughStart {
+  from: [number, number, number];
+  fromTarget: [number, number, number];
+  elapsed: number;
+}
+
+/**
+ * 一人称フライスルーの開始状態を決定する（R3Fに依存しない純ロジック）。
+ * - 初回（俯瞰→一人称）: 俯瞰カメラの位置・注視点から補間を始める（空間の対応付け）。
+ * - 一人称中の席替え: 現在のカメラ位置・注視点から補間を始める（滑らかな席移動）。
+ * - prefers-reduced-motion 時: elapsed を満了させて即時カット（アニメを飛ばす）。
+ *
+ * @param params.started 既に一人称カメラが起動済みか（false=初回）
+ * @param params.reducedMotion reduced-motion 有効時 true
+ * @param params.durationS フライスルー時間(秒)
+ * @param params.overviewPos 俯瞰カメラ位置 / overviewTarget 俯瞰注視点
+ * @param params.currentPos 現在のカメラ位置 / currentTarget 現在の注視点
+ */
+export function resolveFlythroughStart(params: {
+  started: boolean;
+  reducedMotion: boolean;
+  durationS: number;
+  overviewPos: [number, number, number];
+  overviewTarget: [number, number, number];
+  currentPos: [number, number, number];
+  currentTarget: [number, number, number];
+}): FlythroughStart {
+  const {
+    started,
+    reducedMotion,
+    durationS,
+    overviewPos,
+    overviewTarget,
+    currentPos,
+    currentTarget,
+  } = params;
+  return {
+    from: started ? currentPos : overviewPos,
+    fromTarget: started ? currentTarget : overviewTarget,
+    elapsed: reducedMotion ? durationS : 0,
+  };
+}
+
+/**
  * 視野占有率メトリクスを一括計算する（座席の3D位置を考慮）。
  */
 export function calcFieldOfViewMetrics(

--- a/src/features/theaterExperience/utils/theaterGeometry.test.ts
+++ b/src/features/theaterExperience/utils/theaterGeometry.test.ts
@@ -4,7 +4,9 @@
 
 import {
   OVERVIEW_MAX_ZOOM,
+  OVERVIEW_CAMERA_DISTANCE_FACTOR,
   calcOverviewZoom,
+  calcOverviewCameraPosition,
   computeSeatXSegments,
   interpolateFloorHeight,
 } from './theaterGeometry';
@@ -35,6 +37,28 @@ describe('calcOverviewZoom', () => {
 
   it('不正な寸法(0以下)でも上限を返す', () => {
     expect(calcOverviewZoom(0, 0, 0)).toBe(OVERVIEW_MAX_ZOOM);
+  });
+});
+
+describe('calcOverviewCameraPosition', () => {
+  it('最大辺×係数を3軸とも同値に設定する（等角視点）', () => {
+    // standard: max(14.5,21)=21 → 21×1.2=25.2
+    const [x, y, z] = calcOverviewCameraPosition(14.5, 21);
+    expect(x).toBeCloseTo(21 * OVERVIEW_CAMERA_DISTANCE_FACTOR, 6);
+    expect(x).toBe(y);
+    expect(y).toBe(z);
+  });
+
+  it('幅と奥行のうち大きい方で律速する', () => {
+    // 幅の方が大きいケース
+    const [x] = calcOverviewCameraPosition(30, 10);
+    expect(x).toBeCloseTo(30 * OVERVIEW_CAMERA_DISTANCE_FACTOR, 6);
+  });
+
+  it('大型ルーム(IMAX)ほど引き距離が大きい', () => {
+    const std = calcOverviewCameraPosition(14.5, 21)[0];
+    const imax = calcOverviewCameraPosition(29, 26)[0];
+    expect(imax).toBeGreaterThan(std);
   });
 });
 

--- a/src/features/theaterExperience/utils/theaterGeometry.ts
+++ b/src/features/theaterExperience/utils/theaterGeometry.ts
@@ -6,6 +6,22 @@
 export const OVERVIEW_MAX_ZOOM = 28;
 /** 俯瞰ズーム定数（= 上限28 × 基準fitSize≈25）。部屋が大きいほどズームアウトする */
 export const OVERVIEW_ZOOM_CONSTANT = 700;
+/** 俯瞰カメラの引き距離係数（部屋の最大辺に対する倍率。等角3方向とも同値） */
+export const OVERVIEW_CAMERA_DISTANCE_FACTOR = 1.2;
+
+/**
+ * 等角俯瞰カメラの設置位置を算出する（3軸とも同じ引き距離のアイソメトリック視点）。
+ * 一人称遷移のフライスルー開始点（俯瞰視点）と、俯瞰カメラリグの設置位置で
+ * 同一値を共有するため、単一ソースとして切り出している。
+ */
+export function calcOverviewCameraPosition(
+  roomWidth: number,
+  roomDepth: number,
+): [number, number, number] {
+  const distance =
+    Math.max(roomWidth, roomDepth) * OVERVIEW_CAMERA_DISTANCE_FACTOR;
+  return [distance, distance, distance];
+}
 
 /**
  * 部屋サイズに応じた等角俯瞰カメラのズームを算出する。


### PR DESCRIPTION
## 概要

一人称カメラの見え方の忠実度を改善しました。フォーマット非依存な固定値（fov=85°・注視点Y=眼+1.5m）を、**スクリーン寸法/フォーマット・席距離に追従する可変方式**へ刷新し、俯瞰→一人称の瞬間カットを**短いフライスルー**に置き換えました。

**主な変更:**

- **FOV可変**（`calcFirstPersonFov`）: 眼→スクリーン中心の視聴距離とスクリーン高から、スクリーンが視野の一定割合を占めるFOVを算出し `[50, 75]°` でクランプ。近い/大画面ほど広く（上限張り付き時は画面が視界を**はみ出す**＝過小表現しない）、遠い/小画面ほど狭い（距離感を保持）。
- **見上げ角のフォーマット追従**（`calcPitchClampedTargetY`）: 眼+1.5m固定を廃し、実スクリーン中心Yに追従する pitch-clamp（既存 `calcYawClampedTargetX` の垂直版）へ。上限 `22°` で頭打ち。standard(4.35) / IMAX(10.45) 等のフォーマット差に追従。
- **フライスルー**: 俯瞰視点→着座点へ ease-out cubic の短い移動（0.55s）。`prefers-reduced-motion` 有効時は即時カット。
- 俯瞰カメラ設置位置を `calcOverviewCameraPosition` に集約し、フライスルー開始点と共有（単一ソース）。

## ロードマップ

- P2改善（シアター体験の一人称忠実度）。`Closes #473`

## レビューポイント

- **算出ロジックを util へ切り出し単体テスト化**（Issue指摘「fov=85・+1.5 のJSX/useMemo内マジックナンバー」の解消）: `fieldOfView.ts` に `calcFirstPersonFov` / `calcPitchClampedTargetY` / `easeOutCubic` / `resolveFlythroughStart`、`theaterGeometry.ts` に `calcOverviewCameraPosition`。
- **fov方針の判断**: 「フォーマット/席距離で可変」を採用（もう一方の「60〜70°固定」は不採用）。`fillRatio 0.7`・上下限 `[50,75]°` は、前列/大画面の**はみ出しを隠さず**（上限張り付き）、後列の**距離感を保つ**（下限）よう調整し、常に画面いっぱいへ再フレームしないようにしています。
- **フライスルー起点の分岐**（初回=俯瞰起点 / 席替え=現在位置起点 / reduced-motion=即時）は、R3F描画から分離した純関数 `resolveFlythroughStart` に切り出して単体テスト。`useFrame` での補間適用のみがR3F側（カバレッジ除外）です。
- ミラーX補正・距離/視野占有率メトリクスの算出は従来どおり実座標系のまま不変（表示値は正確）。

## テスト

- 単体テスト追加: `fieldOfView.test.ts`（fov 7 / pitch 6 / easeOutCubic 4 / resolveFlythroughStart 4 ケース）、`theaterGeometry.test.ts`（`calcOverviewCameraPosition` 3 ケース）。**theaterExperience 全256テストパス**。
- 型（`tsc`）・ESLint・Prettier・pre-commit AIレビュー: パス。
- **agent-browser 目視検証**（fresh dev server・コンソールは Three.js deprecation 警告のみ／エラーなし）: 下記。

### FOVが席距離に追従（standard）

前列は見上げでスクリーンが視界を占有（台形＝キーストーン）、後列はスクリーンが小さく遠くほぼ正対。旧固定fovでは両者がほぼ同じ広角に見えていました。

| 前列中央 A8（距離6.3m・歪み53%） | 後列中央 N8（距離19.8m・歪み2%） |
| --- | --- |
| ![A8](https://github.com/user-attachments/assets/37176689-7c0c-4191-bd40-d39d29eea797) | ![N8](https://github.com/user-attachments/assets/d503dfca-936f-4c29-b0cb-9b2dfa7a0fc7) |

### FOV/見上げがフォーマットに追従（IMAX）

IMAX前列はスクリーンが視界を**超えてはみ出す**（右パネル「スクリーンの見え方」で実線スクリーン＞破線ビューポート）。大画面のはみ出し・見上げが過小表現されません。

| IMAX前列 A17（距離12.1m・歪み70%・はみ出し） | IMAX中列 H17（距離16.0m・歪み33%） |
| --- | --- |
| ![A17](https://github.com/user-attachments/assets/01d5be54-e677-4e75-b4d2-2c136dcdd6cb) | ![H17](https://github.com/user-attachments/assets/3c9cffe7-b40a-474f-8743-fcd0d099683e) |

### 俯瞰→一人称フライスルー（reduced-motion時は即時カット）

俯瞰視点から着座点へ短くスウープし、俯瞰と一人称の空間の対応付けを助けます。

https://github.com/user-attachments/assets/9f89876b-88db-4461-bf5e-491de39ceddd

Closes #473
