### PR TITLE
fix(api): favorites/watchlist/dismissed-movies POST の重複INSERT race を吸収

### DIFF
--- a/src/app/api/dismissed-movies/route.test.ts
+++ b/src/app/api/dismissed-movies/route.test.ts
@@ -279,6 +279,47 @@ describe('POST /api/dismissed-movies', () => {
     expect(response.status).toBe(401);
   });
 
+  it('INSERT時にUNIQUE違反(23505)が発生したら409を返す', async () => {
+    // 重複チェック: 存在しない（race: 直後に別リクエストが挿入した想定）
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: jest.fn().mockReturnValue({
+          eq: () => ({
+            is: () => ({
+              single: () => ({
+                data: null,
+                error: { code: 'PGRST116' },
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+    // INSERT: UNIQUE violation
+    mockFrom.mockReturnValueOnce({
+      insert: () => ({
+        select: () => ({
+          single: () => ({
+            data: null,
+            error: { code: '23505', message: 'duplicate key' },
+          }),
+        }),
+      }),
+    });
+
+    const response = await POST(
+      createPostRequest({
+        tmdb_movie_id: 12345,
+        title: 'テスト映画',
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('CONFLICT');
+  });
+
   it('INSERTエラー時に500を返す', async () => {
     // 重複チェック: 存在しない
     mockFrom.mockReturnValueOnce({

--- a/src/app/api/dismissed-movies/route.ts
+++ b/src/app/api/dismissed-movies/route.ts
@@ -19,6 +19,7 @@ import {
 import {
   checkDuplicate,
   conflictResponse,
+  isUniqueViolation,
   rateLimitExceededResponse,
 } from '@/helpers/apiHelpers';
 import { parseAndValidate } from '@/helpers/requestValidation';
@@ -97,6 +98,9 @@ export const POST = withAuth(
       .single();
 
     if (insertError) {
+      if (isUniqueViolation(insertError)) {
+        return conflictResponse(DISMISSED_MOVIES_ERROR_MESSAGES.ALREADY_EXISTS);
+      }
       throw insertError;
     }
 

--- a/src/app/api/favorites/route.test.ts
+++ b/src/app/api/favorites/route.test.ts
@@ -338,6 +338,48 @@ describe('POST /api/favorites', () => {
     expect(response.status).toBe(401);
   });
 
+  it('INSERT時にUNIQUE違反(23505)が発生したら409を返す', async () => {
+    // 重複チェック: 存在しない（race: 直後に別リクエストが挿入した想定）
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: jest.fn().mockReturnValue({
+          eq: () => ({
+            is: () => ({
+              single: () => ({
+                data: null,
+                error: { code: 'PGRST116' },
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+    // INSERT: UNIQUE violation
+    mockFrom.mockReturnValueOnce({
+      insert: () => ({
+        select: () => ({
+          single: () => ({
+            data: null,
+            error: { code: '23505', message: 'duplicate key' },
+          }),
+        }),
+      }),
+    });
+
+    const response = await POST(
+      createPostRequest({
+        tmdb_movie_id: 12345,
+        title: 'テスト映画',
+        rating: 8,
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('CONFLICT');
+  });
+
   it('INSERTエラー時に500を返す', async () => {
     // 重複チェック: 存在しない
     mockFrom.mockReturnValueOnce({

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -11,6 +11,7 @@ import { parseAndValidate } from '@/helpers/requestValidation';
 import {
   checkDuplicate,
   conflictResponse,
+  isUniqueViolation,
   rateLimitExceededResponse,
 } from '@/helpers/apiHelpers';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
@@ -155,6 +156,9 @@ export const POST = withAuth(
       .single();
 
     if (insertError) {
+      if (isUniqueViolation(insertError)) {
+        return conflictResponse(FAVORITES_ERROR_MESSAGES.ALREADY_EXISTS);
+      }
       throw insertError;
     }
 

--- a/src/app/api/watchlist/route.test.ts
+++ b/src/app/api/watchlist/route.test.ts
@@ -341,6 +341,47 @@ describe('POST /api/watchlist', () => {
     expect(response.status).toBe(401);
   });
 
+  it('INSERT時にUNIQUE違反(23505)が発生したら409を返す', async () => {
+    // 重複チェック: 存在しない（race: 直後に別リクエストが挿入した想定）
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: jest.fn().mockReturnValue({
+          eq: () => ({
+            is: () => ({
+              single: () => ({
+                data: null,
+                error: { code: 'PGRST116' },
+              }),
+            }),
+          }),
+        }),
+      }),
+    });
+    // INSERT: UNIQUE violation
+    mockFrom.mockReturnValueOnce({
+      insert: () => ({
+        select: () => ({
+          single: () => ({
+            data: null,
+            error: { code: '23505', message: 'duplicate key' },
+          }),
+        }),
+      }),
+    });
+
+    const response = await POST(
+      createPostRequest({
+        tmdb_movie_id: 12345,
+        title: 'テスト映画',
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('CONFLICT');
+  });
+
   it('INSERTエラー時に500を返す', async () => {
     // 重複チェック: 存在しない
     mockFrom.mockReturnValueOnce({

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -18,6 +18,7 @@ import {
 import {
   checkDuplicate,
   conflictResponse,
+  isUniqueViolation,
   rateLimitExceededResponse,
 } from '@/helpers/apiHelpers';
 import { parseAndValidate } from '@/helpers/requestValidation';
@@ -197,6 +198,9 @@ export const POST = withAuth(
       .single();
 
     if (insertError) {
+      if (isUniqueViolation(insertError)) {
+        return conflictResponse(WATCHLIST_ERROR_MESSAGES.ALREADY_EXISTS);
+      }
       throw insertError;
     }
 

--- a/src/helpers/apiHelpers.test.ts
+++ b/src/helpers/apiHelpers.test.ts
@@ -6,7 +6,11 @@
  * apiHelpers テスト
  */
 
-import { conflictResponse, notFoundResponse } from './apiHelpers';
+import {
+  conflictResponse,
+  isUniqueViolation,
+  notFoundResponse,
+} from './apiHelpers';
 
 describe('conflictResponse', () => {
   it('409ステータスのレスポンスを返す', async () => {
@@ -17,6 +21,31 @@ describe('conflictResponse', () => {
     expect(json.success).toBe(false);
     expect(json.error.code).toBe('CONFLICT');
     expect(json.error.message).toBe('重複エラー');
+  });
+});
+
+describe('isUniqueViolation', () => {
+  it('SQLSTATE 23505 の error オブジェクトで true を返す', () => {
+    expect(isUniqueViolation({ code: '23505', message: 'duplicate' })).toBe(
+      true,
+    );
+  });
+
+  it('別の SQLSTATE では false を返す', () => {
+    expect(isUniqueViolation({ code: '23503' })).toBe(false);
+    expect(isUniqueViolation({ code: 'PGRST116' })).toBe(false);
+  });
+
+  it('null / undefined / プリミティブでは false を返す', () => {
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+    expect(isUniqueViolation('23505')).toBe(false);
+    expect(isUniqueViolation(23505)).toBe(false);
+  });
+
+  it('code プロパティを持たないオブジェクトでは false を返す', () => {
+    expect(isUniqueViolation({})).toBe(false);
+    expect(isUniqueViolation(new Error('boom'))).toBe(false);
   });
 });
 

--- a/src/helpers/apiHelpers.ts
+++ b/src/helpers/apiHelpers.ts
@@ -57,6 +57,19 @@ export async function checkDuplicate(
 }
 
 /**
+ * Postgres の UNIQUE 制約違反（SQLSTATE 23505）判定。
+ * checkDuplicate と INSERT の間に生じる race を安全側で吸収するために使う。
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === '23505'
+  );
+}
+
+/**
  * 409 Conflictレスポンスを生成
  */
 export function conflictResponse(message: string) {


### PR DESCRIPTION
## 概要

`favorites` / `watchlist` / `dismissed_movies` の POST で `checkDuplicate → INSERT` が非原子的なため、同一 (user, tmdb_movie_id) の並行リクエストで UNIQUE 制約違反 (SQLSTATE 23505) が発生し 500 化していた問題を修正する。

## ロードマップ
（該当なし）

## 発見経緯

Supabase ログに \`duplicate key value violates unique constraint \"idx_favorites_user_movie\"\` が散発。詳細は Issue #547。

## 変更内容

- `src/helpers/apiHelpers.ts`: `isUniqueViolation(error)` ヘルパーを追加（SQLSTATE 23505 を型安全に判定）
- `src/app/api/favorites/route.ts` / `watchlist/route.ts` / `dismissed-movies/route.ts`: INSERT エラーが 23505 の場合は `conflictResponse()` で 409 を返すよう変更（API 仕様は「重複=409」を維持）

`checkDuplicate` は残置（重複時に無駄な INSERT を避けるための最適化）。race 発生時のみ 23505 catch が働く安全網構成。

## レビューポイント

- `isUniqueViolation` は `code === '23505'` のみで判定。Supabase / postgres-js / pg いずれのクライアントも SQLSTATE を `code` に載せるため十分（詳細メッセージや制約名までは見ない）
- `checkDuplicate` を残した理由: 明示的な事前チェックで「典型ケースは即 409」を担保しつつ、race 時のみ 23505 catch にフォールバック（追加 SQL 1回で無駄な INSERT を回避）
- API 仕様は変更なし: 重複時は 409 conflict、code は `CONFLICT`、メッセージも既存の `ALREADY_EXISTS` 系を再利用

## テスト

- 各 route に「INSERT時にUNIQUE違反(23505)が発生したら409を返す」テストを追加（3本）
- `apiHelpers.test.ts` に `isUniqueViolation` の単体テストを追加（4本）
- `npx jest` 全体: **243 suites / 2527 tests all pass**（+7）
- `npx tsc --noEmit` エラー無し

## 別件（対応不要）

favorites 側の UNIQUE 制約は partial index (`WHERE deleted_at IS NULL`) のため、論理削除→再追加も従来通り可能。今回の変更で挙動変化なし。

Closes #547