### PR TITLE
fix(ci): E2E を concurrency で直列化し共有Supabase DBの並列衝突を解消

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+# 共有 Supabase DB に対して E2E が並列実行されるとテストデータ（ハードコード済みメール）が
+# 別 run の cleanupAuthUser で消され OTP テストが失敗する。
+# リポ全体で E2E を直列化し衝突を防ぐ。実行中は強制キャンセルせず DB を中途半端な状態にしない。
+concurrency:
+  group: e2e-shared-db
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: Playwright E2E


### PR DESCRIPTION
## 概要
複数 PR の E2E 並列実行時、共有 Supabase DB 上で OTP テストが衝突して失敗する問題を、workflow-level `concurrency` で直列化することで解消する。

Closes #533

## 変更内容
`.github/workflows/e2e.yml` に以下を追加:

```yaml
concurrency:
  group: e2e-shared-db
  cancel-in-progress: false
```

## 背景
Dependabot Security Updates 有効化により 5 本の Dependabot PR が同時に立ち、それぞれの E2E が並列実行された結果、全 PR で以下のテストが失敗:

- `e2e/auth/otpFlow.spec.ts:129 有効期限切れの確認コードだとエラーが表示される`
  - `expect(code).toBeTruthy()` で `code === null`
  - 原因: 別 PR の `beforeEach` の `cleanupAuthUser` が自 PR の OTP レコードを削除

main の push は単一ストリームなので発生していない。並列 pull_request 特有の問題。

## レビューポイント
- `group: e2e-shared-db` はリポ全体で単一（ref 非依存）とすることで意図的にリポ全体を直列化
- `cancel-in-progress: false` により実行中の run を強制中断させず、DB を中途半端な状態にしない
- トレードオフ: 5 本並列 PR 時に最大 30 分ほどキュー待機が発生（暫定対応として許容）

## テスト
- [x] YAML 構文検証
- [ ] マージ後、Dependabot PR #527〜#531 の E2E を rerun して全緑になることを確認

## 長期改善（別 Issue 化候補）
- テスト用メールに `github.run_id` を混ぜてユニーク化 → concurrency 制約を外して並列化可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)