### PR TITLE
fix(db): rate_limits.chk_action_type を実コードの action_type に追従

### DIFF
--- a/supabase/migrations/20260811010325_fix_rate_limits_chk_action_type.sql
+++ b/supabase/migrations/20260811010325_fix_rate_limits_chk_action_type.sql
@@ -1,0 +1,48 @@
+-- rate_limits.chk_action_type を、現在アプリが使用中の全 action_type に合わせて更新する。
+--
+-- 背景:
+--   20260208100000_add_password_security.sql で ('login','otp_verify','otp_resend','change_password')
+--   に更新されたまま、その後追加された RATE_LIMIT_ACTION / OTP_ACTION の各値が
+--   反映されておらず、大半の insert が CHECK 制約違反(23514)で拒否されていた。
+--   結果として DBベースのレート制限が事実上無効化されていたため修正する。
+--
+-- 対象一覧:
+--   OTP_ACTION (src/constants/otp.ts):
+--     - registration
+--     - login
+--     - password_change
+--   RATE_LIMIT_ACTION (src/constants/rateLimit.ts):
+--     - write_api_favorites / write_api_watchlist / write_api_dismissed_movies
+--     - write_api_profile / write_api_settings
+--     - read_api_theaters / read_api_theater_detail
+--     - awards_fetch / suggest_title / register / change_password
+--   Legacy (旧値: 既存レコードとの互換のため残置):
+--     - otp_verify / otp_resend
+
+ALTER TABLE rate_limits
+  DROP CONSTRAINT IF EXISTS chk_action_type;
+
+ALTER TABLE rate_limits
+  ADD CONSTRAINT chk_action_type CHECK (
+    action_type IN (
+      -- OTP_ACTION
+      'registration',
+      'login',
+      'password_change',
+      -- RATE_LIMIT_ACTION
+      'write_api_favorites',
+      'write_api_watchlist',
+      'write_api_dismissed_movies',
+      'write_api_profile',
+      'write_api_settings',
+      'read_api_theaters',
+      'read_api_theater_detail',
+      'awards_fetch',
+      'suggest_title',
+      'register',
+      'change_password',
+      -- legacy
+      'otp_verify',
+      'otp_resend'
+    )
+  );


### PR DESCRIPTION
## 概要

`rate_limits.chk_action_type` の CHECK 制約が旧仕様のまま4値 (`login`, `otp_verify`, `otp_resend`, `change_password`) のみを許可しており、その後追加された多数の `action_type` が全て CHECK 違反 (SQLSTATE 23514) で拒否されていた問題を修正する。

## ロードマップ
（該当なし）

## 発見経緯

Supabase ログに `new row for relation "rate_limits" violates check constraint "chk_action_type"` が大量発生（例: 2026-08-11 00:50〜00:58 UTC の CI E2E 実行時間帯に数十件/分）。

## 影響

- **DBベースのレート制限が事実上無効化されていた**（`checkRateLimit` の insert が失敗しても現実装は許可側に倒れる）
- Supabase ログのエラーノイズ増によるトリアージ阻害

## 変更内容

`supabase/migrations/20260811010325_fix_rate_limits_chk_action_type.sql` を追加し、以下を全許可:

- **OTP_ACTION**: `registration` / `login` / `password_change`
- **RATE_LIMIT_ACTION**: `write_api_favorites` / `write_api_watchlist` / `write_api_dismissed_movies` / `write_api_profile` / `write_api_settings` / `read_api_theaters` / `read_api_theater_detail` / `awards_fetch` / `suggest_title` / `register` / `change_password`
- **Legacy 値**（既存レコード互換のため残置）: `otp_verify` / `otp_resend`

## 適用済みリモート反映

`supabase db push` を実行済み（本番相当の remote DB に反映済み）。マージ後はリポジトリ上の履歴を正とする。

## レビューポイント

- 許可リストは `src/constants/rateLimit.ts` の `RATE_LIMIT_ACTION` と `src/constants/otp.ts` の `OTP_ACTION` の全値を網羅
- 型 `action_type: string`（enum ではない）ため型再生成は不要
- Legacy 値 (`otp_verify`, `otp_resend`) は現行コードでは insert 経路無し、既存レコード互換のみを目的に残置

## テスト

- `supabase db push` 成功
- E2E は本 PR の CI で再実行して 23514 が消えることを確認予定

## 別件

favorites の `idx_favorites_user_movie` UNIQUE 違反 (23505) は別 Issue #547 で対応（本 PR スコープ外）。

Closes #546