### PR TITLE
feat(theme): 全画面ダークモード対応・テーマ追従とUIコントラスト(a11y)を包括的に改善（Closes #203, #202）

### DIFF
--- a/src/components/layout/mobileDrawer/mobileDrawer.module.scss
+++ b/src/components/layout/mobileDrawer/mobileDrawer.module.scss
@@ -110,9 +110,10 @@
   }
 
   &--active {
-    color: $primary-700;
+    // 固定の淡青(primary-50)＋青文字はダークで明ブロック化するため、テーマ追従の青ティントに。
+    color: $text-primary;
     font-weight: $font-weight-bold;
-    background-color: $primary-50;
+    background-color: color-alpha(--primary-500, 15%);
   }
 }
 

--- a/src/components/layout/searchBar/searchBar.module.scss
+++ b/src/components/layout/searchBar/searchBar.module.scss
@@ -110,7 +110,7 @@
 
     &:hover:not(:disabled) {
       color: $primary-500;
-      background-color: $primary-50;
+      background-color: color-alpha(--primary-500, 15%);
     }
 
     @include focus-visible;

--- a/src/components/layout/sideNav/sideNav.module.scss
+++ b/src/components/layout/sideNav/sideNav.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/variables' as *;
+@use '@/styles/mixins' as *;
 
 .c_side_nav {
   &__list {
@@ -36,9 +37,11 @@
     }
 
     &--active {
-      color: $primary-700;
+      // 固定の淡青(primary-50)＋青文字はダークで明ブロック化＆低コントラストになるため、
+      // テーマ追従の青ティント＋text-primary＋青の左ボーダーでアクティブを示す。
+      color: $text-primary;
       font-weight: $font-weight-bold;
-      background-color: $primary-50;
+      background-color: color-alpha(--primary-500, 15%);
       border-left-color: $primary-500;
     }
   }

--- a/src/components/ui/heading/heading.module.scss
+++ b/src/components/ui/heading/heading.module.scss
@@ -5,7 +5,7 @@
   font-family: $font-family-heading;
   font-weight: $font-weight-bold;
   line-height: $line-height-tight;
-  color: $gray-900;
+  color: $text-primary;
 }
 
 .c_heading__level__1 {

--- a/src/components/ui/movie/filterModal/filterModal.module.scss
+++ b/src/components/ui/movie/filterModal/filterModal.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/variables' as *;
+@use '@/styles/mixins' as *;
 
 .c_filter {
   &__modal {
@@ -80,10 +81,10 @@
 
     &:has(input:checked) {
       border-color: $primary-500;
-      background-color: $primary-50;
+      background-color: color-alpha(--primary-500, 15%);
 
       .c_filter__label {
-        color: $primary-700;
+        color: $text-primary;
         font-weight: $font-weight-medium;
       }
     }
@@ -131,8 +132,8 @@
     transition: $transition-all;
 
     .c_filter__tag_input:checked + & {
-      color: $primary-700;
-      background-color: $primary-50;
+      color: $text-primary;
+      background-color: color-alpha(--primary-500, 15%);
       border-color: $primary-500;
       font-weight: $font-weight-medium;
     }

--- a/src/components/ui/movie/movieTile/movieTile.module.scss
+++ b/src/components/ui/movie/movieTile/movieTile.module.scss
@@ -31,7 +31,9 @@
     width: 100%;
     height: 100%;
     font-size: $font-size-sm;
-    color: $text-disabled;
+    // プレースホルダ文言はダークで text-disabled(#6b6b6b) だと低コントラストのため
+    // text-secondary に一段上げて可読性を確保する。
+    color: $text-secondary;
   }
 
   &__rating {

--- a/src/features/auth/loginForm/loginForm.module.scss
+++ b/src/features/auth/loginForm/loginForm.module.scss
@@ -34,7 +34,7 @@
   margin-top: $spacing-6;
   text-align: center;
   font-size: $font-size-sm;
-  color: $gray-500;
+  color: $text-secondary;
 }
 
 .c_login_form__link {

--- a/src/features/auth/otpLoginForm/otpLoginForm.module.scss
+++ b/src/features/auth/otpLoginForm/otpLoginForm.module.scss
@@ -34,7 +34,7 @@
   margin-top: $spacing-6;
   text-align: center;
   font-size: $font-size-sm;
-  color: $gray-500;
+  color: $text-secondary;
 }
 
 .c_otp_login_form__link {

--- a/src/features/auth/otpVerification/otpVerification.module.scss
+++ b/src/features/auth/otpVerification/otpVerification.module.scss
@@ -16,13 +16,13 @@
   margin-top: $spacing-4;
   text-align: center;
   font-size: $font-size-sm;
-  color: $gray-600;
+  color: $text-secondary;
   line-height: $line-height-normal;
 }
 
 .c_otp_verification__email {
   font-weight: $font-weight-bold;
-  color: $gray-900;
+  color: $text-primary;
 }
 
 .c_otp_verification__form {
@@ -60,5 +60,5 @@
 
 .c_otp_verification__countdown {
   font-size: $font-size-sm;
-  color: $gray-500;
+  color: $text-secondary;
 }

--- a/src/features/auth/registerForm/registerForm.module.scss
+++ b/src/features/auth/registerForm/registerForm.module.scss
@@ -34,7 +34,7 @@
   margin-top: $spacing-6;
   text-align: center;
   font-size: $font-size-sm;
-  color: $gray-500;
+  color: $text-secondary;
 }
 
 .c_register_form__link {

--- a/src/features/auth/socialLoginButtons/socialLoginButtons.module.scss
+++ b/src/features/auth/socialLoginButtons/socialLoginButtons.module.scss
@@ -14,13 +14,13 @@
     content: '';
     flex: 1;
     height: $border-width-1;
-    background-color: $gray-300;
+    background-color: $border-color;
   }
 }
 
 .c_social_login__divider_text {
   font-size: $font-size-sm;
-  color: $gray-500;
+  color: $text-secondary;
   white-space: nowrap;
 }
 
@@ -57,7 +57,9 @@
 .c_social_login__github {
   background-color: $gray-900;
   color: white;
-  border: $border-width-1 solid $gray-900;
+  // 枠線はテーマ追従色にする（ダーク背景 #111 と地の $gray-900 が同色で輪郭が
+  // 消えるのを防ぎ、ボタン形状を両テーマで維持する）。
+  border: $border-width-1 solid $border-color;
 
   &:hover:not(:disabled) {
     background-color: $gray-800;

--- a/src/features/awards/awardSection/awardSection.module.scss
+++ b/src/features/awards/awardSection/awardSection.module.scss
@@ -35,7 +35,7 @@
     }
 
     &:hover {
-      background-color: $primary-50;
+      background-color: color-alpha(--primary-500, 15%);
       box-shadow: $shadow-md;
     }
 

--- a/src/features/calendar/component/calendarDialog.module.scss
+++ b/src/features/calendar/component/calendarDialog.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/variables' as *;
+@use '@/styles/mixins' as *;
 
 .c_calendarDialog__body {
   padding: 0;
@@ -86,7 +87,7 @@
 }
 
 .c_calendarDialog__calendar :global(.fc .fc-daygrid-day:hover) {
-  background-color: $primary-50;
+  background-color: color-alpha(--primary-500, 12%);
 }
 
 .c_calendarDialog__calendar :global(.fc .fc-daygrid-day-number) {
@@ -97,7 +98,7 @@
 }
 
 .c_calendarDialog__calendar :global(.fc .fc-day-today) {
-  background-color: $primary-50 !important;
+  background-color: color-alpha(--primary-500, 14%) !important;
 }
 
 .c_calendarDialog__calendar :global(.fc .fc-day-today .fc-daygrid-day-number) {

--- a/src/features/calendar/component/calendarMovieList.module.scss
+++ b/src/features/calendar/component/calendarMovieList.module.scss
@@ -73,7 +73,7 @@
   justify-content: center;
   width: 100%;
   height: 100%;
-  background-color: $gray-200;
+  background-color: $background-secondary;
   color: $text-secondary;
   font-size: $font-size-2xs;
 }

--- a/src/features/dismissedMovies/component/dismissButton/dismissButton.module.scss
+++ b/src/features/dismissedMovies/component/dismissButton/dismissButton.module.scss
@@ -8,8 +8,13 @@
   flex-shrink: 0;
   border: none;
   border-radius: $border-radius-full;
-  background-color: rgba(255, 255, 255, 0.85);
-  color: $gray-400;
+  // ポスター上のオーバーレイ。テーマ追従の frosted サーフェスにし、
+  // ライト=白 / ダーク=暗 のピルへ切り替える（ダークで白ピルが浮く問題を解消）。
+  background-color: color-alpha(--background-paper, 85%);
+  // 同色サーフェス（詳細モーダルの paper 背景）上でも輪郭が出るよう極薄リングを付与。
+  box-shadow: inset 0 0 0 $border-width-1 color-alpha(--text-primary, 12%);
+  // 非アクティブは text-secondary（ライト 5.7:1 / ダーク 5.9:1 で WCAG 1.4.11 を満たす）。
+  color: $text-secondary;
   cursor: pointer;
   transition:
     opacity $duration-fast $ease-in-out,
@@ -17,7 +22,7 @@
     color $duration-fast $ease-in-out;
 
   &:hover {
-    background-color: rgba(255, 255, 255, 1);
+    background-color: $background-paper;
     color: $error-dark;
   }
 

--- a/src/features/favorites/component/favoriteButton/favoriteButton.module.scss
+++ b/src/features/favorites/component/favoriteButton/favoriteButton.module.scss
@@ -8,8 +8,13 @@
   flex-shrink: 0;
   border: none;
   border-radius: $border-radius-full;
-  background-color: rgba(255, 255, 255, 0.85);
-  color: $gray-400;
+  // ポスター上のオーバーレイ。テーマ追従の frosted サーフェスにし、
+  // ライト=白 / ダーク=暗 のピルへ切り替える（ダークで白ピルが浮く問題を解消）。
+  background-color: color-alpha(--background-paper, 85%);
+  // 同色サーフェス（詳細モーダルの paper 背景）上でも輪郭が出るよう極薄リングを付与。
+  box-shadow: inset 0 0 0 $border-width-1 color-alpha(--text-primary, 12%);
+  // 非アクティブは text-secondary（ライト 5.7:1 / ダーク 5.9:1 で WCAG 1.4.11 を満たす）。
+  color: $text-secondary;
   cursor: pointer;
   transition:
     opacity $duration-fast $ease-in-out,
@@ -17,7 +22,7 @@
     color $duration-fast $ease-in-out;
 
   &:hover {
-    background-color: rgba(255, 255, 255, 1);
+    background-color: $background-paper;
     color: $secondary-600;
   }
 

--- a/src/features/favorites/component/favoriteList/favoriteList.module.scss
+++ b/src/features/favorites/component/favoriteList/favoriteList.module.scss
@@ -27,7 +27,8 @@
     width: 100%;
     height: 100%;
     font-size: $font-size-sm;
-    color: $text-disabled;
+    // プレースホルダ文言はダークで低コントラストになるため text-secondary に。
+    color: $text-secondary;
   }
 
   &__favorite_button {

--- a/src/features/favorites/component/ratingIndicator/ratingIndicator.module.scss
+++ b/src/features/favorites/component/ratingIndicator/ratingIndicator.module.scss
@@ -18,10 +18,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border: $border-width-1 solid $gray-300;
+    // 枠線・文字はテーマ追従色にする（ダークで gray-300 の明枠・
+    // text-disabled(#6b6b6b) の低コントラスト文字が浮く問題を解消）。
+    border: $border-width-1 solid $border-color;
     border-radius: $border-radius-md;
     background-color: transparent;
-    color: $text-disabled;
+    color: $text-secondary;
     font-size: $font-size-xs;
     font-weight: $font-weight-medium;
     cursor: default;
@@ -44,9 +46,11 @@
     }
 
     &__active {
-      background-color: $secondary-50;
-      border-color: $secondary-400;
-      color: $secondary-800;
+      // 固定クリーム地の代わりにオレンジの半透明ティント（ライト/ダーク双方に追従）。
+      // 数値は text-primary で常に高コントラストにし、暖色ティント＋枠で「評価済み」を示す。
+      background-color: color-alpha(--secondary-500, 16%);
+      border-color: color-alpha(--secondary-500, 55%);
+      color: $text-primary;
     }
 
     &__selected {
@@ -63,9 +67,9 @@
     cursor: pointer;
 
     &:hover {
-      background-color: $secondary-100;
+      background-color: color-alpha(--secondary-500, 28%);
       border-color: $secondary-500;
-      color: $secondary-800;
+      color: $text-primary;
     }
 
     @include focus-visible;

--- a/src/features/movies/component/movieDetailContent/movieDetailContent.module.scss
+++ b/src/features/movies/component/movieDetailContent/movieDetailContent.module.scss
@@ -209,8 +209,10 @@
   &__genre_tag {
     padding: $spacing-1 $spacing-2;
     font-size: $font-size-xs;
-    color: $primary-700;
-    background-color: $primary-50;
+    // 固定の淡青(primary-50)＋青文字はダークで浮く/低コントラストのため、
+    // テーマ追従の青ティント＋text-primary に。
+    color: $text-primary;
+    background-color: color-alpha(--primary-500, 15%);
     border-radius: $border-radius-md;
   }
 
@@ -327,7 +329,7 @@
     width: 48px;
     height: 48px;
     border-radius: $border-radius-full;
-    background-color: $gray-200;
+    background-color: $background-secondary;
     color: $text-secondary;
     font-size: $font-size-base;
     font-weight: $font-weight-medium;

--- a/src/features/movies/component/videoDialog/videoDialog.module.scss
+++ b/src/features/movies/component/videoDialog/videoDialog.module.scss
@@ -120,7 +120,7 @@
   // 動画タイプ
   &__video_type {
     font-size: $font-size-xs;
-    color: $gray-400;
+    color: $text-secondary;
     flex-shrink: 0;
   }
 

--- a/src/features/nowShowing/component/nowShowingMovieList/nowShowingMovieList.module.scss
+++ b/src/features/nowShowing/component/nowShowingMovieList/nowShowingMovieList.module.scss
@@ -23,7 +23,7 @@
     margin-top: $spacing-4;
     overflow-x: auto;
     scrollbar-width: thin;
-    scrollbar-color: $gray-300 transparent;
+    scrollbar-color: var(--color-scrollbar-thumb) transparent;
 
     &::-webkit-scrollbar {
       height: 6px;
@@ -34,7 +34,7 @@
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: $gray-300;
+      background-color: var(--color-scrollbar-thumb);
       border-radius: $border-radius-full;
     }
   }

--- a/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
+++ b/src/features/theaterExperience/component/seatA11yList/seatA11yList.module.scss
@@ -70,9 +70,9 @@ $seat-cell-size: 28px;
   font-size: $font-size-2xs;
   font-weight: $font-weight-medium;
   // 席番号は 10px(通常テキスト扱い)のため WCAG 1.4.3 の 4.5:1 が必要。
-  // text-secondary(--gray-500) だと 10% alpha 背景を body(#fafafa)に合成後 4.50:1 で
-  // 境界を割るため、--gray-600 に一段濃くして 8.2:1 を確保する（背景依存も解消）。
-  color: $gray-600;
+  // 半透明背景をライト/ダーク双方の body に合成しても十分なコントラストを保つよう、
+  // テーマ追従の text-primary(ライト #111 / ダーク #f5f5f5) を用いる。
+  color: $text-primary;
   background-color: color-alpha(--gray-500, 10%);
   border-radius: $border-radius-sm;
   cursor: pointer;
@@ -81,10 +81,9 @@ $seat-cell-size: 28px;
     color $duration-fast $ease-in-out;
 
   &:hover {
+    // ホバーは背景の青系ティントで示し、文字色は text-primary のまま高コントラストを維持する
+    // （テーマ非追従の固定青文字はダーク時に同系背景へ埋もれるため使わない）。
     background-color: color-alpha(--primary-500, 15%);
-    // primary-500 文字は同系色(primary@15%)背景の合成で 3.74:1 と不足するため、
-    // primary-800 まで濃くして 5.7:1 を確保する（WCAG 1.4.3）。
-    color: $primary-800;
   }
 
   @include focus-visible;

--- a/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.module.scss
+++ b/src/features/theaterExperience/theaterExperiencePage/theaterExperiencePage.module.scss
@@ -104,15 +104,17 @@
   z-index: 10;
   padding: $spacing-2 $spacing-4;
   font-size: $font-size-sm;
+  // キャンバス上のオーバーレイ。テーマ追従サーフェスにし、
+  // ダークで「白背景×白文字」で見えなくなる問題を解消する。
   color: $text-primary;
-  background-color: rgba(255, 255, 255, 0.92);
+  background-color: color-alpha(--background-paper, 92%);
   border: 1px solid color-alpha(--gray-500, 20%);
   border-radius: $border-radius-md;
   cursor: pointer;
   transition: background-color $duration-fast $ease-in-out;
 
   &:hover {
-    background-color: rgba(255, 255, 255, 1);
+    background-color: $background-paper;
   }
 
   @include focus-visible;

--- a/src/features/watchlist/component/watchlistAddButton/watchlistAddButton.module.scss
+++ b/src/features/watchlist/component/watchlistAddButton/watchlistAddButton.module.scss
@@ -8,7 +8,12 @@
   flex-shrink: 0;
   border: none;
   border-radius: $border-radius-full;
-  background-color: rgba(255, 255, 255, 0.85);
+  // ポスター上のオーバーレイ。テーマ追従の frosted サーフェスにし、
+  // ライト=白 / ダーク=暗 のピルへ切り替える（ダークで白ピルが浮く問題を解消）。
+  background-color: color-alpha(--background-paper, 85%);
+  // 同色サーフェス（詳細モーダルの paper 背景）上でも輪郭が出るよう極薄リングを付与。
+  box-shadow: inset 0 0 0 $border-width-1 color-alpha(--text-primary, 12%);
+  // ＋は主要アクションのため text-primary（ライト濃色 / ダーク明色）で高コントラストに。
   color: $text-primary;
   cursor: pointer;
   transition:
@@ -16,7 +21,7 @@
     background-color $duration-fast $ease-in-out;
 
   &:hover {
-    background-color: rgba(255, 255, 255, 1);
+    background-color: $background-paper;
   }
 
   @include focus-visible;

--- a/src/features/watchlist/component/watchlistList/watchlistList.module.scss
+++ b/src/features/watchlist/component/watchlistList/watchlistList.module.scss
@@ -53,7 +53,8 @@
     width: 100%;
     height: 100%;
     font-size: $font-size-sm;
-    color: $text-disabled;
+    // プレースホルダ文言はダークで低コントラストになるため text-secondary に。
+    color: $text-secondary;
   }
 
   &__delete_button {

--- a/src/styles/global/_global.scss
+++ b/src/styles/global/_global.scss
@@ -22,8 +22,8 @@ body {
   font-size: 1.6rem; // 16px
   font-weight: $font-weight-regular;
   line-height: $line-height-normal;
-  color: $gray-900;
-  background: $gray-50;
+  color: $text-primary;
+  background: $background-default;
   margin: 0;
   min-height: 100vh;
 }
@@ -157,14 +157,14 @@ summary {
 }
 
 ::-webkit-scrollbar-track {
-  background: $gray-100;
+  background: var(--color-scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: $gray-400;
+  background: var(--color-scrollbar-thumb);
   border-radius: $border-radius-full;
 
   &:hover {
-    background: $gray-500;
+    background: var(--color-scrollbar-thumb-hover);
   }
 }


### PR DESCRIPTION
## 概要

アプリ全体のダークモードを正式対応しました（Closes #203）。あわせて #202 の本丸バグ（`data-theme="dark"` でも body 背景がライトのままで、認証画面のラベルが読めない等）を修正しました（Closes #202）。

ダークモードの CSS 変数基盤（`[data-theme="dark"]`）は既存でしたが、一部が固定パレット色でテーマに追従しておらず破綻していたのが実態でした。全画面を洗い出し、固定色をセマンティック変数／テーマ追従トークンへ是正し、ダーク/ライト両モードで可読性（WCAG コントラスト）を確保しています。**変更は SCSS のみ（ロジック変更なし）**。

### 主な修正

- **#202 本丸**: `body`／スクロールバーの固定色（`$gray-50`/`$gray-900` 等）→ `$text-primary`/`$background-default`/CSS変数へ。背景がテーマに追従するように是正
- 見出し・認証/OTP の補足文字・動画タイプ・座席番号など固定 gray をセマンティック変数へ
- GitHub ログインボタンの枠線を `border-color` にし、ダーク背景（#111）と地色（gray-900）が同色で**輪郭が消える**問題を解消
- **オーバーレイボタン**（お気に入り♡／興味なし／ウォッチリスト＋／シアターの「俯瞰に戻る」）を、テーマ追従の frosted サーフェス＋高コントラストアイコン＋極薄リングに統一（ダークで白ピル上のアイコンが不可視／低コントラストだった問題を解消）
- **評価インジケータ／ジャンルタグ／No Image／ポスターfallback** の固定淡色（`secondary-50`/`gray-200`）・低コントラスト文字（`text-disabled`）をテーマ追従に是正
- サイドバー／モバイルドロワー／フィルタ／検索／受賞／カレンダーの**選択・ホバー背景**（固定 `primary-50`）を、テーマ追従の primary ティントへ統一

### 据え置き（意図的）

ブランドボタン（Google 白／GitHub 黒）、色付きボタン上の白文字、3D シーン背景、音響ヒートマップの科学的カラーマップ、フォームの disabled 文字・カレンダーの当月外日付（正しい `text-disabled` 用途）。

## ロードマップ

ダークモードは GitHub Issue（#203 / #202）で管理されており、`roadmap.md` のフェーズ表に該当項目はないため表の更新はありません。

## レビューポイント

- `src/styles/global/_global.scss` の body / スクロールバーのテーマ追従（#202 の核心）
- オーバーレイボタン4種（favoriteButton / dismissButton / watchlistAddButton / theaterExperiencePage の back_to_overview）で採用した「frosted サーフェス＋輪郭リング」方針の妥当性
- `ratingIndicator` / `genre_tag` 等で、暖色/寒色ティント＋`text-primary` に寄せた配色（ライトの見た目が青/橙文字から中立文字に変わる点）
- `primary-50` → `color-alpha(--primary-500, X%)` への統一（`color-alpha` 利用のため sideNav / filterModal / calendarDialog に `@use mixins` を追加）

## テスト

- 単体テスト: `npx jest` → **241 suites / 2497 tests 全パス**（SCSS のみの変更のため既存テストへの回帰なし）
- Prettier: `src/**/*.scss` フォーマット確認済み
- 静的監査: 非追従の固定淡色・低コントラスト文字が残っていないことを grep で確認（残存はブランド/色付きボタン/3D/科学カラーマップ/正しい disabled 用途のみ）
- ブラウザ実機（ダーク/ライト両モード）で全画面を目視確認: ホーム / 一覧（公開中・公開予定・ストリーミング）/ お気に入り / ウォッチリスト / 受賞作品 / 設定＋テーマ切替 / 映画詳細モーダル＋キャスト / 新規登録・ログイン・メールログイン / シアター体験（俯瞰・一人称・座席メトリクス・ヒートマップ・2D座席一覧）/ モバイルドロワー / 404。Next.js エラーバッジなし

### Before / After（ダークモード）

#### body 背景のテーマ追従（#202）
`data-theme="dark"` でも背景がライト（#fafafa）のまま → テーマに追従（#111）

| Before | After |
|---|---|
| ![home-dark-before.png](https://github.com/user-attachments/assets/58cc5b33-330a-496c-8cbe-ba7acf543803) | ![home-dark-after.png](https://github.com/user-attachments/assets/54583101-6e77-48ef-98dd-2b5a33c170fb) |

#### オーバーレイボタンのアクセシビリティ
白ピル上で ＋ が不可視・♡ が低コントラスト → 追従サーフェス＋高コントラストアイコン＋輪郭

| Before | After |
|---|---|
| ![cards-dark-before.png](https://github.com/user-attachments/assets/f7bfb523-52dc-45e6-8f61-162a32c11958) | ![cards-dark-after.png](https://github.com/user-attachments/assets/9cd8123b-9859-4ef9-8238-2d972cd743a4) |

#### お気に入りの評価数値
明るい枠・低コントラスト数値・固定クリーム地 → 追従枠＋読める数値＋暖色ティント

| Before | After |
|---|---|
| ![dark-favorites-rating.png](https://github.com/user-attachments/assets/19daa475-19ad-479f-87aa-c88d95549448) | ![dark-favorites-final.png](https://github.com/user-attachments/assets/5fd058dd-0efd-41e6-bcad-fcfa649686db) |

### After（主要画面）

ログイン画面（GitHub ボタン輪郭も改善）:

![dark-signin.png](https://github.com/user-attachments/assets/2ae314fd-f8e6-44be-8fad-9672ed515065)

シアター体験・一人称視点（「← 俯瞰に戻る」ボタンがダークで視認可能に）:

![dark-theater-backbtn.png](https://github.com/user-attachments/assets/db29ae02-21b1-4c24-bd4f-b094bc22d95f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
