### PR TITLE
test(ui): radioGroup 新規テスト作成 + tabs/formFieldMessage の境界値追加

### DIFF
--- a/src/components/ui/formFieldMessage/formFieldMessage.test.tsx
+++ b/src/components/ui/formFieldMessage/formFieldMessage.test.tsx
@@ -49,4 +49,21 @@ describe('FormFieldMessage', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('境界値: error が空文字列(falsy)の場合はヘルパーテキストが表示される', () => {
+    render(
+      <FormFieldMessage {...defaultProps} error='' helperText='ヘルパーです' />,
+    );
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('ヘルパーです')).toBeInTheDocument();
+  });
+
+  it('境界値: helperText が空文字列(falsy)のみの場合は何もレンダリングしない', () => {
+    const { container } = render(
+      <FormFieldMessage {...defaultProps} helperText='' />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/src/components/ui/radioGroup/radioGroup.test.tsx
+++ b/src/components/ui/radioGroup/radioGroup.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * RadioGroup コンポーネントのテスト
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { RadioGroup } from './radioGroup';
+
+const defaultOptions = [
+  { label: 'ライト', value: 'light' },
+  { label: 'ダーク', value: 'dark' },
+];
+
+describe('RadioGroup', () => {
+  it('全ての選択肢がラジオボタンとして表示される', () => {
+    render(
+      <RadioGroup
+        options={defaultOptions}
+        value='light'
+        onValueChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: 'ライト' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'ダーク' })).toBeInTheDocument();
+  });
+
+  it('value に一致する選択肢が checked=true になる', () => {
+    render(
+      <RadioGroup
+        options={defaultOptions}
+        value='dark'
+        onValueChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'ライト' })).not.toBeChecked();
+  });
+
+  it('選択肢クリックで onValueChange が呼ばれる', () => {
+    const onValueChange = jest.fn();
+    render(
+      <RadioGroup
+        options={defaultOptions}
+        value='light'
+        onValueChange={onValueChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'ダーク' }));
+    expect(onValueChange).toHaveBeenCalledWith('dark');
+  });
+
+  it('aria-label が radiogroup に設定される', () => {
+    render(
+      <RadioGroup
+        options={defaultOptions}
+        value='light'
+        onValueChange={jest.fn()}
+        aria-label='テーマを選択'
+      />,
+    );
+
+    expect(screen.getByRole('radiogroup')).toHaveAttribute(
+      'aria-label',
+      'テーマを選択',
+    );
+  });
+
+  it('label クリックでも onValueChange が呼ばれる（label と radio の紐付け）', () => {
+    const onValueChange = jest.fn();
+    render(
+      <RadioGroup
+        options={defaultOptions}
+        value='light'
+        onValueChange={onValueChange}
+      />,
+    );
+
+    // label element を name でクリック（htmlFor で radio に紐付いている）
+    fireEvent.click(screen.getByText('ダーク'));
+    expect(onValueChange).toHaveBeenCalledWith('dark');
+  });
+
+  it('境界値: options が空配列でもエラーにならない', () => {
+    const { container } = render(
+      <RadioGroup options={[]} value='' onValueChange={jest.fn()} />,
+    );
+
+    expect(container.querySelector('[role="radiogroup"]')).toBeInTheDocument();
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('境界値: options が1件でも表示される', () => {
+    render(
+      <RadioGroup
+        options={[{ label: '唯一の選択肢', value: 'only' }]}
+        value='only'
+        onValueChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: '唯一の選択肢' })).toBeChecked();
+  });
+
+  it('カスタム className が root に適用される', () => {
+    const { container } = render(
+      <RadioGroup
+        options={defaultOptions}
+        value='light'
+        onValueChange={jest.fn()}
+        className='custom-class'
+      />,
+    );
+
+    const root = container.querySelector('[role="radiogroup"]');
+    expect(root).toHaveClass('custom-class');
+  });
+});

--- a/src/components/ui/tabs/tabs.test.tsx
+++ b/src/components/ui/tabs/tabs.test.tsx
@@ -71,6 +71,42 @@ describe('Tabs', () => {
     expect(handleChange).not.toHaveBeenCalled();
   });
 
+  it('境界値: 矢印キーで次のタブにフォーカスが移動する（キーボードナビゲーション）', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    render(
+      <Tabs
+        options={options}
+        value='theatrical'
+        onValueChange={handleChange}
+      />,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: '劇場公開' });
+    firstTab.focus();
+    expect(firstTab).toHaveFocus();
+
+    // ArrowRight でフォーカスが次タブに移り、選択も切り替わる（Radix Tabs のデフォルト挙動）
+    await user.keyboard('{ArrowRight}');
+    expect(handleChange).toHaveBeenCalledWith('streaming');
+  });
+
+  it('境界値: options が1件のみでも tab が表示される', () => {
+    render(
+      <Tabs
+        options={[{ label: '唯一のタブ', value: 'only' }]}
+        value='only'
+        onValueChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole('tab', { name: '唯一のタブ' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '唯一のタブ' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
   it('aria-labelが設定できる', () => {
     render(
       <Tabs


### PR DESCRIPTION
## 概要

\`src/components/ui/\` 配下 21コンポーネントを調査し、**テストファイル未作成の \`radioGroup\`** と **薄い既存テスト（tabs/formFieldMessage）** の境界値ギャップを補完する11テストを追加。

## ロードマップ
（該当なし）

## 発見

### 未テストコンポーネント
- **radioGroup**: テストファイルが存在せず、\`themeSettings\` で実利用中（ライト/ダーク切替）にもかかわらず単体レベルの回帰防止が無い状態だった

### 薄いテスト
- **tabs (5 tests)**: キーボードナビゲーション（Radix Tabs のデフォルト矢印キー挙動）が未検証
- **formFieldMessage (4 tests)**: エラー/ヘルパーの分岐は覆っているが、空文字列 falsy 経路の境界が未検証

## 追加テスト（+11）

### radioGroup（新規: 0→8）
- 全選択肢が \`radio\` として表示
- \`value\` に一致する radio が \`aria-checked=true\`
- クリックで \`onValueChange\` 呼び出し
- \`aria-label\` が radiogroup に設定
- **label** クリックでも onValueChange 呼び出し（\`htmlFor\` による紐付けの担保）
- **境界値**: \`options\` が空配列でも root がレンダリングされる
- **境界値**: \`options\` が1件のみでも正しく描画・選択される
- カスタム \`className\` が root に適用される

### tabs（5→7）
- **境界値**: \`ArrowRight\` キーで次タブにフォーカス移動 + onValueChange 発火（キーボード操作担保）
- **境界値**: \`options\` が1件のみでも表示され \`aria-selected=true\`

### formFieldMessage（4→6）
- **境界値**: \`error=''\`（falsy）の場合は helperText 表示にフォールバック
- **境界値**: \`helperText=''\`（falsy）のみの場合は何もレンダリングしない

## レビューポイント

- radioGroup は Radix UI \`RadioGroupPrimitive\` のラッパー。ラップ層の props → primitive の contract を単体で担保
- tabs のキーボードナビは Radix のデフォルト挙動だが、当該挙動に依存する UX（例: SP アクセシビリティ）を回帰防止で固定
- formFieldMessage の空文字境界は、フォーム側で error/helper を空文字で渡した際の予期しない挙動（描画/非描画の判定）を明確化

## テスト

- \`npx jest src/components/ui/\`: **25 suites / 276 tests all pass**（+11）
- \`npx tsc --noEmit\`: エラー無し