### PR TITLE
feat(theater): レンダリング質感向上（ライト比/接地影/Bloom/座席Standard材質）（Closes #474）

### DIFF
--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.test.tsx
@@ -9,10 +9,16 @@ jest.mock('three', () => ({
   ) {
     this.position = { set: jest.fn() };
     this.rotation = { set: jest.fn() };
+    this.scale = { set: jest.fn() };
     this.matrix = {};
     this.updateMatrix = jest.fn();
   }),
-  Color: jest.fn(),
+  // 背もたれ色の生成（clone().multiplyScalar()）がモジュール読込時に走るため、
+  // Color モックにも clone/multiplyScalar を持たせる（自身を返す軽量スタブ）。
+  Color: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.clone = jest.fn(() => this);
+    this.multiplyScalar = jest.fn(() => this);
+  }),
   RepeatWrapping: 1000,
 }));
 
@@ -47,6 +53,7 @@ import type { TheaterSeat } from '../../types';
 import {
   SeatMeshes,
   getSeatColorKey,
+  getSeatBackColor,
   resolveHoverEmitId,
   getHoverHighlightSeat,
 } from './seatMeshes';
@@ -140,5 +147,33 @@ describe('getSeatColorKey', () => {
   it('通常席は単色 seat（列に依らず一定）', () => {
     expect(getSeatColorKey({ ...base, row_label: 'A' }, null)).toBe('seat');
     expect(getSeatColorKey({ ...base, row_label: 'B' }, null)).toBe('seat');
+  });
+});
+
+describe('getSeatBackColor', () => {
+  const base: TheaterSeat = {
+    id: 's1',
+    row_label: 'A',
+    seat_number: 1,
+    position_x: 0,
+    position_y: 0,
+    position_z: 0,
+    seat_type: 'standard',
+  };
+
+  // getSeatColorKey と同じ優先度で色種別を選び、種別ごとに一段暗い色を返す。
+  // （three は本テストでモックのため実RGBの暗さは検証せず、種別分岐の一貫性を検証）
+  it('色種別ごとに定義済みの背もたれ色を返す', () => {
+    expect(getSeatBackColor(base, null)).toBeDefined();
+    expect(
+      getSeatBackColor({ ...base, seat_type: 'wheelchair' }, null),
+    ).toBeDefined();
+    expect(getSeatBackColor(base, 's1')).toBeDefined();
+  });
+
+  it('同一種別では同じインスタンス（事前計算マップ）を返す', () => {
+    expect(getSeatBackColor(base, null)).toBe(getSeatBackColor(base, null));
+    // 選択中は種別が selected に変わるため seat とは別インスタンス
+    expect(getSeatBackColor(base, null)).not.toBe(getSeatBackColor(base, 's1'));
   });
 });

--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -40,12 +40,22 @@ declare module '@react-three/fiber' {
  */
 const SEAT_CUSHION = { width: 0.5, height: 0.12, depth: 0.45 };
 const SEAT_BACK = { width: 0.5, height: 0.5, depth: 0.08 };
+/** 座面下の台座（脚）。床(y)からクッション下端(y+0.24)までを埋め、座席の浮きを解消する */
+const SEAT_BASE = { width: 0.2, height: 0.24, depth: 0.34 };
+/** 肘掛けバー。クッション両脇に配置し、椅子のシルエットを立たせる */
+const SEAT_ARMREST = { width: 0.05, height: 0.14, depth: 0.4 };
+/** 肘掛けをクッション中心から左右に置くオフセット（席ピッチ0.6内に収める） */
+const ARMREST_OFFSET_X = 0.27;
 
 /** ドールハウス座席カラー（単色） */
 const COLOR_SEAT = new Color('#bf4040');
 const COLOR_SELECTED = new Color('#ffaa00');
 /** 車椅子席カラー（他席と区別できる青系） */
 const COLOR_WHEELCHAIR = new Color('#3b82f6');
+/** 座席フレーム（脚・肘掛け）の暗色。座面/背もたれと分離し椅子構造を見せる */
+const COLOR_FRAME = new Color('#3a2e30');
+/** 背もたれは座面より一段暗くして、座面と背もたれの境界（椅子のシルエット）を立たせる */
+const BACK_DARKEN = 0.78;
 /**
  * ホバー強調枠の色（design-system の --warning-dark と一致させ、2Dリング色と揃える）。
  * 明色背景の2Dリングが WCAG 1.4.11(非テキスト3:1) を満たすよう、--warning-main(#f59e0b,
@@ -76,8 +86,23 @@ const SEAT_COLOR_BY_KEY: Record<SeatColorKey, Color> = {
   seat: COLOR_SEAT,
 };
 
+// 背もたれ用に一段暗くした色（座面との境界＝椅子のシルエットを立たせる）
+const SEAT_BACK_COLOR_BY_KEY: Record<SeatColorKey, Color> = {
+  selected: COLOR_SELECTED.clone().multiplyScalar(BACK_DARKEN),
+  wheelchair: COLOR_WHEELCHAIR.clone().multiplyScalar(BACK_DARKEN),
+  seat: COLOR_SEAT.clone().multiplyScalar(BACK_DARKEN),
+};
+
 function getSeatColor(seat: TheaterSeat, selectedSeatId: string | null): Color {
   return SEAT_COLOR_BY_KEY[getSeatColorKey(seat, selectedSeatId)];
+}
+
+/** 背もたれの色（座面より一段暗い）。座面/背もたれの輝度差でシルエットを立たせる。 */
+export function getSeatBackColor(
+  seat: TheaterSeat,
+  selectedSeatId: string | null,
+): Color {
+  return SEAT_BACK_COLOR_BY_KEY[getSeatColorKey(seat, selectedSeatId)];
 }
 
 /**
@@ -176,7 +201,8 @@ const SeatCushions = memo<{
           0.03,
         ]}
       />
-      <meshLambertMaterial />
+      {/* Lambert(拡散のみ) → Standard(PBR)。強めた directional 光で微光沢と陰影が出る */}
+      <meshStandardMaterial roughness={0.68} metalness={0.05} />
     </instancedMesh>
   );
 });
@@ -210,11 +236,11 @@ const SeatBacks = memo<{
     meshRef.current.instanceMatrix.needsUpdate = true;
   }, [seats, tempObject]);
 
-  // 色は座席データと選択状態に依存（選択変更時はここだけ再実行）
+  // 色は座席データと選択状態に依存（背もたれは座面より一段暗い色を使う）
   useEffect(() => {
     if (!meshRef.current) return;
     seats.forEach((seat, i) => {
-      meshRef.current!.setColorAt(i, getSeatColor(seat, selectedSeatId));
+      meshRef.current!.setColorAt(i, getSeatBackColor(seat, selectedSeatId));
     });
     if (meshRef.current.instanceColor) {
       meshRef.current.instanceColor.needsUpdate = true;
@@ -231,11 +257,110 @@ const SeatBacks = memo<{
       <roundedBoxGeometry
         args={[SEAT_BACK.width, SEAT_BACK.height, SEAT_BACK.depth, 4, 0.02]}
       />
-      <meshLambertMaterial />
+      <meshStandardMaterial roughness={0.72} metalness={0.05} />
     </instancedMesh>
   );
 });
 SeatBacks.displayName = 'SeatBacks';
+
+/**
+ * 座面下の台座（脚）のInstancedMesh。
+ * 床(position_y)からクッション下端までを埋め、座席が床から浮いて見えるのを解消する。
+ * 車椅子席は座席構造が無いため scale=0 で描かない。
+ */
+const SeatBases = memo<{ seats: TheaterSeat[] }>(function SeatBases({ seats }) {
+  const meshRef = useRef<InstancedMeshType>(null);
+  const tempObject = useMemo(() => new Object3D(), []);
+
+  useEffect(() => {
+    if (!meshRef.current) return;
+    seats.forEach((seat, i) => {
+      // 台座中心 = 床 + 高さ/2（床からクッション下端 y+0.24 を埋める）
+      tempObject.position.set(
+        seat.position_x,
+        seat.position_y + SEAT_BASE.height / 2,
+        seat.position_z,
+      );
+      tempObject.rotation.set(0, 0, 0);
+      const hidden = seat.seat_type === 'wheelchair';
+      tempObject.scale.set(1, hidden ? 0 : 1, 1);
+      tempObject.updateMatrix();
+      meshRef.current!.setMatrixAt(i, tempObject.matrix);
+    });
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  }, [seats, tempObject]);
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, seats.length]}
+      frustumCulled={false}
+      castShadow
+      receiveShadow
+    >
+      <boxGeometry
+        args={[SEAT_BASE.width, SEAT_BASE.height, SEAT_BASE.depth]}
+      />
+      <meshStandardMaterial
+        color={COLOR_FRAME}
+        roughness={0.6}
+        metalness={0.15}
+      />
+    </instancedMesh>
+  );
+});
+SeatBases.displayName = 'SeatBases';
+
+/**
+ * 肘掛けバーのInstancedMesh（1席につき左右2本 = seats.length * 2 インスタンス）。
+ * クッション両脇に置き、椅子のシルエットを立たせる。車椅子席は scale=0 で描かない。
+ */
+const SeatArmrests = memo<{ seats: TheaterSeat[] }>(function SeatArmrests({
+  seats,
+}) {
+  const meshRef = useRef<InstancedMeshType>(null);
+  const tempObject = useMemo(() => new Object3D(), []);
+
+  useEffect(() => {
+    if (!meshRef.current) return;
+    seats.forEach((seat, i) => {
+      const hidden = seat.seat_type === 'wheelchair';
+      // 肘掛け高さ = クッション上面のやや上（座面 y+0.3・厚み0.12 → 上面 y+0.36）
+      const armY = seat.position_y + 0.42;
+      [-ARMREST_OFFSET_X, ARMREST_OFFSET_X].forEach((dx, side) => {
+        tempObject.position.set(
+          seat.position_x + dx,
+          armY,
+          seat.position_z + 0.02,
+        );
+        tempObject.rotation.set(0, 0, 0);
+        tempObject.scale.set(1, hidden ? 0 : 1, 1);
+        tempObject.updateMatrix();
+        meshRef.current!.setMatrixAt(i * 2 + side, tempObject.matrix);
+      });
+    });
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  }, [seats, tempObject]);
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, seats.length * 2]}
+      frustumCulled={false}
+      castShadow
+    >
+      <boxGeometry
+        args={[SEAT_ARMREST.width, SEAT_ARMREST.height, SEAT_ARMREST.depth]}
+      />
+      <meshStandardMaterial
+        color={COLOR_FRAME}
+        roughness={0.55}
+        metalness={0.15}
+      />
+    </instancedMesh>
+  );
+});
+SeatArmrests.displayName = 'SeatArmrests';
 
 /**
  * ホバー席のハイライト枠（Edges）＋席番号ラベル
@@ -362,6 +487,8 @@ export const SeatMeshes = memo<SeatMeshesProps>(function SeatMeshes({
 
   return (
     <group>
+      <SeatBases seats={seats} />
+      <SeatArmrests seats={seats} />
       <SeatCushions seats={seats} selectedSeatId={selectedSeatId} />
       <SeatBacks seats={seats} selectedSeatId={selectedSeatId} />
       <HoverHighlight seat={hoveredSeat} />

--- a/src/features/theaterExperience/component/theaterCanvas/theaterCanvas.tsx
+++ b/src/features/theaterExperience/component/theaterCanvas/theaterCanvas.tsx
@@ -1,13 +1,15 @@
 /**
  * TheaterCanvasコンポーネント
  * R3F Canvasのラッパー、dynamic importでSSR無効化
- * アイソメトリック ドールハウススタイル: フラット背景・ポストプロセスなし
+ * アイソメトリック ドールハウススタイル + シネマ質感のポストプロセス（Bloom/Vignette）
  */
 
 'use client';
 
 import { memo, type ReactNode } from 'react';
 import { Canvas } from '@react-three/fiber';
+import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing';
+import { ACESFilmicToneMapping } from 'three';
 
 import { cn } from '@/utils/cn';
 
@@ -33,10 +35,29 @@ export const TheaterCanvas = memo<TheaterCanvasProps>(function TheaterCanvas({
           antialias: true,
           alpha: false,
           preserveDrawingBuffer: true,
+          toneMapping: ACESFilmicToneMapping,
         }}
       >
         <color attach='background' args={['#f5f3ee']} />
         {children}
+        {/*
+          ポストプロセス（シネマ質感）:
+          - Bloom: 通路灯・段差LED等の HDR 発光体（toneMapped=false）だけを滲ませる。
+            luminanceThreshold=0.9 は明るい背景(#f5f3ee, ACES後≈0.8)を超える値で、
+            背景をブルームさせず（ハロ/かすみを防ぎ）発光体のみ光らせるための設定。
+            これにより #464 で自作していた加算合成グロー球が不要になり削除できる。
+          - Vignette: 画面周縁をわずかに落とし、スクリーンへ視線を集めるシネマ感を付与。
+          mipmapBlur で低コストに広がりを出し、E2E(WebGL)を重くしない。
+        */}
+        <EffectComposer>
+          <Bloom
+            luminanceThreshold={0.9}
+            luminanceSmoothing={0.08}
+            intensity={0.8}
+            mipmapBlur
+          />
+          <Vignette offset={0.32} darkness={0.5} />
+        </EffectComposer>
       </Canvas>
     </div>
   );

--- a/src/features/theaterExperience/component/theaterScene/theaterScene.test.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.test.tsx
@@ -28,6 +28,11 @@ jest.mock('three', () => ({
     this.copy = jest.fn();
     this.set = jest.fn();
   }),
+  // 発光体の HDR カラー（new Color(...).multiplyScalar(...)）がモジュール読込時に
+  // 走るため、Color モックにも multiplyScalar を持たせる（自身を返す軽量スタブ）。
+  Color: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.multiplyScalar = jest.fn(() => this);
+  }),
   RepeatWrapping: 1000,
 }));
 

--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -11,12 +11,13 @@ import {
   OrthographicCamera,
   PerspectiveCamera,
   Edges,
+  ContactShadows,
 } from '@react-three/drei';
 import { useThree } from '@react-three/fiber';
 import {
   PlaneGeometry,
   Vector3,
-  AdditiveBlending,
+  Color,
   type OrthographicCamera as OrthographicCameraType,
   type PerspectiveCamera as PerspectiveCameraType,
 } from 'three';
@@ -78,6 +79,20 @@ const COLOR_EDGE = '#b0a0a8'; // 暗色背景に対する明色エッジ線
 const COLOR_AISLE_LIGHT = '#ffd4a0'; // 通路灯（暖色）
 const COLOR_EXIT_SIGN = '#00b06b'; // 非常口誘導灯（日本の法定色：緑）
 const COLOR_STEP_LED = '#ffe8c4'; // 段差LED（やや暖白）
+
+/**
+ * 発光体の HDR カラー（各チャンネルを 1.0 超へ増幅）。
+ * Bloom は「明るい背景(#f5f3ee, ACES後≈0.8)は光らせず、発光体だけ滲ませる」ため
+ * luminanceThreshold を 0.9 に設定している。LDR(≤1.0)のままだと背景に埋もれて
+ * 閾値を超えないため、発光体は toneMapped=false かつ HDR にして確実にブルームさせる。
+ */
+const COLOR_AISLE_LIGHT_HDR = new Color(COLOR_AISLE_LIGHT).multiplyScalar(2.4);
+const COLOR_STEP_LED_HDR = new Color(COLOR_STEP_LED).multiplyScalar(1.6);
+
+/** ライティング用カラー */
+const COLOR_HEMI_SKY = '#cfd6e6'; // 半球光の空側フィル（やや寒色）
+const COLOR_HEMI_GROUND = '#2a2130'; // 半球光の地面側フィル（暗紫・床トーンに寄せる）
+const COLOR_CONTACT_SHADOW = '#000000'; // 接地影（ContactShadows）の色
 
 /** マージン: 傾斜床は座席より少し外側まで広げる */
 const SLOPE_MARGIN = 0.5;
@@ -238,9 +253,9 @@ BackStepFill.displayName = 'BackStepFill';
 
 /**
  * 通路灯（壁際・足元の小さな発光体）
- * 両側通路に等間隔で配置。旧実装は半径0.22m+グロー0.5mの大きな発光球で「浮いた
- * 金色の玉」に見え、しかもグローが加算合成でなく暗環（黒い縁取り）になっていた。
- * 足元(y≈0.15)の小型発光体＋加算合成の淡いグローに変更し、足元灯らしくする。
+ * 両側通路に等間隔で配置。発光体本体（toneMapped=false）のみを描き、滲み（グロー）は
+ * ポストプロセスの Bloom に委ねる。#464 で自作していた加算合成グロー球（半透明の大球）は
+ * Bloom 導入により不要になったため削除した（暗環化リスクもなくなる）。
  */
 const AisleLights = memo<{
   roomWidth: number;
@@ -269,20 +284,11 @@ const AisleLights = memo<{
     <group>
       {lights.map((pos) => (
         <group key={`${pos[0]},${pos[2]}`} position={pos}>
-          {/* 足元の小さな発光体 */}
+          {/* 足元の小さな発光体（HDR＋toneMapped=false で Bloom が滲みを付与） */}
           <mesh>
             <sphereGeometry args={[0.08, 12, 12]} />
-            <meshBasicMaterial color={COLOR_AISLE_LIGHT} toneMapped={false} />
-          </mesh>
-          {/* 加算合成の淡いグロー（暗環にならず自然に滲む） */}
-          <mesh>
-            <sphereGeometry args={[0.22, 12, 12]} />
             <meshBasicMaterial
-              color={COLOR_AISLE_LIGHT}
-              transparent
-              opacity={0.35}
-              blending={AdditiveBlending}
-              depthWrite={false}
+              color={COLOR_AISLE_LIGHT_HDR}
               toneMapped={false}
             />
           </mesh>
@@ -367,7 +373,8 @@ const StepLEDs = memo<{
         return seatSegments.map((seg) => (
           <mesh key={`${z}:${seg.center}`} position={[seg.center, ledY, ledZ]}>
             <boxGeometry args={[seg.width, 0.04, 0.04]} />
-            <meshBasicMaterial color={COLOR_STEP_LED} />
+            {/* 段差LEDも HDR＋toneMapped=false で Bloom により細く滲ませる（過度な全開発光は避ける控えめ増幅） */}
+            <meshBasicMaterial color={COLOR_STEP_LED_HDR} toneMapped={false} />
           </mesh>
         ));
       })}
@@ -577,11 +584,18 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
         />
       )}
 
-      {/* フラットライティング */}
-      <ambientLight intensity={1.0} />
+      {/*
+        ライティング: 旧実装は ambient=1.0 優位（ambient:directional≈1.67:1）で
+        キーライトが形を変調できず全体がフラットだった。ambient を下げ directional を
+        上げて比を反転（≈1:2）し、座席・壁に陰影と接地感を出す。hemisphereLight で
+        天井側の淡いフィル（sky→ground のグラデ）を加え、暗部が潰れ過ぎないようにする。
+      */}
+      <ambientLight intensity={0.5} />
+      {/* args=[skyColor, groundColor, intensity]（groundColor はコンストラクタ引数で渡す） */}
+      <hemisphereLight args={[COLOR_HEMI_SKY, COLOR_HEMI_GROUND, 0.35]} />
       <directionalLight
         position={[10, 20, 5]}
-        intensity={0.6}
+        intensity={1.15}
         castShadow
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
@@ -592,6 +606,21 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
         shadow-camera-near={0.1}
         shadow-camera-far={roomHeight + 30}
         shadow-bias={-0.002}
+      />
+
+      {/*
+        接地影（ContactShadows）: 座席群の足元に安価なソフト接地影を敷き、座席が床から
+        浮いて見えるのを緩和する。傾斜床の前縁付近（床y=0）に置き、opacity/blur を控えめに
+        してドールハウスのフラット感を壊さない範囲に留める。
+      */}
+      <ContactShadows
+        position={[0, 0.02, 0]}
+        scale={Math.max(roomWidth, roomDepth) * 1.1}
+        resolution={1024}
+        far={roomHeight}
+        blur={2.6}
+        opacity={0.45}
+        color={COLOR_CONTACT_SHADOW}
       />
 
       {/* 床 */}


### PR DESCRIPTION
## 概要

`ambient=1.0` 優位でキーライトが形を変調できず、全面 meshLambert＋Bloom/AO不在で座席がマットな塊に見えていたフラットな描画を、シネマ質感へ引き上げました。Issue の (a)+(b)+(c) を段階導入しています（ドールハウスのフラット感は壊さない範囲）。

- **(a) ライト比の見直し＋接地影**: `ambientLight` 1.0→0.5 / `directionalLight` 0.6→1.15（比を約 1:2 へ反転しキーライトで陰影を出す）。`hemisphereLight` で天井側の淡いフィルを追加。`ContactShadows` で座席足元に安価な接地影を敷き、床からの浮きを緩和。
- **(b) Bloom 配線**（既存依存 `@react-three/postprocessing`）: `EffectComposer` + `Bloom` + `Vignette`。`luminanceThreshold=0.9` で明るい背景(`#f5f3ee`)はブルームさせず、**HDR 発光体（通路灯・段差LED, `toneMapped=false`×増幅）だけ**を滲ませる。これにより **#464 の自作加算合成グロー球を削除**。
- **(c) 座席の質感**: 座面・背もたれを `meshLambert`→`meshStandard`(PBR) 化し、強めた directional 光で微光沢・陰影を出す。背もたれ色を一段暗くして座面との境界（椅子のシルエット）を立たせ、**台座（脚）と肘掛けバー**のメッシュを追加して座席の浮きを解消。

## ロードマップ

- P2改善（シアター体験の3D品質向上・質感）。`Closes #474`

## レビューポイント

- **Bloom と明るい背景の両立**: 背景 `#f5f3ee`（ACES後≈0.8）が閾値を超えて全体がハロ/かすみになる問題を、`luminanceThreshold=0.9` ＋ 発光体の HDR 化（`Color.multiplyScalar` で 1.0 超、`toneMapped=false`）で解決。発光体だけが滲み、背景は素のまま。
- **#470 との重複について**: Issue が (c) の懸念に挙げていた #470（座席配色）は**既にクローズ済み**で単色(`#bf4040`)が確定しているため、配色の競合はありません（材質・構造のみ変更）。
- **Environment は見送り**: Issue (c) の「軽量 `<Environment>`」は、drei の preset が CDN/ネットワーク読込で **E2E(WebGL) の flaky 化**リスクがあるため採用せず、PBR の陰影は 3灯構成（ambient + hemisphere + directional）で得ています（完了条件「postprocessing/Environment 追加後も E2E が flaky 化しない」への配慮）。必要なら別Issueでローカル Lightformer 等を検討。
- **既存テストのモック整理**（Issueのレビューポイント）: 過去実装の名残だった `Bloom`/`Vignette`/`ContactShadows`/`ACESFilmicToneMapping` のモックが実装と一致。発光体/背もたれ色の生成が読込時に走るため three モックへ `Color`(clone/multiplyScalar) を追加。
- `getSeatBackColor`（背もたれ用に一段暗い色を返す純関数）を切り出し単体テスト追加。R3F 描画（材質・ライト・ポストプロセス）はカバレッジ除外方針どおり。

## テスト

- 単体テスト: `seatMeshes.test.tsx`（`getSeatBackColor` 2ケース追加）。**theaterExperience 全239テストパス**。
- 型（`tsc`）・ESLint・Prettier・pre-commit AIレビュー: パス。
- **非機能条件**: Canvas は従来どおり `dpr={[1,1.5]}`／`preserveDrawingBuffer:true`（#420 安定化を維持）。Bloom は `mipmapBlur` で低コスト。
- **agent-browser 目視検証**（fresh dev server・コンソールエラーなし＝Three.js deprecation 警告のみ）: 下記。standard / IMAX / Dolby いずれも良好。

### Before / After（俯瞰・standard）

フラットな一様照明から、キーライトの陰影・接地感・暖色の通路灯グロー（Bloom）が付き、背景ハロも無く立体的に。

| Before（main・フラット） | After（#474） |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/5d9dcd80-5907-42a1-a8d9-89dcdb200e3b) | ![after](https://github.com/user-attachments/assets/d15544e4-b446-42c7-99e2-f5c8af6cda24) |

### 座席の質感（一人称・後列から）

座面/背もたれの Standard 材質＋背もたれ一段暗め＋台座/肘掛けで、椅子のシルエットと奥行きが立つ。段差LEDが細く発光（Bloom）。

![seats](https://github.com/user-attachments/assets/41e88bbe-5f0c-40f7-b23e-74087443dea0)

### Dolby Cinema（ブラックアウト内装・回帰確認）

減光後もブラックアウト内装で座席は明瞭、通路灯/段差LEDが暖色に滲み、暗すぎない。

![dolby](https://github.com/user-attachments/assets/18d96a74-096c-4ec2-830e-d125f3db3bb7)

Closes #474
