### PR TITLE
feat(next): middleware.ts を proxy.ts に移行（Next.js 16 対応）

### DIFF
--- a/.claude/documents/architecture.md
+++ b/.claude/documents/architecture.md
@@ -105,7 +105,7 @@ src/
 ├── test/                # テストユーティリティ・セットアップ
 ├── types/               # TypeScript型定義
 ├── utils/               # 汎用ユーティリティ
-├── middleware.ts         # Next.js Middleware
+├── proxy.ts              # Next.js Proxy（旧 middleware.ts）
 └── styles/              # グローバルスタイル
 ```
 

--- a/.claude/documents/theater-experience-design.md
+++ b/.claude/documents/theater-experience-design.md
@@ -562,7 +562,7 @@ export interface FieldOfViewMetrics {
 
 - `src/constants/common.ts` の `ROUTES` に `THEATER_EXPERIENCE: '/theater-experience'` を追加
 - `src/constants/navigation.ts` の `NAV_ITEMS` 配列**末尾**に `{ label: 'シアター体験', href: ROUTES.THEATER_EXPERIENCE }` を追加
-- `src/middleware.ts` の `protectedPaths` 配列に **`ROUTES.THEATER_EXPERIENCE`** を追加（既存の `.startsWith()` 判定により `/theater-experience/[slug]` も含めて保護される）
+- `src/proxy.ts` の `protectedPaths` 配列に **`ROUTES.THEATER_EXPERIENCE`** を追加（既存の `.startsWith()` 判定により `/theater-experience/[slug]` も含めて保護される）
 
 ---
 
@@ -707,6 +707,6 @@ ONの場合:
 8. 一人称プレビュー（`firstPersonPreview`、drei `<View>` 採用）
 9. 操作UI（`frequencySelector`, `seatInfoPanel`, `distortionPreview`, `theaterSelector`）
 10. `unsupportedBrowserNotice`（WebGL2/モバイル非対応時）
-11. ページ統合（`theaterExperiencePage`）・動的ルート `[slug]` 対応・ナビゲーション追加・認証ガード（`middleware.ts` 更新）
+11. ページ統合（`theaterExperiencePage`）・動的ルート `[slug]` 対応・ナビゲーション追加・認証ガード（`proxy.ts` 更新）
 12. アクセシビリティ対応（`prefers-reduced-motion`、コントラスト調整、キーボード操作）
 13. E2E・スナップショットテスト整備・カバレッジ80%確認

--- a/.claude/documents/theater-experience-implementation-plan.md
+++ b/.claude/documents/theater-experience-implementation-plan.md
@@ -924,7 +924,7 @@ export default function TheaterExperienceRoute() {
 |---|---|
 | `src/constants/common.ts` | `ROUTES` に `THEATER_EXPERIENCE: '/theater-experience'` 追加 |
 | `src/constants/navigation.ts` | `NAV_ITEMS` 末尾に `{ label: 'シアター体験', href: ROUTES.THEATER_EXPERIENCE }` 追加 |
-| `src/middleware.ts` | `protectedPaths` に `ROUTES.THEATER_EXPERIENCE` 追加 |
+| `src/proxy.ts` | `protectedPaths` に `ROUTES.THEATER_EXPERIENCE` 追加 |
 
 ### アクセシビリティ対応
 

--- a/src/components/providers/sessionExpiryHandler.tsx
+++ b/src/components/providers/sessionExpiryHandler.tsx
@@ -4,7 +4,7 @@
  * セッションが確定的にunauthenticatedになった場合、NextAuthのsignOutを実行してログインページへ遷移する。
  * - authenticated → unauthenticated（ライブセッション切れ）
  *
- * ※ loading → unauthenticated（リロード時）はmiddlewareがサーバーサイドで
+ * ※ loading → unauthenticated（リロード時）はproxyがサーバーサイドで
  *   期限切れcookieの削除とリダイレクトを処理するため、クライアント側では対応しない。
  *   これにより未ログインユーザーが公開ページに正常にアクセスできる。
  */

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -45,8 +45,8 @@ export const ROUTES = {
 } as const;
 
 /**
- * 認証が必要なルート（middleware と ナビゲーションの共通定義）
- * 未認証アクセス時は middleware がリダイレクトし、ナビからはログイン誘導を表示する。
+ * 認証が必要なルート（proxy と ナビゲーションの共通定義）
+ * 未認証アクセス時は proxy がリダイレクトし、ナビからはログイン誘導を表示する。
  */
 export const AUTH_REQUIRED_ROUTES = [
   ROUTES.WATCHLIST,

--- a/src/features/auth/signInContent/signInContent.tsx
+++ b/src/features/auth/signInContent/signInContent.tsx
@@ -14,7 +14,7 @@ import { OtpLoginForm } from '@/features/auth/otpLoginForm/otpLoginForm';
 type LoginMode = 'password' | 'otp';
 
 interface SignInContentProps {
-  /** ログイン後の戻り先（middlewareが付与する callbackUrl） */
+  /** ログイン後の戻り先（proxyが付与する callbackUrl） */
   callbackUrl?: string;
 }
 

--- a/src/hooks/useNavAuthGuard.ts
+++ b/src/hooks/useNavAuthGuard.ts
@@ -34,7 +34,7 @@ export function useNavAuthGuard() {
       if (isAuthenticated) {
         return;
       }
-      // 「保護対象か」は middleware と共通の AUTH_REQUIRED_ROUTES を真実源に判定する
+      // 「保護対象か」は proxy と共通の AUTH_REQUIRED_ROUTES を真実源に判定する
       const isProtected = AUTH_REQUIRED_ROUTES.some((route) => route === href);
       if (!isProtected) {
         return;

--- a/src/lib/auth/README.md
+++ b/src/lib/auth/README.md
@@ -24,7 +24,7 @@ src/
 │       └── auth/
 │           └── [...nextauth]/
 │               └── route.ts     # NextAuth.js API Route
-├── middleware.ts                # 認証保護ミドルウェア
+├── proxy.ts                     # 認証保護 Proxy（Next.js 16 file convention）
 └── types/
     └── next-auth.d.ts           # NextAuth.js 型定義拡張
 ```
@@ -199,9 +199,9 @@ export async function login(formData: FormData) {
 - セキュアクッキー（本番環境）
 - HttpOnly, SameSite=Lax
 
-## ミドルウェア
+## Proxy（旧 Middleware）
 
-`src/middleware.ts` で認証保護を実装：
+`src/proxy.ts` で認証保護を実装（Next.js 16 で `middleware` は `proxy` にリネームされた）：
 
 ```typescript
 // 認証が必要なパス

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -260,6 +260,145 @@ describe('proxy', () => {
     });
   });
 
+  describe('境界値: callbackUrl 生成', () => {
+    it('保護ページへの未認証アクセス時、クエリ文字列を含む callbackUrl が生成される', () => {
+      const req = createMockRequest({
+        pathname: '/favorites',
+        auth: null,
+        hasSessionCookie: false,
+      });
+      // search を持たせる（createMockRequest は new URL(pathname) で組み立てるので追加で書き換える）
+      req.nextUrl.search = '?tab=recent&sort=asc';
+
+      const response = proxy(req);
+      const location = response.headers.get('location');
+
+      // callbackUrl はエンコード済み: /favorites?tab=recent&sort=asc
+      expect(location).toContain(
+        'callbackUrl=%2Ffavorites%3Ftab%3Drecent%26sort%3Dasc',
+      );
+    });
+
+    it('クエリなしの保護ページアクセスでは callbackUrl にパスのみが含まれる', () => {
+      const req = createMockRequest({
+        pathname: '/watchlist',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+      const location = response.headers.get('location');
+
+      expect(location).toContain('callbackUrl=%2Fwatchlist');
+      expect(location).not.toContain('%3F'); // クエリを表す '?' を含まない
+    });
+  });
+
+  describe('境界値: protectedPaths / authPaths のマッチング', () => {
+    it('動的セグメント /theater-experience/[slug] も startsWith で保護される', () => {
+      const req = createMockRequest({
+        pathname: '/theater-experience/imax-osaka-expocity',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+      const location = response.headers.get('location');
+
+      expect(location).toContain('/auth/signin');
+      expect(location).toContain(
+        'callbackUrl=%2Ftheater-experience%2Fimax-osaka-expocity',
+      );
+    });
+
+    it('/settings も未認証時はサインインにリダイレクトされる', () => {
+      const req = createMockRequest({
+        pathname: '/settings',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+
+      expect(response.headers.get('location')).toContain(
+        'callbackUrl=%2Fsettings',
+      );
+    });
+
+    it('認証済で /auth/signup にアクセスするとホームにリダイレクトされる', () => {
+      const req = createMockRequest({
+        pathname: '/auth/signup',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const response = proxy(req);
+
+      expect(response.headers.get('location')).toContain(
+        'http://localhost:3000/',
+      );
+      expect(response.headers.get('location')).not.toContain('/auth/');
+    });
+
+    it('/auth/error は authPaths 外なので、認証済でもホームにリダイレクトされず表示される', () => {
+      const req = createMockRequest({
+        pathname: '/auth/error',
+        auth: mockAuth,
+        hasSessionCookie: true,
+      });
+
+      const response = proxy(req);
+
+      // リダイレクトされずに通過（location ヘッダなし）
+      expect(response.headers.get('location')).toBeNull();
+    });
+
+    it('未認証で /auth/signin にアクセスしても通過する（リダイレクトループを防ぐ）', () => {
+      const req = createMockRequest({
+        pathname: '/auth/signin',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+
+      expect(response.headers.get('location')).toBeNull();
+      expect(mockNextResponseNext).toHaveBeenCalled();
+    });
+  });
+
+  describe('境界値: ローカル/Preview 環境での /api/* 素通し', () => {
+    it('VERCEL_ENV 未設定時、/api/* は認証判定をスキップして通過する', () => {
+      const req = createMockRequest({
+        pathname: '/api/watchlist',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      // NextAuth の API は認証情報なしでも proxy を通過する必要がある
+      expect(response.headers.get('location')).toBeNull();
+    });
+
+    it('VERCEL_ENV="preview" では /api/* は素通し（本番404封鎖の対象外）', () => {
+      process.env.VERCEL_ENV = 'preview';
+
+      const req = createMockRequest({
+        pathname: '/api/auth/session',
+        auth: null,
+        hasSessionCookie: false,
+      });
+
+      const response = proxy(req);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('location')).toBeNull();
+    });
+  });
+
   describe('CSP / nonce を付与しない（静的配信へ移行）', () => {
     it('通常応答に Content-Security-Policy ヘッダを設定しない（next.config で静的配信）', () => {
       const req = createMockRequest({

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,5 +1,5 @@
 /**
- * Next.js Middleware テスト
+ * Next.js Proxy テスト（旧 middleware.test.ts / Next.js 16 対応）
  */
 
 // next/serverをモック
@@ -60,9 +60,9 @@ jest.mock('@/lib/auth/auth', () => ({
   auth: (callback: (...args: unknown[]) => unknown) => callback,
 }));
 
-// middleware.tsのdefault exportはauth(callback)の結果＝callback自体
+// proxy.tsの named export `proxy` は auth(callback) の結果＝callback自体
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const middleware = require('./middleware').default as (req: unknown) => {
+const proxy = require('./proxy').proxy as (req: unknown) => {
   headers: Headers;
   status?: number;
   cookies?: { delete: jest.Mock };
@@ -86,7 +86,7 @@ function createMockRequest(options: {
   };
 }
 
-describe('middleware', () => {
+describe('proxy', () => {
   const mockAuth = { user: { id: 'user-1' } };
   const originalVercelEnv = process.env.VERCEL_ENV;
 
@@ -118,7 +118,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(mockNextResponseNext).toHaveBeenCalled();
       expect(response.status).toBe(200);
@@ -131,7 +131,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.status).toBe(404);
     });
@@ -143,7 +143,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.status).toBe(404);
       expect(response.headers.get('location')).toBeNull();
@@ -156,7 +156,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.status).toBe(404);
     });
@@ -170,7 +170,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       // NextResponse.next()が返される（リダイレクトではない）
       expect(response.headers.get('location')).toBeNull();
@@ -185,7 +185,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('location')).toContain('/auth/signin');
       expect(mockCookiesDelete).toHaveBeenCalledWith('next-auth.session-token');
@@ -200,7 +200,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('location')).toContain('/auth/signin');
     });
@@ -212,7 +212,7 @@ describe('middleware', () => {
         hasSessionCookie: false,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       // リダイレクトではなく通常応答（location ヘッダが無い）
       expect(response.headers.get('location')).toBeNull();
@@ -227,7 +227,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('location')).toContain(
         'http://localhost:3000/',
@@ -242,7 +242,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('location')).toBeNull();
     });
@@ -254,7 +254,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('location')).toBeNull();
     });
@@ -268,7 +268,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      const response = middleware(req);
+      const response = proxy(req);
 
       expect(response.headers.get('content-security-policy')).toBeNull();
     });
@@ -280,7 +280,7 @@ describe('middleware', () => {
         hasSessionCookie: true,
       });
 
-      middleware(req);
+      proxy(req);
 
       // 認証のみのため init（{ request: { headers } }）は渡されない
       const init = mockNextResponseNext.mock.calls[0][0];

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -385,17 +385,21 @@ describe('proxy', () => {
 
     it('VERCEL_ENV="preview" では /api/* は素通し（本番404封鎖の対象外）', () => {
       process.env.VERCEL_ENV = 'preview';
+      try {
+        const req = createMockRequest({
+          pathname: '/api/auth/session',
+          auth: null,
+          hasSessionCookie: false,
+        });
 
-      const req = createMockRequest({
-        pathname: '/api/auth/session',
-        auth: null,
-        hasSessionCookie: false,
-      });
+        const response = proxy(req);
 
-      const response = proxy(req);
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get('location')).toBeNull();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('location')).toBeNull();
+      } finally {
+        // 後続テストへの副作用を防ぐため即時復元（上位 beforeEach でも delete されるが多重防御）
+        delete process.env.VERCEL_ENV;
+      }
     });
   });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,11 @@
 /**
- * Next.js Middleware - 認証保護
+ * Next.js Proxy - 認証保護（旧 middleware.ts / Next.js 16 対応）
  *
  * CSP は static prerender を維持するため next.config.mjs で静的配信する
  * （script-src 'unsafe-inline' 許容により nonce 不要）。ここでは認証保護のみを担う。
+ *
+ * proxy はネットワーク層のリダイレクト/リライトに徹し、認可の最終判定は
+ * Server Components / Route Handlers 側でも二重に行う設計とする。
  */
 
 import { NextResponse } from 'next/server';
@@ -22,7 +25,7 @@ const protectedPaths = AUTH_REQUIRED_ROUTES;
 /** 認証ページ */
 const authPaths = [ROUTES.LOGIN, ROUTES.REGISTER];
 
-export default auth((req) => {
+export const proxy = auth((req) => {
   const { nextUrl } = req;
 
   // 本番Vercelデプロイではローカル運用のためcron以外を全て404で隠す。


### PR DESCRIPTION
## 概要

Next.js 16 で `middleware` ファイル規約が deprecated となり `proxy` にリネームされた件への対応。Issue #223 で一度は「NextAuth の `auth()` ラッパーが proxy 非対応」を理由に見送っていたが、以下の再調査を経て **問題なく移行可能** と判断した。

## 再開判断の根拠（再調査）

- **NextAuth.js v5 の proxy 対応パターンが確立**（[Auth.js Discussion #13315](https://github.com/nextauthjs/next-auth/discussions/13315)）
  - 動作する形: \`export const proxy = auth((req) => {...})\` / \`export { auth as proxy }\`
  - 動作しない形: \`export const { auth: proxy } = NextAuth(authConfig)\`
- \`auth()\` ラッパーはそのまま維持できるため、当初の見送り理由（セッション期限切れ検知・cookie 削除機能の喪失）は該当しない
- \`next-auth@5.0.0-beta.32\`（現状 = 最新 beta）で動作確認済み

## ロードマップ
（該当なし）

## 変更内容

### コア変更
- \`src/middleware.ts\` → \`src/proxy.ts\`（\`git mv\` で履歴保持）
- \`src/middleware.test.ts\` → \`src/proxy.test.ts\`（\`git mv\`）
- \`export default auth(...)\` → \`export const proxy = auth(...)\`
- test の \`require('./middleware').default\` → \`require('./proxy').proxy\`
- ロジック無変更（VERCEL_ENV 404 隠蔽 / 保護パスリダイレクト / セッション期限切れ cookie 削除 は全て維持）

### 参照更新（コメント / docs）
- \`src/constants/common.ts\` / \`src/features/auth/signInContent/signInContent.tsx\` / \`src/components/providers/sessionExpiryHandler.tsx\` / \`src/hooks/useNavAuthGuard.ts\` / \`src/lib/auth/README.md\`
- \`.claude/documents/architecture.md\` / \`theater-experience-design.md\` / \`theater-experience-implementation-plan.md\`

## レビューポイント

- \`export const proxy = auth((req) => {...})\` の named export 形式は Auth.js コミュニティで確立された動作パターン
- proxy 内の認証判定は従来通り「一次防衛線」であり、認可の最終判定は Server Components / Route Handlers 側でも二重に行う設計（コメントに追記）
- \`.claude/skills/middleware/\` skill 定義はスコープ外（汎用テンプレートのため別 Issue で扱うのが妥当）

## テスト

- \`npx jest\` 全体: **243 suites / 2527 tests all pass**
- \`npx tsc --noEmit\` エラー無し
- dev サーバー起動 + agent-browser で手動検証:
  - [x] 未認証で \`/favorites\` → \`/auth/signin?callbackUrl=%2Ffavorites\` にリダイレクト
  - [x] ログイン後 \`/favorites\` にアクセス可能（cookie 経由の \`auth()\` 判定 OK）
  - [x] 認証済みで \`/auth/signin\` → \`/\` にリダイレクト
  - [x] middleware deprecation 警告が HMR 以降は再発生しない
  - [x] Next.js dev バッジ赤なし（コンソール/ランタイムエラー無し）

Closes #223