### PR TITLE
test(movies): useMovieDetail / videoDialog の境界値テストを追加

### DIFF
--- a/src/features/movies/component/videoDialog/videoDialog.test.tsx
+++ b/src/features/movies/component/videoDialog/videoDialog.test.tsx
@@ -146,6 +146,85 @@ describe('VideoDialog', () => {
     ).toBeInTheDocument();
   });
 
+  it('同一タイプの動画は published_at 降順（新しい順）でソートされる', () => {
+    const videos = [
+      createVideo({
+        id: 'v1',
+        name: '古い予告編',
+        type: 'Trailer',
+        published_at: '2025-01-01T00:00:00.000Z',
+      }),
+      createVideo({
+        id: 'v2',
+        name: '新しい予告編',
+        type: 'Trailer',
+        published_at: '2025-06-01T00:00:00.000Z',
+      }),
+      createVideo({
+        id: 'v3',
+        name: '中間の予告編',
+        type: 'Trailer',
+        published_at: '2025-03-01T00:00:00.000Z',
+      }),
+    ];
+
+    render(<VideoDialog {...defaultProps} videos={videos} />);
+
+    const videoNames =
+      screen.getAllByText(/古い予告編|新しい予告編|中間の予告編/);
+    expect(videoNames[0]).toHaveTextContent('新しい予告編');
+    expect(videoNames[1]).toHaveTextContent('中間の予告編');
+    expect(videoNames[2]).toHaveTextContent('古い予告編');
+  });
+
+  it('境界値: 優先タイプが1件のみの場合、非優先タイプの前に表示される', () => {
+    const videos = [
+      createVideo({
+        id: 'v1',
+        name: 'メイキング',
+        type: 'Behind the Scenes',
+        published_at: '2025-06-01T00:00:00.000Z',
+      }),
+      createVideo({
+        id: 'v2',
+        name: '予告編',
+        type: 'Trailer',
+        published_at: '2025-01-01T00:00:00.000Z',
+      }),
+    ];
+
+    render(<VideoDialog {...defaultProps} videos={videos} />);
+
+    const videoNames = screen.getAllByText(/予告編|メイキング/);
+    // Trailer は published_at が古くても優先タイプなので先頭に来る
+    expect(videoNames[0]).toHaveTextContent('予告編');
+    expect(videoNames[1]).toHaveTextContent('メイキング');
+  });
+
+  it('境界値: 優先タイプが全く無い場合、published_at 降順のみでソートされる', () => {
+    const videos = [
+      createVideo({
+        id: 'v1',
+        name: 'メイキング1',
+        type: 'Behind the Scenes',
+        published_at: '2025-01-01T00:00:00.000Z',
+      }),
+      createVideo({
+        id: 'v2',
+        name: 'メイキング2',
+        type: 'Featurette',
+        published_at: '2025-03-01T00:00:00.000Z',
+      }),
+    ];
+
+    render(<VideoDialog {...defaultProps} videos={videos} />);
+
+    const videoNames = screen.getAllByText(/メイキング/);
+    // 両者とも非優先タイプ → published_at 降順で新しい方が先
+    expect(videoNames[0]).toHaveTextContent('メイキング2');
+    expect(videoNames[1]).toHaveTextContent('メイキング1');
+  });
+
   it('空の動画一覧の場合、動画アイテムが表示されない', () => {
     render(<VideoDialog {...defaultProps} videos={[]} />);
 

--- a/src/features/movies/hooks/useMovieDetail.test.ts
+++ b/src/features/movies/hooks/useMovieDetail.test.ts
@@ -69,6 +69,49 @@ describe('useMovieDetail', () => {
     expect(result.current.isError).toBe(false);
   });
 
+  it('movieId=0（境界値: falsy だが null ではない）でもクエリを実行する', async () => {
+    const mockMovie = { id: 0, title: 'ID=0の映画' };
+    mockGetMovieDetail.mockResolvedValue({ data: mockMovie });
+
+    const { result } = renderHook(() => useMovieDetail(0), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.movie).toEqual(mockMovie);
+    });
+
+    // enabled: movieId !== null → 0 は null 判定ではないので実行される
+    expect(mockGetMovieDetail).toHaveBeenCalledWith(0);
+  });
+
+  it('movieId が変わると新しい ID でクエリが実行される', async () => {
+    mockGetMovieDetail
+      .mockResolvedValueOnce({ data: { id: 1, title: '映画A' } })
+      .mockResolvedValueOnce({ data: { id: 2, title: '映画B' } });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: number }) => useMovieDetail(id),
+      {
+        wrapper: createWrapper(),
+        initialProps: { id: 1 },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.movie?.id).toBe(1);
+    });
+
+    rerender({ id: 2 });
+
+    await waitFor(() => {
+      expect(result.current.movie?.id).toBe(2);
+    });
+
+    expect(mockGetMovieDetail).toHaveBeenNthCalledWith(1, 1);
+    expect(mockGetMovieDetail).toHaveBeenNthCalledWith(2, 2);
+  });
+
   it('エラー時にisErrorがtrueになる', async () => {
     mockGetMovieDetail.mockRejectedValue(new Error('API error'));
 


### PR DESCRIPTION
## 概要

\`src/features/movies/\` 配下を agent-browser で実機検証し、既存 117 テストで抜けていた **useMovieDetail の境界 movieId** と **videoDialog のソート境界** を補完する5テストを追加。

## ロードマップ
（該当なし）

## 実機検証（すべて期待通り）

- **/movies/upcoming**: 劇場公開 ↔ ストリーミング タブ切替, ソートSelect (公開日順)
- **/movies/now-showing**: 一覧, フィルタボタン (ジャンル/公開日/リバイバル)
- **詳細モーダル**: 映画タイル click → タイトル・日付・ジャンル・詳細情報 (人気度/制作予算/興行収入)・キャスト・お気に入り/ウォッチリスト追加
- **リバイバル映画**: 「リバイバル」バッジ表示
- **フィルターモーダル**: 公開日レンジ + ジャンル選択UI

## 既存カバレッジ（117 tests）
- movieDetailContent: 33 / useMovieList: 27 / movieListContent: 27 / useMovieListContent: 10 / videoDialog: 9 / useNowShowing: 4 / useUpcoming: 4 / useMovieDetail: 3

いずれも密度十分だが、下記の境界値が未検証だった。

## 追加テスト（+5）

### useMovieDetail（3→5）
- **境界値**: \`movieId=0\`（falsy だが null ではない）でクエリ実行 — 既存は null と 123 のみ
- **movieId 変更**: 新しい ID で再fetch されることを検証（キャッシュキー切り替え）

### videoDialog（9→12）
- **同一タイプ内ソート**: 3件の Trailer を \`published_at\` 降順で確認
- **境界値**: 優先タイプが1件のみでも非優先タイプの前に来る（優先度ロジックの単独動作確認）
- **境界値**: 優先タイプが全く無い場合、\`published_at\` 降順のみでソート（フォールバック挙動）

## レビューポイント

- useMovieDetail は \`enabled: movieId !== null\` — 0 は valid として扱う設計を明示的にテストで固定
- videoDialog の \`sortVideos\` は Trailer/Teaser 優先＋published_at 降順の二段階ソート。既存テストは複合ケースのみだったので、優先タイプ単独／非優先タイプ単独の各境界を追加

## テスト
- \`npx jest src/features/movies/\`: **8 suites / 122 tests all pass**（+5）
- \`npx tsc --noEmit\`: エラー無し