### PR TITLE
test(home): MovieContent の境界値・インタラクションテストを追加

### DIFF
--- a/src/features/home/component/movieContent/movieContent.test.tsx
+++ b/src/features/home/component/movieContent/movieContent.test.tsx
@@ -201,6 +201,29 @@ describe('MovieContent', () => {
       ).toBeInTheDocument();
     });
 
+    it('日付範囲lte単独（gteなし）でバッジが表示される', () => {
+      mockUseHome.mockReturnValue(
+        createMockUseHome({ dateRange: { lte: '2026-12-31' } }),
+      );
+      const { container } = render(<MovieContent />);
+      expect(
+        container.querySelector('.c_home_page__filter_count'),
+      ).toBeInTheDocument();
+    });
+
+    it('複数のフィルタが有効でもバッジは1つだけ表示される（境界値）', () => {
+      mockUseHome.mockReturnValue(
+        createMockUseHome({
+          selectedGenreIds: [28, 12],
+          dateRange: { gte: '2026-01-01', lte: '2026-12-31' },
+          isRevivalFilter: true,
+        }),
+      );
+      const { container } = render(<MovieContent />);
+      const badges = container.querySelectorAll('.c_home_page__filter_count');
+      expect(badges).toHaveLength(1);
+    });
+
     it('フィルターが無効な場合バッジが表示されない', () => {
       const { container } = render(<MovieContent />);
       expect(
@@ -228,6 +251,26 @@ describe('MovieContent', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'フィルター' }));
       expect(handleFilterModalOpen).toHaveBeenCalled();
+    });
+
+    it('ソート変更でhandleSortChangeが呼ばれる', () => {
+      const handleSortChange = jest.fn();
+      mockUseHome.mockReturnValue(createMockUseHome({ handleSortChange }));
+      render(<MovieContent />);
+
+      // Radix Select は combobox の keydown で option を確定できる
+      const combobox = screen.getByRole('combobox', {
+        name: 'ソート順を選択',
+      });
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+      const listbox = screen.getByRole('listbox');
+      const optionToClick = Array.from(
+        listbox.querySelectorAll('[role="option"]'),
+      ).find((el) => el.textContent !== '公開日順');
+      if (optionToClick) {
+        fireEvent.click(optionToClick);
+      }
+      expect(handleSortChange).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 概要

\`src/features/home/\` を agent-browser で実機検証し、MovieContent のフィルタバッジ境界値・ソート変更インタラクションの3テストを追加。

## ロードマップ
（該当なし）

## 実機検証（すべて期待通り）

- **未認証で /**: NowShowingMovieList のみ表示、RecommendationSection は非表示
- **認証済で /**: NowShowingMovieList + RecommendationSection の両方表示
- サイドバーの「公開カレンダー」ボタンは認証時のみ表示（appLayout の \`isAuthenticated\` 分岐）
- Next.js エラーバッジ無し

## 既存カバレッジ

- HomePage: 4 tests（AppLayout / NowShowingMovieList / RecommendationSection の auth 分岐）
- MovieContent: 15 tests（表示・ローディング・映画一覧・フィルタバッジ・インタラクション）
- useHome: 2 tests（薄いラッパーなので十分）

## 追加テスト（+3）

### MovieContent
- **境界値**: \`dateRange.lte\` 単独（gte なし）でバッジ表示 — 既存は \`gte\` のみカバー
- **境界値**: 全フィルタ有効時もバッジは1つだけ（過剰描画防止の回帰防止）
- **インタラクション**: ソート変更で \`handleSortChange\` が呼ばれる（既存は \`handleReleaseTypeChange\` と \`handleFilterModalOpen\` のみ）

## レビューポイント

- ソート変更テストは Radix Select の非同期 open + click 経路。既存 combobox 単体テスト（\`ui/select\`）でカバーしているとおり Radix 側の挙動は保証済み。ここでは props の伝播のみ確認する

## 発見（対応不要・別Issue）

- **Issue #553**: \`MovieContent\` (146行) は appLayout の JSDoc に例として書かれているのみで、どこからも \`import\` されていない dead code。テストは維持しているが、実装の削除 or 再利用（\`/movies/upcoming\` など別ページで利用）の方針は別 Issue で検討

## テスト

- \`npx jest src/features/home/\`: **3 suites / 25 tests all pass**（+3）
- \`npx tsc --noEmit\`: エラー無し