### PR TITLE
fix(theater): E2E(WebGL)安定化のため per-frame/メモリ負荷を削減（Closes #493）

### DIFF
--- a/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
+++ b/src/features/theaterExperience/component/seatMeshes/seatMeshes.tsx
@@ -295,9 +295,10 @@ const SeatBases = memo<{ seats: TheaterSeat[] }>(function SeatBases({ seats }) {
       ref={meshRef}
       args={[undefined, undefined, seats.length]}
       frustumCulled={false}
-      castShadow
       receiveShadow
     >
+      {/* castShadow は付けない: 床際の小さな台座で影寄与は僅少、影マップ描画コストを抑える
+          （CIのソフトウェアWebGLでの負荷/flaky化を避けるため。座面・背もたれのみ影を落とす） */}
       <boxGeometry
         args={[SEAT_BASE.width, SEAT_BASE.height, SEAT_BASE.depth]}
       />
@@ -347,8 +348,9 @@ const SeatArmrests = memo<{ seats: TheaterSeat[] }>(function SeatArmrests({
       ref={meshRef}
       args={[undefined, undefined, seats.length * 2]}
       frustumCulled={false}
-      castShadow
     >
+      {/* castShadow は付けない: 肘掛けは細く影寄与は僅少。影マップ描画のジオメトリを抑える
+          （instance数は seats*2 と多いため、castShadow 除外の効果が大きい） */}
       <boxGeometry
         args={[SEAT_ARMREST.width, SEAT_ARMREST.height, SEAT_ARMREST.depth]}
       />

--- a/src/features/theaterExperience/component/theaterCanvas/theaterCanvas.tsx
+++ b/src/features/theaterExperience/component/theaterCanvas/theaterCanvas.tsx
@@ -49,7 +49,13 @@ export const TheaterCanvas = memo<TheaterCanvasProps>(function TheaterCanvas({
           - Vignette: 画面周縁をわずかに落とし、スクリーンへ視線を集めるシネマ感を付与。
           mipmapBlur で低コストに広がりを出し、E2E(WebGL)を重くしない。
         */}
-        <EffectComposer>
+        {/*
+          multisampling={0}: MSAA レンダーターゲットを持たせず GPU メモリを抑える。
+          CIのソフトウェアWebGL(SwiftShader)で EffectComposer のマルチサンプル用
+          レンダーターゲットがメモリ/コンテキストを圧迫し、大席数(IMAX)でクラッシュ
+          （E2Eの net::ERR_ABORTED）する事象を避けるための設定。
+        */}
+        <EffectComposer multisampling={0}>
           <Bloom
             luminanceThreshold={0.9}
             luminanceSmoothing={0.08}

--- a/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
+++ b/src/features/theaterExperience/component/theaterScene/theaterScene.tsx
@@ -11,7 +11,6 @@ import {
   OrthographicCamera,
   PerspectiveCamera,
   Edges,
-  ContactShadows,
 } from '@react-three/drei';
 import { useThree, useFrame } from '@react-three/fiber';
 import {
@@ -100,7 +99,6 @@ const COLOR_STEP_LED_HDR = new Color(COLOR_STEP_LED).multiplyScalar(1.6);
 /** ライティング用カラー */
 const COLOR_HEMI_SKY = '#cfd6e6'; // 半球光の空側フィル（やや寒色）
 const COLOR_HEMI_GROUND = '#2a2130'; // 半球光の地面側フィル（暗紫・床トーンに寄せる）
-const COLOR_CONTACT_SHADOW = '#000000'; // 接地影（ContactShadows）の色
 
 /** マージン: 傾斜床は座席より少し外側まで広げる */
 const SLOPE_MARGIN = 0.5;
@@ -748,19 +746,12 @@ export const TheaterScene = memo<TheaterSceneProps>(function TheaterScene({
       />
 
       {/*
-        接地影（ContactShadows）: 座席群の足元に安価なソフト接地影を敷き、座席が床から
-        浮いて見えるのを緩和する。傾斜床の前縁付近（床y=0）に置き、opacity/blur を控えめに
-        してドールハウスのフラット感を壊さない範囲に留める。
+        接地感は「強めた directionalLight の実影（castShadow）＋座席台座メッシュ」で担保する。
+        以前はここに ContactShadows（drei）を敷いていたが、既定で毎フレーム影マップを
+        再描画するため、CIのソフトウェアWebGL(SwiftShader)＋最大席数(IMAX 544席)で
+        描画が重くなり E2E がタイムアウト/クラッシュ（#474 完了条件「E2Eをflaky化させない」に
+        抵触）した。per-frame コストの大きい ContactShadows を撤去し安定性を優先する。
       */}
-      <ContactShadows
-        position={[0, 0.02, 0]}
-        scale={Math.max(roomWidth, roomDepth) * 1.1}
-        resolution={1024}
-        far={roomHeight}
-        blur={2.6}
-        opacity={0.45}
-        color={COLOR_CONTACT_SHADOW}
-      />
 
       {/* 床 */}
       <FloorMesh roomWidth={roomWidth} roomDepth={roomDepth} />


### PR DESCRIPTION
## 概要

#474（レンダリング質感向上）マージ後に発生した **E2E(WebGL) の flaky（IMAXで2件失敗）** を解消します。CIのソフトウェアWebGL(SwiftShader)＋低速2コア＋本番ビルドで、最大席数(IMAX 544席)の描画が重くなり、劇場切替テストがタイムアウト／ページクラッシュ(`net::ERR_ABORTED; frame detached`)していました（ローカルの高速HWでは再現せず＝性能起因）。

失敗CI: https://github.com/Fn-front/movie-app/actions/runs/29722965876/job/88289679536

**#474 の見た目改善（ライト比 / Bloom / 座席Standard材質 / 台座・肘掛け / 背もたれ暗色）は維持**したまま、per-frame・GPUメモリ負荷のみ削減します。

- **`ContactShadows` を撤去**: drei の既定は**毎フレーム影マップを再描画**するため 544席では per-frame コストが大きい。接地感は「強めた `directionalLight` の実影(`castShadow`)＋座席台座メッシュ」で担保する（ソフトAOの喪失は軽微）。
- **台座（`SeatBases`）・肘掛け（`SeatArmrests`, instance数 `seats×2`）の `castShadow` を除去**: 床際で小さく影寄与は僅少。影マップ描画ジオメトリを削減（座面・背もたれの `castShadow` は従来どおり維持）。
- **`EffectComposer multisampling={0}`**: MSAA レンダーターゲットの GPUメモリ/コンテキスト圧を抑え、SwiftShader でのクラッシュを回避。

## ロードマップ

- #474 のマージで顕在化した E2E flaky の修正。`Closes #493`

## レビューポイント

- **なぜ `frames={1}` でなく撤去か**: `ContactShadows frames={1}` は描画1回だが、InstancedMesh の行列適用（`useEffect`）前に描画されると空の影になる懸念があり、堅牢性を優先して撤去。接地は実影＋台座で十分。
- 見た目は #474 とほぼ同一（下記スクショ）。失われるのは座席足元の淡いソフト接地影のみ。
- Bloom / meshStandardMaterial / ライト比 / hemisphereLight は変更なし。

## テスト

- **ローカル `npx playwright test e2e/theaterExperience --project=chromium`（SwiftShader・reuseExistingServer）: 7件全パス（30.4s）**。standard/IMAX 切替、リロード保持、車椅子席表示を含む。
- 型（`tsc`）・ESLint・Prettier・component単体テスト(70)・pre-commit AIレビュー: パス。
- ※ CI(GitHub Actions)の Playwright E2E での最終確認をもって完了条件（IMAX切替2件を含む全パス）を満たす想定。
- 目視（agent-browser・standard俯瞰）: 接地感・座席立体感・通路灯Bloomが維持され、背景ハロ無し・コンソールエラー無し。

![after-fix](https://github.com/user-attachments/assets/75cc1399-9b77-4d92-8d6e-167db99c81c2)

Closes #493
