### PR TITLE
test(layout): footer/mobileDrawer/mobileMenuButton の境界値テストを追加

### DIFF
--- a/src/components/layout/footer/footer.test.tsx
+++ b/src/components/layout/footer/footer.test.tsx
@@ -51,4 +51,23 @@ describe('Footer', () => {
     const footer = container.querySelector('footer');
     expect(footer?.className).toContain('custom-class');
   });
+
+  it('境界値: links が空配列の場合、nav 要素が描画されない', () => {
+    const { container } = render(<Footer links={[]} />);
+    expect(container.querySelector('nav')).not.toBeInTheDocument();
+  });
+
+  it('境界値: links が未指定の場合も nav 要素が描画されない', () => {
+    const { container } = render(<Footer />);
+    expect(container.querySelector('nav')).not.toBeInTheDocument();
+  });
+
+  it('children が渡されると custom 領域として描画される', () => {
+    render(
+      <Footer>
+        <span data-testid='custom-content'>カスタム</span>
+      </Footer>,
+    );
+    expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/mobileDrawer/useMobileDrawer.test.ts
+++ b/src/components/layout/mobileDrawer/useMobileDrawer.test.ts
@@ -46,6 +46,20 @@ describe('useMobileDrawer', () => {
     expect(result.current.isOpen).toBe(false);
   });
 
+  it('境界値: 閉じている状態で pathname が変わっても閉じたまま（no-op）', () => {
+    const { result, rerender } = renderHook(() => useMobileDrawer());
+
+    // 初期状態で閉じている
+    expect(result.current.isOpen).toBe(false);
+
+    // パス変更
+    mockPathname = '/settings';
+    rerender();
+
+    // 閉じたまま
+    expect(result.current.isOpen).toBe(false);
+  });
+
   it('pathname変更時にisOpenがfalseになる', () => {
     const { result, rerender } = renderHook(() => useMobileDrawer());
 

--- a/src/components/layout/mobileMenuButton/mobileMenuButton.test.tsx
+++ b/src/components/layout/mobileMenuButton/mobileMenuButton.test.tsx
@@ -46,4 +46,28 @@ describe('MobileMenuButton', () => {
     render(<MobileMenuButton {...defaultProps} className='custom-class' />);
     expect(screen.getByRole('button').className).toContain('custom-class');
   });
+
+  it('境界値: Enter キーでも onToggle が呼ばれる（キーボード操作）', async () => {
+    const user = userEvent.setup();
+    const onToggle = jest.fn();
+    render(<MobileMenuButton {...defaultProps} onToggle={onToggle} />);
+
+    const button = screen.getByRole('button');
+    button.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('境界値: Space キーでも onToggle が呼ばれる（キーボード操作）', async () => {
+    const user = userEvent.setup();
+    const onToggle = jest.fn();
+    render(<MobileMenuButton {...defaultProps} onToggle={onToggle} />);
+
+    const button = screen.getByRole('button');
+    button.focus();
+    await user.keyboard(' ');
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## 概要

\`src/components/layout/\` 9コンポーネントを agent-browser で実機検証し、既存 98 テストで抜けていた**空/未指定 props と キーボード操作**の6テストを追加。

## ロードマップ
（該当なし）

## 実機検証（すべて期待通り）

- **header + searchBar**: ロゴ + 検索input（空入力時は検索ボタン disabled、入力後 enabled）
- **sideNav**: 公開予定/公開中/お気に入り/ウォッチリスト/受賞作品/シアター体験
- **userMenu**: dropdown で 設定/ダークモード/ログアウト の menuitem 表示
- **footer**: コピーライト + TMDB attribution + アイコン
- **appLayout**: 認証時のみ 公開カレンダーボタン + user avatar 表示
- 各遷移で Next.js エラーバッジ無し

## 既存カバレッジ（98 tests）
- mobileDrawer 17 / searchBar 14 / userMenu 12 / appLayout 12 / sidebar 10 / header 10
- sideNav 8 / footer 6 / mobileMenuButton 5 / useMobileDrawer 4

## 追加テスト（+6）

### footer（6→9）
- **境界値**: \`links=[]\` の場合、\`<nav>\` 要素が描画されない
- **境界値**: \`links\` 未指定の場合も \`<nav>\` 要素が描画されない
- \`children\` prop が渡されると custom 領域として描画される

### useMobileDrawer（4→5）
- **境界値**: 閉じている状態で pathname が変わっても閉じたまま（no-op）
  → 既存は「開状態 → 閉」のみ。閉状態から余計な状態変化が起きないことを担保

### mobileMenuButton（5→7）
- **境界値**: Enter キーで onToggle が呼ばれる（キーボード操作）
- **境界値**: Space キーで onToggle が呼ばれる（キーボード操作）
  → button の native キーボード挙動の担保。SP ハンバーガーメニュー a11y 要件

## レビューポイント

- footer の links 空/未指定境界は、\`links && links.length > 0\` の分岐で \`<nav>\` が消えることを固定
- useMobileDrawer の閉状態 pathname 変更は「レンダー中の props 変更検出パターン」の副作用ガード
- mobileMenuButton のキーボード操作は button element の native 挙動だが、明示的にテストしておくことで将来的なカスタム onKeyDown の混入時にも守られる

## テスト

- \`npx jest src/components/layout/\`: **10 suites / 104 tests all pass**（+6）
- \`npx tsc --noEmit\`: エラー無し