### PR TITLE
feat(middleware): Vercel本番でcron以外を404化しローカル運用のみ有効化

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -8,32 +8,45 @@ const mockNextResponseNext = jest.fn();
 const mockNextResponseRedirect = jest.fn();
 const mockCookiesDelete = jest.fn();
 
-jest.mock('next/server', () => ({
-  NextResponse: {
-    next: (init?: { request?: { headers?: Headers } }) => {
+jest.mock('next/server', () => {
+  // new NextResponse(null, { status: 404 }) 呼び出しに対応するためクラスとして定義する
+  class MockNextResponse {
+    headers: Headers;
+    status: number;
+    cookies: { delete: jest.Mock };
+    constructor(
+      _body?: unknown,
+      init?: { status?: number; headers?: Record<string, string> },
+    ) {
+      this.headers = new Headers(init?.headers);
+      this.status = init?.status ?? 200;
+      this.cookies = { delete: mockCookiesDelete };
+    }
+    static next(init?: { request?: { headers?: Headers } }) {
       mockNextResponseNext(init);
-      const response = {
-        headers: new Headers(),
-        cookies: { delete: mockCookiesDelete },
-      };
-      return response;
-    },
-    redirect: (url: URL) => {
-      const response = {
-        headers: new Headers({ location: url.toString() }),
-        cookies: { delete: mockCookiesDelete },
-      };
+      return new MockNextResponse();
+    }
+    static redirect(url: URL) {
+      const response = new MockNextResponse(null, {
+        headers: { location: url.toString() },
+      });
       mockNextResponseRedirect.mockReturnValue(response);
       return response;
-    },
-  },
-}));
+    }
+  }
+  return { NextResponse: MockNextResponse };
+});
 
 // ResponseグローバルをJest環境に追加
 global.Response = class MockResponse {
   headers: Headers;
-  constructor(_body?: unknown, init?: { headers?: Record<string, string> }) {
+  status: number;
+  constructor(
+    _body?: unknown,
+    init?: { status?: number; headers?: Record<string, string> },
+  ) {
     this.headers = new Headers(init?.headers);
+    this.status = init?.status ?? 200;
   }
   static redirect(url: URL) {
     return new MockResponse(null, {
@@ -51,6 +64,7 @@ jest.mock('@/lib/auth/auth', () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const middleware = require('./middleware').default as (req: unknown) => {
   headers: Headers;
+  status?: number;
   cookies?: { delete: jest.Mock };
 };
 
@@ -74,11 +88,78 @@ function createMockRequest(options: {
 
 describe('middleware', () => {
   const mockAuth = { user: { id: 'user-1' } };
+  const originalVercelEnv = process.env.VERCEL_ENV;
 
   beforeEach(() => {
     mockNextResponseNext.mockClear();
     mockNextResponseRedirect.mockClear();
     mockCookiesDelete.mockClear();
+    // 既定はローカル環境として扱う
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterAll(() => {
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+  });
+
+  describe('Vercel本番デプロイ（VERCEL_ENV=production）', () => {
+    beforeEach(() => {
+      process.env.VERCEL_ENV = 'production';
+    });
+
+    it('/api/cron/* は通過する（Vercel Cronのため）', () => {
+      const req = createMockRequest({
+        pathname: '/api/cron/sync-movies',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = middleware(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalled();
+      expect(response.status).toBe(200);
+    });
+
+    it('トップページは404で隠す', () => {
+      const req = createMockRequest({
+        pathname: '/',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = middleware(req);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('保護ページは404で隠す（サインインへリダイレクトしない）', () => {
+      const req = createMockRequest({
+        pathname: '/favorites',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = middleware(req);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('location')).toBeNull();
+    });
+
+    it('cron以外の /api/* は404で隠す', () => {
+      const req = createMockRequest({
+        pathname: '/api/watchlist',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const response = middleware(req);
+
+      expect(response.status).toBe(404);
+    });
   });
 
   describe('セッション期限切れ検知（cookie残存）', () => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,6 +24,21 @@ const authPaths = [ROUTES.LOGIN, ROUTES.REGISTER];
 
 export default auth((req) => {
   const { nextUrl } = req;
+
+  // 本番Vercelデプロイではローカル運用のためcron以外を全て404で隠す。
+  // Vercel Cronは /api/cron/* のみ通過させ、routeハンドラの Bearer 認証へ委ねる。
+  if (process.env.VERCEL_ENV === 'production') {
+    if (nextUrl.pathname.startsWith('/api/cron/')) {
+      return NextResponse.next();
+    }
+    return new NextResponse(null, { status: 404 });
+  }
+
+  // ローカル/Preview: NextAuth の API 系はミドルウェア判定をスキップする
+  if (nextUrl.pathname.startsWith('/api/')) {
+    return NextResponse.next();
+  }
+
   const isAuthenticated = !!req.auth;
 
   const isProtectedPath = protectedPaths.some((path) =>
@@ -72,12 +87,14 @@ export const config = {
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
-     * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - public (public files)
+     * NOTE: 本番Vercel環境で /api/* 配下も封鎖するため api は除外しない。
+     * ローカル/Preview では冒頭で /api/ を素通しにして NextAuth 等の
+     * 動作を阻害しないようにしている。
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
## 概要
Vercel 本番デプロイ時に画面（App）を非公開化し、`/api/cron/*` のみを通過させる。ローカルと本番の Supabase を同一 DB で運用しているため、Vercel Cron だけを本番で動かしたい要件に対応する。

Closes #499

## 変更内容
- `src/middleware.ts`
  - `process.env.VERCEL_ENV === 'production'` の分岐を追加
  - `/api/cron/*` は通過、それ以外は `new NextResponse(null, { status: 404 })` を返す
  - ローカル / Preview では `/api/*` を素通しにして NextAuth の挙動を維持
  - `matcher` から `api` 除外を外し、`/api/*` にもミドルウェアを適用
- `src/middleware.test.ts`
  - `next/server` モックを class 化して `new NextResponse(...)` に対応
  - Vercel 本番デプロイ用のケースを 4 件追加
  - 全 13 テスト通過

## ロードマップ
本 PR に該当タスクなし（Issue #499 起因）。

## レビューポイント
- `VERCEL_ENV === 'production'` の判定で問題ないか（Preview は非対応・実質差なし）
- `matcher` 変更に伴う既存 NextAuth 挙動への影響（ローカル分岐で `/api/*` 素通しにより保護）
- 404 応答を空ボディで返す設計（本番非公開が目的のため意図的にアプリらしさを見せない）

## テスト
- [x] `npx jest src/middleware.test.ts` → 13 tests passed
- [ ] Vercel Production 環境変数に `CRON_SECRET` を登録
- [ ] マージ後、Production URL が 404 を返すこと & Dashboard から Cron Run で正常応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)