### PR TITLE
test(theater): useSeatSelection / useTheater の境界値テストを追加

### DIFF
--- a/src/features/theaterExperience/hooks/useSeatSelection.test.ts
+++ b/src/features/theaterExperience/hooks/useSeatSelection.test.ts
@@ -66,6 +66,37 @@ describe('useSeatSelection', () => {
     expect(result.current.selectedSeat?.id).toBe('seat-2');
   });
 
+  it('境界値: 同座席toggleで解除後、もう一度同じ座席を選択できる（toggle2周目）', () => {
+    const { result } = renderHook(() => useSeatSelection());
+    const seat = createMockSeat('seat-1');
+
+    // 1周目: 選択
+    act(() => {
+      result.current.selectSeat(seat);
+    });
+    // 1周目: 解除
+    act(() => {
+      result.current.selectSeat(seat);
+    });
+    expect(result.current.selectedSeat).toBeNull();
+
+    // 2周目: 再選択できる
+    act(() => {
+      result.current.selectSeat(seat);
+    });
+    expect(result.current.selectedSeat?.id).toBe('seat-1');
+  });
+
+  it('境界値: 選択なし状態で clearSelection を呼んでもエラーにならない（no-op）', () => {
+    const { result } = renderHook(() => useSeatSelection());
+
+    // 初期状態から clearSelection を呼ぶ
+    act(() => {
+      result.current.clearSelection();
+    });
+    expect(result.current.selectedSeat).toBeNull();
+  });
+
   it('clearSelectionで選択を解除できる', () => {
     const { result } = renderHook(() => useSeatSelection());
     const seat = createMockSeat('seat-1');

--- a/src/features/theaterExperience/hooks/useTheater.test.ts
+++ b/src/features/theaterExperience/hooks/useTheater.test.ts
@@ -51,6 +51,34 @@ describe('useTheater', () => {
     expect(mockGetTheaterBySlug).not.toHaveBeenCalled();
   });
 
+  it('境界値: slug 変更時に新しいクエリが実行される', async () => {
+    mockGetTheaterBySlug
+      .mockResolvedValueOnce({ theater: { id: 'a', slug: 'standard-medium' } })
+      .mockResolvedValueOnce({ theater: { id: 'b', slug: 'imax-large' } });
+
+    const { result, rerender } = renderHook(
+      ({ slug }: { slug: string }) => useTheater(slug),
+      {
+        wrapper: createQueryWrapper(),
+        initialProps: { slug: 'standard-medium' },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.theater.slug).toBe('standard-medium');
+    });
+
+    rerender({ slug: 'imax-large' });
+
+    await waitFor(() => {
+      expect(result.current.data?.theater.slug).toBe('imax-large');
+    });
+
+    expect(mockGetTheaterBySlug).toHaveBeenCalledTimes(2);
+    expect(mockGetTheaterBySlug).toHaveBeenNthCalledWith(1, 'standard-medium');
+    expect(mockGetTheaterBySlug).toHaveBeenNthCalledWith(2, 'imax-large');
+  });
+
   it('APIエラー時はisErrorがtrueになる', async () => {
     mockGetTheaterBySlug.mockRejectedValue(new Error('API error'));
 


### PR DESCRIPTION
## 概要

\`src/features/theaterExperience/\` を agent-browser で実機検証し、既存 262 テストで抜けていた **座席toggle再選択** と **slug 変更時の再fetch** の3テストを追加。

## ロードマップ
（該当なし）

## 実機検証（すべて期待通り）

- **/theater-experience（認証済）**: 3D 劇場シーン（座席グリッド、スクリーン、スピーカー(緑)）React Three Fiber 描画
- **音響ヒートマップ表示切替**: OFF→ON で相対音圧レジェンド出現、床面にヒートマップ描画
- **周波数帯切替**: 低音 80Hz / 中音 1kHz / 高音 8kHz の3値
- **座席選択（A列1番）**: スクリーン距離 8.2m / 水平視野占有率 42.8% / 垂直 22.1% / 歪みスコア 91% / **非推奨** バッジ表示
- **車椅子席マーカー**: A列 5番・12番に♿アイコン表示
- **座席一覧アクセシビリティリスト**: 全座席が button として提供、aria-label に距離・視野情報含む
- 各操作で Next.js エラーバッジ無し

## 既存カバレッジ（262 tests, 31 suites）

utils: fieldOfView 48 / physics 28 / theaterGeometry 19 / seatRecommendation 10 / speakerKinds 9 / theaterPalette 6 / resolveInitialTheaterSlug 4
theaterExperiencePage: 27 / seatMeshes: 13 / seatA11yList: 11 / seatInfoPanel: 8 / heatmapToggle: 7
hooks: useAudioShader 9 / useTheaterSelection 5 / useSeatSelection 5 / useFieldOfView 5 / useTheater 3 / useTheaters 2
shaders + component (残り): 3件前後ずつ

WebGL/R3F 描画部分は本質的にテスト困難だが、utils/hooks/component は非常に密度高い。

## 追加テスト（+3）

### useSeatSelection（5→7）
- **境界値**: 同座席トグルで解除後、再選択できる（toggle **2周目**）
  → 既存は1周目のみ。状態リセット後の再操作が壊れないことを固定
- **境界値**: 選択なし状態で \`clearSelection\` を呼んでもエラーにならない（no-op）
  → 冪等性の担保

### useTheater（3→4）
- **境界値**: slug 変更時に新しいクエリが実行される（キャッシュキー切替）
  → \`useMovieDetail\` の同型パターン。既存は 成功/空slug/エラー のみで、slug 変更経路が抜けていた

## テスト

- \`npx jest src/features/theaterExperience/\`: **31 suites / 265 tests all pass**（+3）
- \`npx tsc --noEmit\`: エラー無し