### PR TITLE
test(features): nowShowing/recommendations/search の境界値テストを追加

### DIFF
--- a/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
+++ b/src/features/recommendations/component/recommendationSection/recommendationSection.test.tsx
@@ -213,6 +213,23 @@ describe('RecommendationSection', () => {
       expect(screen.getByText('あなたへのおすすめ')).toBeInTheDocument();
       expect(screen.getByText('おすすめ映画を準備中です')).toBeInTheDocument();
     });
+
+    it('境界値: recommendations=[] かつ isRefreshing=true では準備中テキストが出ずグリッドが表示される', () => {
+      mockRefreshState = {
+        ...mockRefreshState,
+        isRefreshing: true,
+      };
+
+      render(
+        <RecommendationSection recommendations={[]} hasFavorites={true} />,
+      );
+
+      // 準備中は表示されず、代わりに更新中オーバーレイのグリッドが出る
+      expect(
+        screen.queryByText('おすすめ映画を準備中です'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('おすすめを更新中...')).toBeInTheDocument();
+    });
   });
 
   describe('レコメンドあり', () => {

--- a/src/features/search/component/titleSuggestion/titleSuggestion.test.tsx
+++ b/src/features/search/component/titleSuggestion/titleSuggestion.test.tsx
@@ -50,6 +50,19 @@ describe('TitleSuggestion', () => {
     expect(screen.getByText('原題を検索中...')).toBeInTheDocument();
   });
 
+  it('複数の候補が全て表示される（境界値: 複数レンダリング）', () => {
+    render(
+      <TitleSuggestion
+        suggestions={['Godzilla Minus One', 'Godzilla', 'Godzilla vs Kong']}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText('Godzilla Minus One')).toBeInTheDocument();
+    expect(screen.getByText('Godzilla')).toBeInTheDocument();
+    expect(screen.getByText('Godzilla vs Kong')).toBeInTheDocument();
+  });
+
   it('クリックで原題で再検索する', async () => {
     const user = userEvent.setup();
     render(
@@ -62,5 +75,36 @@ describe('TitleSuggestion', () => {
     await user.click(screen.getByRole('button', { name: 'Pumping Iron' }));
 
     expect(mockPush).toHaveBeenCalledWith('/search?query=Pumping%20Iron');
+  });
+
+  it('クリック時に候補配列全体を sessionStorage に保存する', async () => {
+    const user = userEvent.setup();
+    const suggestions = ['The Shawshank Redemption', 'Pumping Iron'];
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    render(<TitleSuggestion suggestions={suggestions} isLoading={false} />);
+
+    await user.click(screen.getByRole('button', { name: 'Pumping Iron' }));
+
+    // TITLE_SUGGESTION.STORAGE_KEY に候補全体を JSON.stringify で保存
+    expect(setItemSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      JSON.stringify(suggestions),
+    );
+    setItemSpy.mockRestore();
+  });
+
+  it('境界値: タイトルに特殊文字(スラッシュ/クエスチョン)を含んでも encodeURIComponent される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TitleSuggestion suggestions={['Batman: Year One?']} isLoading={false} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Batman: Year One?' }));
+
+    // "?" は %3F, ":" は %3A にエンコードされる
+    expect(mockPush).toHaveBeenCalledWith(
+      `/search?query=${encodeURIComponent('Batman: Year One?')}`,
+    );
   });
 });


### PR DESCRIPTION
## 概要

\`src/features/{nowShowing,recommendations,search}/\` の3機能を agent-browser で実機検証し、既存 110 テストで抜けていた **isRefreshing 分岐 / sessionStorage 保存 / URL エンコード境界** の4テストを追加。

## ロードマップ
（該当なし）

## 実機検証（すべて期待通り）

- **nowShowingMovieList**: /（ホーム）で「劇場公開中の人気作品」ランク番号付きスクロール表示
- **recommendationSection**: 認証時のみ /（ホーム）にセクション表示、お気に入り0件時は「準備中」メッセージ
- **searchPage**: フィルターパネル（ジャンル checkbox / 公開年 combobox / 最低評価 combobox）、検索キーワード送信、検索結果グリッド表示
- **filter interaction**: ジャンル checkbox toggle で検索結果が絞り込まれる

## 既存カバレッジ（110 tests）
- nowShowing 9 / recommendationSection 26 / useRecommendationRefresh 8
- searchPage 7 / searchResults 11 / movieFilter 17 / titleSuggestion 4
- useSearch 8 / useMovieFilter 15 / useGenres 5

いずれも密度十分だが、以下の境界値が未検証だった。

## 追加テスト（+4）

### recommendationSection（26→27）
- **境界値**: \`recommendations=[]\` かつ \`isRefreshing=true\` では「準備中」は出ず更新中オーバーレイのグリッドが表示される
  → 実装 \`recommendations.length === 0 && !isRefreshing\` 分岐の \`false\` 側を明示的にテスト。更新中に一時的にリストが空になった場合の挙動を固定

### titleSuggestion（4→7）
- **複数候補レンダリング**: 3件の候補が全て表示される
- **sessionStorage 保存**: クリック時に候補配列全体が \`TITLE_SUGGESTION.STORAGE_KEY\` に \`JSON.stringify\` で保存される（ページ遷移後に他候補も参照可能にするロジック）
- **境界値**: タイトルに特殊文字 (\`:\`, \`?\`) を含んでも \`encodeURIComponent\` されて安全な URL になる

## レビューポイント

- recommendationSection の isRefreshing テストは、レコメンド生成直後にサーバー応答を待つ間の UX 保証（旧レコメンドがない状態で更新中でも「準備中」が出ないこと）
- titleSuggestion の sessionStorage 保存は「もしかして」候補の一貫性のための実装で、既存テストで漏れていたキー機能を明示

## テスト

- \`npx jest src/features/{nowShowing,recommendations,search}/\`: **10 suites / 114 tests all pass**（+4）
- \`npx tsc --noEmit\`: エラー無し