### PR TITLE
refactor: getClientIp を src/lib/http に集約（Closes #452）

### DIFF
--- a/src/app/api/awards/route.ts
+++ b/src/app/api/awards/route.ts
@@ -25,6 +25,7 @@ import {
   createServiceRoleClient,
   dbConnectionErrorResponse,
 } from '@/helpers/supabase';
+import { getClientIp } from '@/lib/http/getClientIp';
 import { checkRateLimit } from '@/lib/rateLimit/rateLimit';
 import type {
   AwardMovie,
@@ -77,15 +78,6 @@ function toAwardMovie(row: {
     genreIds: row.genre_ids,
     personName: row.person_name,
   };
-}
-
-/** リクエストからクライアントIPを取得 */
-function getClientIp(request: Request): string {
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
-  return 'unknown';
 }
 
 export async function GET(request: Request) {

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -16,6 +16,7 @@
 import { NextResponse } from 'next/server';
 
 import { HTTP_STATUS, IN_MEMORY_RATE_LIMIT } from '@/constants';
+import { getClientIp } from '@/lib/http/getClientIp';
 import { createInMemoryRateLimiter } from '@/lib/rateLimit/inMemoryRateLimit';
 
 /**
@@ -35,15 +36,6 @@ const rateLimiter = createInMemoryRateLimiter({
   maxRequests: IN_MEMORY_RATE_LIMIT.CSP_REPORT.maxRequests,
   windowMs: IN_MEMORY_RATE_LIMIT.CSP_REPORT.windowMs,
 });
-
-/** リクエストからクライアント IP を取得する（取得不可時は 'unknown'）。 */
-function getClientIp(request: Request): string {
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
-  return 'unknown';
-}
 
 /**
  * 単一の CSP 違反レポート本体から、ログに残す主要フィールドを抽出する。

--- a/src/lib/http/getClientIp.test.ts
+++ b/src/lib/http/getClientIp.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+import { getClientIp } from './getClientIp';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/test', { headers });
+}
+
+describe('getClientIp', () => {
+  it('x-forwarded-for が無い場合は "unknown" を返す', () => {
+    expect(getClientIp(makeRequest())).toBe('unknown');
+  });
+
+  it('x-forwarded-for 単一 IP をそのまま返す', () => {
+    expect(getClientIp(makeRequest({ 'x-forwarded-for': '203.0.113.1' }))).toBe(
+      '203.0.113.1',
+    );
+  });
+
+  it('x-forwarded-for がカンマ区切りの場合、先頭 IP を返す（クライアント側）', () => {
+    expect(
+      getClientIp(
+        makeRequest({
+          'x-forwarded-for': '203.0.113.1, 198.51.100.2, 10.0.0.1',
+        }),
+      ),
+    ).toBe('203.0.113.1');
+  });
+
+  it('境界値: 先頭 IP の前後の空白を trim する', () => {
+    expect(
+      getClientIp(
+        makeRequest({ 'x-forwarded-for': '  203.0.113.1  , 10.0.0.1' }),
+      ),
+    ).toBe('203.0.113.1');
+  });
+
+  it('境界値: x-forwarded-for が空文字列なら "unknown" を返す', () => {
+    // Request コンストラクタは空 header 値を落とすため、明示的に headers を組む
+    const headers = new Headers();
+    headers.set('x-forwarded-for', '');
+    const request = new Request('http://localhost/api/test', { headers });
+    expect(getClientIp(request)).toBe('unknown');
+  });
+});

--- a/src/lib/http/getClientIp.ts
+++ b/src/lib/http/getClientIp.ts
@@ -1,0 +1,14 @@
+/**
+ * リクエストからクライアント IP を取得する（取得不可時は 'unknown'）
+ *
+ * `x-forwarded-for` ヘッダの先頭値を採用する。Vercel / 一般的なリバースプロキシ
+ * 経由でリクエストが来た際に、上流の IP をレート制限識別子として使う想定。
+ * ヘッダが無いローカル起動等では 'unknown' を返し、レート制限側で fallback する。
+ */
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+  return 'unknown';
+}


### PR DESCRIPTION
## 概要

Issue #452 の主タスク（**推奨**マーク付き）を実施。\`src/app/api/awards/route.ts\` と \`src/app/api/csp-report/route.ts\` に同一実装で重複していた \`getClientIp\` を \`src/lib/http/getClientIp.ts\` に共有ヘルパーとして集約。

## ロードマップ
（該当なし）

## 変更内容

- **新規**: \`src/lib/http/getClientIp.ts\`
  \`\`\`ts
  export function getClientIp(request: Request): string {
    const forwarded = request.headers.get('x-forwarded-for');
    if (forwarded) return forwarded.split(',')[0].trim();
    return 'unknown';
  }
  \`\`\`
- **新規**: \`src/lib/http/getClientIp.test.ts\`（5 tests、境界値含む）
- **修正**: \`awards/route.ts\` / \`csp-report/route.ts\` のローカル定義を削除し共有ヘルパーを import

## レビューポイント

- Issue #452 の主タスク（推奨マーク付き）を優先し、「余力があれば」項目（USER_ROLE / LOGIN_METHOD / MS_PER_DAY / APP_NAME / Wikipedia API パラメータ / TMDB_MOVIE_DETAIL_APPEND / inMemoryRateLimit maxKeys）は今回スコープ外
- \`src/lib/http/\` は新規ディレクトリ。将来的な HTTP レベルの共通ユーティリティ配置場所として利用

## テスト

- \`src/lib/http/getClientIp.test.ts\`: 5 tests
  - x-forwarded-for 未指定 → \`'unknown'\`
  - 単一 IP をそのまま返す
  - カンマ区切りで先頭 IP を返す
  - **境界値**: 前後空白を trim
  - **境界値**: 空文字列 → \`'unknown'\`
- \`npx jest src/lib/http/ src/app/api/awards/ src/app/api/csp-report/\`: **3 suites / 32 tests all pass**
- \`npx tsc --noEmit\`: エラー無し
- \`npm run build\`: 成功

Closes #452